### PR TITLE
fix: explicitly require db/index after validateEnv to guard pool cons…

### DIFF
--- a/novaRewards/backend/server.js
+++ b/novaRewards/backend/server.js
@@ -1,8 +1,13 @@
 require('dotenv').config();
 const { validateEnv } = require('./middleware/validateEnv');
 
-// Validate all required env vars before anything else — halts if any are missing
+// Validate all required env vars before anything else — halts if any are missing.
+// This MUST run before requiring ./db/index because the Pool constructor reads
+// DATABASE_URL immediately at require-time.
 validateEnv();
+
+// Safe to require db now — DATABASE_URL is guaranteed to be present
+require('./db/index');
 
 const express = require('express');
 const cors = require('cors');


### PR DESCRIPTION
this pr closes #16 

Problem

The pg.Pool constructor in 
index.js
 reads DATABASE_URL immediately at require-time. If anything caused db/index to be evaluated before validateEnv() ran, the pool would be constructed with an undefined connection string — silently failing or throwing a confusing error.

Changes

Added an explicit require('./db/index') directly after validateEnv() in server.js
Added comments making the ordering guarantee clear for future maintainers
Result

DATABASE_URL is guaranteed to be present before the pool is ever constructed, regardless of how routes or imports are reorganized later.