### PR TITLE
expose NEXT_PUBLIC_HORIZON_URL and NEXT_PUBLIC_STELLAR_NETWORK to bro…

### DIFF
--- a/novaRewards/frontend/next.config.js
+++ b/novaRewards/frontend/next.config.js
@@ -6,6 +6,10 @@ const nextConfig = {
     NEXT_PUBLIC_ISSUER_PUBLIC: process.env.NEXT_PUBLIC_ISSUER_PUBLIC,
     NEXT_PUBLIC_STELLAR_NETWORK: process.env.NEXT_PUBLIC_STELLAR_NETWORK,
   },
+  publicRuntimeConfig: {
+    NEXT_PUBLIC_HORIZON_URL: process.env.NEXT_PUBLIC_HORIZON_URL,
+    NEXT_PUBLIC_STELLAR_NETWORK: process.env.NEXT_PUBLIC_STELLAR_NETWORK,
+  },
 };
 
 module.exports = nextConfig;


### PR DESCRIPTION
closes #5
 
Added public Runtime Config in next.config.js to ensure NEXT_PUBLIC_HORIZON_URL and NEXT_PUBLIC_STELLAR_NETWORK are available to the browser at runtime. Without this, frontend Horizon calls would fail in production builds.