### PR TITLE
Distinguish missing vs inactive campaigns in rewards distribute route

### DIFF
--- a/novaRewards/backend/db/campaignRepository.js
+++ b/novaRewards/backend/db/campaignRepository.js
@@ -72,6 +72,20 @@ async function getCampaignsByMerchant(merchantId) {
 }
 
 /**
+ * Returns a campaign by id regardless of active/expired state.
+ *
+ * @param {number} campaignId
+ * @returns {Promise<object|null>}
+ */
+async function getCampaignById(campaignId) {
+  const result = await query(
+    'SELECT * FROM campaigns WHERE id = $1',
+    [campaignId]
+  );
+  return result.rows[0] || null;
+}
+
+/**
  * Returns a campaign only if it is active and not expired.
  * Requirements: 7.4, 7.5
  *
@@ -93,5 +107,6 @@ module.exports = {
   validateCampaign,
   createCampaign,
   getCampaignsByMerchant,
+  getCampaignById,
   getActiveCampaign,
 };

--- a/novaRewards/backend/routes/rewards.js
+++ b/novaRewards/backend/routes/rewards.js
@@ -1,6 +1,6 @@
 const router = require('express').Router();
 const { query } = require('../db/index');
-const { getActiveCampaign } = require('../db/campaignRepository');
+const { getCampaignById, getActiveCampaign } = require('../db/campaignRepository');
 const { recordTransaction } = require('../db/transactionRepository');
 const { distributeRewards } = require('../../blockchain/sendRewards');
 const { isValidStellarAddress } = require('../../blockchain/stellarService');
@@ -61,13 +61,23 @@ router.post('/distribute', merchantAuth, async (req, res, next) => {
       });
     }
 
+    // Distinguish campaign not found vs inactive/expired for clearer client handling.
+    const campaignExists = await getCampaignById(campaignId);
+    if (!campaignExists) {
+      return res.status(404).json({
+        success: false,
+        error: 'not_found',
+        message: 'Campaign does not exist',
+      });
+    }
+
     // Validate campaign is active and belongs to this merchant
     const campaign = await getActiveCampaign(campaignId);
     if (!campaign) {
       return res.status(400).json({
         success: false,
         error: 'invalid_campaign',
-        message: 'Campaign not found, expired, or inactive',
+        message: 'Campaign is expired or inactive',
       });
     }
 

--- a/novaRewards/backend/tests/distributeCampaignNotFound.test.js
+++ b/novaRewards/backend/tests/distributeCampaignNotFound.test.js
@@ -1,0 +1,112 @@
+// Feature: nova-rewards, rewards route campaign existence handling
+// Validates: clear distinction between missing and inactive/expired campaign
+
+process.env.HORIZON_URL = 'https://horizon-testnet.stellar.org';
+process.env.ISSUER_PUBLIC = 'GAAZI4TCR3TY5OJHCTJC2A4QSY6CJWJH5IAJTGKIN2ER7LBNVKOCCWN';
+process.env.DISTRIBUTION_PUBLIC = 'GAAZI4TCR3TY5OJHCTJC2A4QSY6CJWJH5IAJTGKIN2ER7LBNVKOCCWN';
+process.env.STELLAR_NETWORK = 'testnet';
+
+jest.mock('../db/index', () => ({ query: jest.fn() }));
+
+jest.mock('../db/campaignRepository', () => ({
+  getCampaignById: jest.fn(),
+  getActiveCampaign: jest.fn(),
+}));
+
+jest.mock('../db/transactionRepository', () => ({
+  recordTransaction: jest.fn(),
+}));
+
+jest.mock('../../blockchain/sendRewards', () => ({
+  distributeRewards: jest.fn(),
+}));
+
+jest.mock('../../blockchain/stellarService', () => ({
+  isValidStellarAddress: jest.fn((addr) => {
+    try {
+      const { StrKey } = require('stellar-sdk');
+      return StrKey.isValidEd25519PublicKey(addr);
+    } catch {
+      return false;
+    }
+  }),
+}));
+
+const express = require('express');
+const http = require('http');
+const { Keypair } = require('stellar-sdk');
+const { query } = require('../db/index');
+const { getCampaignById, getActiveCampaign } = require('../db/campaignRepository');
+const { distributeRewards } = require('../../blockchain/sendRewards');
+
+function buildApp() {
+  const app = express();
+  app.use(express.json());
+  app.use('/api/rewards', require('../routes/rewards'));
+  return app;
+}
+
+function postDistribute(server, body, apiKey) {
+  return new Promise((resolve, reject) => {
+    const payload = JSON.stringify(body);
+    const req = http.request(
+      {
+        hostname: '127.0.0.1',
+        port: server.address().port,
+        path: '/api/rewards/distribute',
+        method: 'POST',
+        headers: {
+          'Content-Type': 'application/json',
+          'Content-Length': Buffer.byteLength(payload),
+          'x-api-key': apiKey,
+        },
+      },
+      (res) => {
+        let raw = '';
+        res.on('data', (chunk) => { raw += chunk; });
+        res.on('end', () => resolve({ status: res.statusCode, body: JSON.parse(raw) }));
+      }
+    );
+    req.on('error', reject);
+    req.write(payload);
+    req.end();
+  });
+}
+
+describe('POST /api/rewards/distribute — campaign not found', () => {
+  let server;
+  const merchant = { id: 1, api_key: 'test-api-key' };
+
+  beforeAll((done) => {
+    server = http.createServer(buildApp()).listen(0, done);
+  });
+
+  afterAll((done) => {
+    server.close(done);
+  });
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+    query.mockResolvedValue({ rows: [merchant] });
+  });
+
+  test('returns 404 when campaign does not exist', async () => {
+    getCampaignById.mockResolvedValue(null);
+
+    const response = await postDistribute(
+      server,
+      {
+        customerWallet: Keypair.random().publicKey(),
+        amount: 10,
+        campaignId: 999,
+      },
+      merchant.api_key
+    );
+
+    expect(response.status).toBe(404);
+    expect(response.body.success).toBe(false);
+    expect(response.body.error).toBe('not_found');
+    expect(getActiveCampaign).not.toHaveBeenCalled();
+    expect(distributeRewards).not.toHaveBeenCalled();
+  });
+});

--- a/novaRewards/backend/tests/distributeExpiredCampaign.test.js
+++ b/novaRewards/backend/tests/distributeExpiredCampaign.test.js
@@ -17,6 +17,7 @@ jest.mock('../db/index', () => ({ query: jest.fn() }));
 
 // Mock campaignRepository — getActiveCampaign returns null for expired campaigns
 jest.mock('../db/campaignRepository', () => ({
+  getCampaignById: jest.fn(),
   getActiveCampaign: jest.fn(),
 }));
 
@@ -43,7 +44,7 @@ jest.mock('../../blockchain/stellarService', () => ({
 }));
 
 const express = require('express');
-const { getActiveCampaign } = require('../db/campaignRepository');
+const { getCampaignById, getActiveCampaign } = require('../db/campaignRepository');
 const { distributeRewards } = require('../../blockchain/sendRewards');
 const { query } = require('../db/index');
 
@@ -85,7 +86,13 @@ describe('POST /api/rewards/distribute — expired campaign (Property 7)', () =>
         pastDateArb,
         fc.integer({ min: 1, max: 999 }), // campaignId
         async (endDate, campaignId) => {
-          // getActiveCampaign returns null — campaign is expired / inactive
+          // Campaign exists, but active lookup fails — expired/inactive.
+          getCampaignById.mockResolvedValue({
+            id: campaignId,
+            merchant_id: MERCHANT.id,
+            end_date: endDate,
+            is_active: false,
+          });
           getActiveCampaign.mockResolvedValue(null);
 
           const customerWallet = Keypair.random().publicKey();


### PR DESCRIPTION
closes #25 

## Summary
- differentiate campaign errors in POST /api/rewards/distribute
- return 404 when campaign does not exist
- return 400 when campaign is expired or inactive
- add campaign existence lookup in repository via getCampaignById
- update and add tests for both 404 and 400 scenarios

## Why
This improves client-side error handling by separating not-found from invalid-state responses.