### PR TITLE
— Property Tests: Write property test for expired campaign blocking distribution (Property 7)

### DIFF
--- a/novaRewards/backend/tests/distributeExpiredCampaign.test.js
+++ b/novaRewards/backend/tests/distributeExpiredCampaign.test.js
@@ -1,0 +1,146 @@
+// Feature: nova-rewards, Property 7: Expired campaigns are rejected at the distribute route
+// Validates: Requirements 7.4, 7.5
+
+const fc = require('fast-check');
+const { Keypair } = require('stellar-sdk');
+
+// ── env setup ────────────────────────────────────────────────────────────────
+process.env.HORIZON_URL = 'https://horizon-testnet.stellar.org';
+process.env.ISSUER_PUBLIC = 'GAAZI4TCR3TY5OJHCTJC2A4QSY6CJWJH5IAJTGKIN2ER7LBNVKOCCWN';
+process.env.DISTRIBUTION_PUBLIC = 'GAAZI4TCR3TY5OJHCTJC2A4QSY6CJWJH5IAJTGKIN2ER7LBNVKOCCWN';
+process.env.STELLAR_NETWORK = 'testnet';
+
+// ── mocks ─────────────────────────────────────────────────────────────────────
+
+// Mock DB so no real Postgres connection is needed
+jest.mock('../db/index', () => ({ query: jest.fn() }));
+
+// Mock campaignRepository — getActiveCampaign returns null for expired campaigns
+jest.mock('../db/campaignRepository', () => ({
+  getActiveCampaign: jest.fn(),
+}));
+
+// Mock transactionRepository
+jest.mock('../db/transactionRepository', () => ({
+  recordTransaction: jest.fn(),
+}));
+
+// Mock distributeRewards — must NOT be called for expired campaigns
+jest.mock('../../blockchain/sendRewards', () => ({
+  distributeRewards: jest.fn(),
+}));
+
+// Mock stellarService so isValidStellarAddress works without network
+jest.mock('../../blockchain/stellarService', () => ({
+  isValidStellarAddress: jest.fn((addr) => {
+    try {
+      const { StrKey } = require('stellar-sdk');
+      return StrKey.isValidEd25519PublicKey(addr);
+    } catch {
+      return false;
+    }
+  }),
+}));
+
+const express = require('express');
+const { getActiveCampaign } = require('../db/campaignRepository');
+const { distributeRewards } = require('../../blockchain/sendRewards');
+const { query } = require('../db/index');
+
+// Build a minimal express app wiring the rewards router
+function buildApp() {
+  const app = express();
+  app.use(express.json());
+  app.use('/api/rewards', require('../routes/rewards'));
+  return app;
+}
+
+// Arbitrary: ISO date string strictly in the past (before today)
+const pastDateArb = fc
+  .date({
+    min: new Date('2000-01-01'),
+    max: new Date(Date.now() - 86_400_000), // yesterday or earlier
+  })
+  .map((d) => d.toISOString().slice(0, 10));
+
+describe('POST /api/rewards/distribute — expired campaign (Property 7)', () => {
+  let app;
+  const VALID_API_KEY = 'test-api-key';
+  const MERCHANT = { id: 1, api_key: VALID_API_KEY };
+
+  beforeAll(() => {
+    app = buildApp();
+  });
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+
+    // merchantAuth: return the mock merchant for the test API key
+    query.mockResolvedValue({ rows: [MERCHANT] });
+  });
+
+  test('returns 400 and never calls distributeRewards for any past end_date', async () => {
+    await fc.assert(
+      fc.asyncProperty(
+        pastDateArb,
+        fc.integer({ min: 1, max: 999 }), // campaignId
+        async (endDate, campaignId) => {
+          // getActiveCampaign returns null — campaign is expired / inactive
+          getActiveCampaign.mockResolvedValue(null);
+
+          const customerWallet = Keypair.random().publicKey();
+
+          const http = require('http');
+          const server = http.createServer(app);
+          await new Promise((resolve) => server.listen(0, resolve));
+          const port = server.address().port;
+
+          let statusCode;
+          let body;
+
+          await new Promise((resolve, reject) => {
+            const payload = JSON.stringify({ customerWallet, amount: 10, campaignId });
+            const req = http.request(
+              {
+                hostname: '127.0.0.1',
+                port,
+                path: '/api/rewards/distribute',
+                method: 'POST',
+                headers: {
+                  'Content-Type': 'application/json',
+                  'Content-Length': Buffer.byteLength(payload),
+                  'x-api-key': VALID_API_KEY,
+                },
+              },
+              (res) => {
+                statusCode = res.statusCode;
+                let raw = '';
+                res.on('data', (chunk) => { raw += chunk; });
+                res.on('end', () => {
+                  body = JSON.parse(raw);
+                  resolve();
+                });
+              }
+            );
+            req.on('error', reject);
+            req.write(payload);
+            req.end();
+          });
+
+          await new Promise((resolve) => server.close(resolve));
+
+          // Assert 400 returned
+          expect(statusCode).toBe(400);
+          expect(body.success).toBe(false);
+          expect(body.error).toBe('invalid_campaign');
+
+          // distributeRewards must never have been called
+          expect(distributeRewards).not.toHaveBeenCalled();
+
+          return true;
+        }
+      ),
+      { numRuns: 50 }
+    );
+  });
+});


### PR DESCRIPTION
closes #42 

test: expired campaign distribution property test Task 6.5 Property 7
test(nova-rewards): add property-based test for expired campaign distribution guard (Task 6.5, Property 7)

Adds distributeExpiredCampaign.test.js to validate that the POST /api/rewards/distribute
route correctly rejects requests when the campaign end_date is in the past.

Using fast-check, the test generates arbitrary past ISO date strings and campaign IDs,
mocks getActiveCampaign to return null (simulating an expired/inactive campaign), and
asserts that:
  - the route responds with HTTP 400
  - the response body contains success: false and error: invalid_campaign
  - distributeRewards is never invoked, preventing any blockchain interaction

All external dependencies (DB, Stellar, sendRewards) are mocked to keep the test
isolated and deterministic. Validates Requirements 7.4 and 7.5.
