### PR TITLE
Fix #23: make transaction campaignId nullable at SQL param $7

### DIFF
--- a/novaRewards/backend/db/transactionRepository.js
+++ b/novaRewards/backend/db/transactionRepository.js
@@ -25,12 +25,14 @@ async function recordTransaction({
   campaignId,
   stellarLedger,
 }) {
+  const nullableCampaignId = campaignId ?? null;
+
   const result = await query(
     `INSERT INTO transactions
        (tx_hash, tx_type, amount, from_wallet, to_wallet, merchant_id, campaign_id, stellar_ledger)
      VALUES ($1, $2, $3, $4, $5, $6, $7, $8)
      RETURNING *`,
-    [txHash, txType, amount, fromWallet, toWallet, merchantId, campaignId, stellarLedger]
+    [txHash, txType, amount, fromWallet, toWallet, merchantId, nullableCampaignId, stellarLedger]
   );
   return result.rows[0];
 }

--- a/novaRewards/backend/tests/transactionRepositoryNullableCampaignId.test.js
+++ b/novaRewards/backend/tests/transactionRepositoryNullableCampaignId.test.js
@@ -1,0 +1,42 @@
+jest.mock('../db/index', () => ({ query: jest.fn() }));
+
+const { query } = require('../db/index');
+const { recordTransaction } = require('../db/transactionRepository');
+
+describe('recordTransaction campaignId nullability', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+    query.mockResolvedValue({ rows: [{ id: 1 }] });
+  });
+
+  test('passes SQL null at $7 when campaignId is undefined', async () => {
+    await recordTransaction({
+      txHash: 'abc123',
+      txType: 'distribution',
+      amount: '10',
+      fromWallet: 'GAAAA',
+      toWallet: 'GBBBB',
+      merchantId: 1,
+      stellarLedger: 123,
+    });
+
+    const params = query.mock.calls[0][1];
+    expect(params[6]).toBeNull();
+  });
+
+  test('passes SQL null at $7 when campaignId is null', async () => {
+    await recordTransaction({
+      txHash: 'def456',
+      txType: 'distribution',
+      amount: '20',
+      fromWallet: 'GCCCC',
+      toWallet: 'GDDDD',
+      merchantId: 2,
+      campaignId: null,
+      stellarLedger: 456,
+    });
+
+    const params = query.mock.calls[0][1];
+    expect(params[6]).toBeNull();
+  });
+});


### PR DESCRIPTION
## Summary
- ensure recordTransaction handles optional campaignId safely
- map campaignId to null when undefined or null before SQL insert
- keep INSERT parameter mapping with campaign_id at $7
- add tests asserting $7 is null for undefined and null campaignId

## Issue
Closes #23