### PR TITLE
Add text memo to reward transactions for block explorer identification

### DIFF
--- a/novaRewards/blockchain/sendRewards.js
+++ b/novaRewards/blockchain/sendRewards.js
@@ -3,6 +3,7 @@ const {
   Keypair,
   TransactionBuilder,
   Operation,
+  Memo,
   Networks,
   BASE_FEE,
 } = require('stellar-sdk');
@@ -70,6 +71,7 @@ async function distributeRewards({ toWallet, amount }) {
         amount: String(amount),
       })
     )
+    .addMemo(Memo.text('NovaRewards distribution'))
     .setTimeout(180)
     .build();
 


### PR DESCRIPTION
Closes #10 


## What
Added a "NovaRewards distribution" text memo to every transaction built in sendRewards.js 
using Stellar's Memo.text().

## Why
Stellar transactions support an optional memo field. Including one makes reward transactions 
easily identifiable on block explorers (e.g. Stellar Expert) and filterable in Horizon API 
queries.

## Changes
- Imported Memo from stellar-sdk
- Chained .addMemo(Memo.text('NovaRewards distribution')) onto the TransactionBuilder in 
distributeRewards()

## Notes
- Memo.text() has a 28-byte limit; "NovaRewards distribution" is 23 characters — within limit
- No behaviour changes, no new dependencies