### PR TITLE
feat: add GET /api/campaigns/:merchantId endpoint with input validation

### DIFF
--- a/novaRewards/backend/routes/campaigns.js
+++ b/novaRewards/backend/routes/campaigns.js
@@ -55,12 +55,21 @@ router.post('/', async (req, res, next) => {
 
 /**
  * GET /api/campaigns/:merchantId
- * Returns all campaigns for a merchant.
- * Requirements: 7.2
+ * Returns all campaigns for a given merchant.
+ * Requirements: 7.2, 10.1
  */
 router.get('/:merchantId', async (req, res, next) => {
   try {
-    const campaigns = await getCampaignsByMerchant(req.params.merchantId);
+    const merchantId = parseInt(req.params.merchantId, 10);
+    if (isNaN(merchantId) || merchantId <= 0) {
+      return res.status(400).json({
+        success: false,
+        error: 'validation_error',
+        message: 'merchantId must be a positive integer',
+      });
+    }
+
+    const campaigns = await getCampaignsByMerchant(merchantId);
     res.json({ success: true, data: campaigns });
   } catch (err) {
     next(err);


### PR DESCRIPTION
this pr closes #29 


Problem

No endpoint existed to fetch all campaigns for a given merchant, and the stub lacked input validation, allowing raw strings to pass directly into the DB query.

Changes

Implemented GET /api/campaigns/:merchantId in 
campaigns.js
Parses and validates merchantId as a positive integer, returns 400 with validation_error if invalid
Calls getCampaignsByMerchant(merchantId) from the campaign repository and returns { success: true, data: campaigns }
Testing

GET /api/campaigns/1 → returns campaigns array for merchant 1
GET /api/campaigns/abc → returns 400 validation_error