### PR TITLE
fix: validate recipient Stellar address before loadAccount in distrib…

### DIFF
--- a/novaRewards/blockchain/sendRewards.js
+++ b/novaRewards/blockchain/sendRewards.js
@@ -6,6 +6,7 @@ const {
   Memo,
   Networks,
   BASE_FEE,
+  StrKey,
 } = require('stellar-sdk');
 const { server, NOVA } = require('./stellarService');
 const { verifyTrustline } = require('./trustline');
@@ -27,6 +28,15 @@ const NETWORK_PASSPHRASE =
  * @throws {Error} with error.code set to 'no_trustline' or 'insufficient_balance'
  */
 async function distributeRewards({ toWallet, amount }) {
+  // 0. Validate recipient address before any network calls
+  if (!toWallet || !StrKey.isValidEd25519PublicKey(toWallet)) {
+    const err = new Error(
+      `Invalid Stellar address: "${toWallet}". Must be a valid Ed25519 public key.`
+    );
+    err.code = 'invalid_address';
+    throw err;
+  }
+
   // 1. Verify recipient has a NOVA trustline before attempting payment
   const { exists } = await verifyTrustline(toWallet);
   if (!exists) {


### PR DESCRIPTION
this pr closes #11 


Problem

distributeRewards in 
sendRewards.js
 called server.loadAccount without first checking if toWallet was a valid Stellar public key. Passing a malformed or missing address would result in a confusing network-level error instead of a clear, actionable one.

Changes

Imported StrKey from stellar-sdk
Added an isValidEd25519PublicKey check at the top of distributeRewards, before any network calls
Throws early with err.code = 'invalid_address' and a descriptive message if the address is invalid
Testing

Pass an invalid or empty address to distributeRewards — it should throw immediately with invalid_address before hitting the Stellar network.