### PR TITLE
feat: implement /api/trustline/build endpoint

### DIFF
--- a/novaRewards/backend/routes/trustline.js
+++ b/novaRewards/backend/routes/trustline.js
@@ -59,4 +59,23 @@ router.post('/build-xdr', async (req, res, next) => {
   }
 });
 
+router.post('/build', async (req, res, next) => {
+  try {
+    const { walletAddress } = req.body;
+
+    if (!walletAddress || !isValidStellarAddress(walletAddress)) {
+      return res.status(400).json({
+        success: false,
+        error: 'validation_error',
+        message: 'walletAddress must be a valid Stellar public key',
+      });
+    }
+
+    const xdr = await buildTrustlineXDR(walletAddress);
+    res.json({ xdr });
+  } catch (err) {
+    next(err);
+  }
+});
+
 module.exports = router;

--- a/novaRewards/frontend/components/TrustlineButton.js
+++ b/novaRewards/frontend/components/TrustlineButton.js
@@ -16,16 +16,9 @@ export default function TrustlineButton({ walletAddress, onSuccess }) {
     setStatus('loading');
     setMessage('');
     try {
-      const { data } = await api.post('/api/trustline/build-xdr', { walletAddress });
+      const { data } = await api.post('/api/trustline/build', { walletAddress });
 
-      if (data.data.status === 'already_exists') {
-        setStatus('done');
-        setMessage('Trustline already exists.');
-        onSuccess?.();
-        return;
-      }
-
-      await signAndSubmit(data.data.xdr);
+      await signAndSubmit(data.xdr);
       setStatus('done');
       setMessage('Trustline created successfully.');
       onSuccess?.();


### PR DESCRIPTION
closes #30
Description:

The frontend TrustlineButton component needs to fetch an unsigned XDR from the backend
Add POST /api/trustline/build that accepts { walletAddress }
Call buildTrustlineXDR and return { xdr }