### PR TITLE
Implement merchant totals aggregation for Requirement 10.2

### DIFF
--- a/novaRewards/backend/db/transactionRepository.js
+++ b/novaRewards/backend/db/transactionRepository.js
@@ -70,20 +70,26 @@ async function getTransactionsByMerchant(merchantId) {
  * Requirements: 10.2
  *
  * @param {number} merchantId
- * @returns {Promise<{ totalDistributed: number, totalRedeemed: number }>}
+ * @returns {Promise<{ totalDistributed: string, totalRedeemed: string }>}
  */
 async function getMerchantTotals(merchantId) {
   const result = await query(
-    `SELECT
-       COALESCE(SUM(CASE WHEN tx_type = 'distribution' THEN amount ELSE 0 END), 0) AS "totalDistributed",
-       COALESCE(SUM(CASE WHEN tx_type = 'redemption'   THEN amount ELSE 0 END), 0) AS "totalRedeemed"
+    `SELECT tx_type, COALESCE(SUM(amount), 0) AS total
      FROM transactions
-     WHERE merchant_id = $1`,
+     WHERE merchant_id = $1
+       AND tx_type IN ('distribution', 'redemption')
+     GROUP BY tx_type`,
     [merchantId]
   );
+
+  const totalsByType = result.rows.reduce((acc, row) => {
+    acc[row.tx_type] = String(row.total);
+    return acc;
+  }, {});
+
   return {
-    totalDistributed: parseFloat(result.rows[0].totalDistributed),
-    totalRedeemed: parseFloat(result.rows[0].totalRedeemed),
+    totalDistributed: totalsByType.distribution || '0',
+    totalRedeemed: totalsByType.redemption || '0',
   };
 }
 

--- a/novaRewards/backend/tests/transactionRepository.test.js
+++ b/novaRewards/backend/tests/transactionRepository.test.js
@@ -1,0 +1,50 @@
+jest.mock('../db/index', () => ({ query: jest.fn() }));
+
+const { query } = require('../db/index');
+const { getMerchantTotals } = require('../db/transactionRepository');
+
+describe('getMerchantTotals', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  test('returns grouped distribution and redemption totals as numeric strings', async () => {
+    query.mockResolvedValue({
+      rows: [
+        { tx_type: 'distribution', total: '125.5000000' },
+        { tx_type: 'redemption', total: '23.2500000' },
+      ],
+    });
+
+    const totals = await getMerchantTotals(7);
+
+    expect(query).toHaveBeenCalledTimes(1);
+    expect(query.mock.calls[0][0]).toMatch(/SUM\(amount\)/i);
+    expect(query.mock.calls[0][0]).toMatch(/GROUP BY tx_type/i);
+    expect(query.mock.calls[0][1]).toEqual([7]);
+    expect(totals).toEqual({
+      totalDistributed: '125.5000000',
+      totalRedeemed: '23.2500000',
+    });
+    expect(typeof totals.totalDistributed).toBe('string');
+    expect(typeof totals.totalRedeemed).toBe('string');
+  });
+
+  test('returns zero strings when no matching transactions exist', async () => {
+    query.mockResolvedValue({ rows: [] });
+
+    const totals = await getMerchantTotals(99);
+
+    expect(totals).toEqual({ totalDistributed: '0', totalRedeemed: '0' });
+  });
+
+  test('returns zero string for missing grouped type', async () => {
+    query.mockResolvedValue({
+      rows: [{ tx_type: 'distribution', total: '10.0000000' }],
+    });
+
+    const totals = await getMerchantTotals(3);
+
+    expect(totals).toEqual({ totalDistributed: '10.0000000', totalRedeemed: '0' });
+  });
+});


### PR DESCRIPTION
closes #22

## Summary
- implement getMerchantTotals(merchantId) using SQL SUM grouped by tx_type
- return totals as numeric strings in the shape { totalDistributed, totalRedeemed }
- add unit tests for grouped totals, missing type fallback, and empty results

## Notes
- only requirement-related backend files are included in this PR