### PR TITLE
feat(security): add 10kb body size limit to express.json middleware

### DIFF
--- a/novaRewards/backend/server.js
+++ b/novaRewards/backend/server.js
@@ -10,7 +10,7 @@ const cors = require('cors');
 const app = express();
 
 app.use(cors());
-app.use(express.json());
+app.use(express.json({ limit: '10kb' }));
 
 // Health check
 app.get('/health', (req, res) => {


### PR DESCRIPTION
Closed #32 

Prevents large payload attacks by capping incoming JSON request bodies at 10kb. Express will respond with 413 Payload Too Large for any request that exceeds this limit, covering all API routes globally.

@milah-247 Please Review Pr