### PR TITLE
perf: add B-tree indexes on from_wallet and to_wallet in transactions…

### DIFF
--- a/novaRewards/database/004_create_transactions.sql
+++ b/novaRewards/database/004_create_transactions.sql
@@ -13,3 +13,8 @@ CREATE TABLE IF NOT EXISTS transactions (
   stellar_ledger INTEGER,
   created_at     TIMESTAMPTZ   DEFAULT NOW()
 );
+
+-- B-tree indexes on wallet columns to avoid full table scans when querying by address
+-- Requirements: 3.4, 4.3
+CREATE INDEX IF NOT EXISTS idx_transactions_from_wallet ON transactions (from_wallet);
+CREATE INDEX IF NOT EXISTS idx_transactions_to_wallet   ON transactions (to_wallet);


### PR DESCRIPTION
this pr close #18 

Problem

transactionRepository.js queries transactions by wallet address, but from_wallet and to_wallet had no indexes — meaning every lookup triggered a full table scan as data grows.

Changes

Added CREATE INDEX IF NOT EXISTS idx_transactions_from_wallet ON transactions (from_wallet)
Added CREATE INDEX IF NOT EXISTS idx_transactions_to_wallet ON transactions (to_wallet)
Both use PostgreSQL's default B-tree index, optimal for equality and range lookups on wallet addresses