### PR TITLE
Add Horizon verification to POST /api/transactions/record endpoint

### DIFF
--- a/backend/routes/transactions.js
+++ b/backend/routes/transactions.js
@@ -143,4 +143,121 @@ router.get('/transactions/:walletAddress', async (req, res) => {
     }
 });
 
+/**
+ * POST /api/transactions/record
+ * Record a transaction - verifies on Horizon before saving locally
+ */
+router.post('/transactions/record', async (req, res) => {
+    try {
+        const { transactionHash, walletAddress, amount, operationType, memo } = req.body;
+
+        // Validate required fields
+        if (!transactionHash || !walletAddress || !amount || !operationType) {
+            return res.status(400).json({ 
+                error: 'Missing required fields',
+                required: ['transactionHash', 'walletAddress', 'amount', 'operationType']
+            });
+        }
+
+        // Validate wallet address format
+        if (!StellarSdk.StrKey.isValidEd25519PublicKey(walletAddress)) {
+            return res.status(400).json({ 
+                error: 'Invalid wallet address format' 
+            });
+        }
+
+        // Step 1: Verify transaction exists on Horizon
+        let horizonTransaction = null;
+        try {
+            horizonTransaction = await server.transactions().transaction(transactionHash).call();
+        } catch (horizonError) {
+            // Transaction not found on Horizon
+            return res.status(400).json({
+                error: 'Transaction not found on Stellar network',
+                message: 'The transaction hash does not exist on Horizon. Please verify the hash and try again.',
+                transactionHash: transactionHash
+            });
+        }
+
+        // Step 2: Verify the transaction involves the wallet address
+        const isSourceAccount = horizonTransaction.source_account === walletAddress;
+        const isInvolved = horizonTransaction.operations?.some(op => 
+            op.source_account === walletAddress || 
+            (op.account === walletAddress) ||
+            (op.from === walletAddress) ||
+            (op.to === walletAddress)
+        );
+
+        if (!isSourceAccount && !isInvolved) {
+            return res.status(400).json({
+                error: 'Transaction not related to wallet',
+                message: 'The transaction hash does not involve the provided wallet address.',
+                transactionHash: transactionHash,
+                walletAddress: walletAddress
+            });
+        }
+
+        // Step 3: Check if transaction already exists in local database
+        const existingCheck = await pool.query(
+            'SELECT id FROM transactions WHERE transaction_hash = $1',
+            [transactionHash]
+        );
+
+        if (existingCheck.rows.length > 0) {
+            return res.status(409).json({
+                error: 'Transaction already recorded',
+                message: 'This transaction has already been recorded in the database.',
+                transactionHash: transactionHash
+            });
+        }
+
+        // Step 4: Record the transaction in PostgreSQL
+        const result = await pool.query(
+            `INSERT INTO transactions 
+             (transaction_hash, wallet_address, amount, operation_type, memo, ledger, created_at) 
+             VALUES ($1, $2, $3, $4, $5, $6, $7) 
+             RETURNING *`,
+            [
+                transactionHash,
+                walletAddress,
+                amount,
+                operationType,
+                memo || null,
+                horizonTransaction.ledger,
+                horizonTransaction.created_at
+            ]
+        );
+
+        // Step 5: Return success response
+        res.status(201).json({
+            success: true,
+            message: 'Transaction verified and recorded successfully',
+            transaction: {
+                id: result.rows[0].id,
+                hash: result.rows[0].transaction_hash,
+                walletAddress: result.rows[0].wallet_address,
+                amount: result.rows[0].amount,
+                operationType: result.rows[0].operation_type,
+                memo: result.rows[0].memo,
+                ledger: result.rows[0].ledger,
+                createdAt: result.rows[0].created_at
+            },
+            horizonVerification: {
+                verified: true,
+                sourceAccount: horizonTransaction.source_account,
+                successful: horizonTransaction.successful,
+                ledger: horizonTransaction.ledger
+            }
+        });
+
+    } catch (error) {
+        console.error('Error recording transaction:', error);
+        res.status(500).json({ 
+            error: 'Server error', 
+            message: 'Failed to record transaction',
+            details: process.env.NODE_ENV === 'development' ? error.message : undefined
+        });
+    }
+});
+
 module.exports = router;


### PR DESCRIPTION
## Description
Added Horizon blockchain verification to the transaction recording endpoint as required by Requirement 4.3.

## Changes Made
- Verify transaction exists on Horizon before saving to database
- Return 400 error with clear message if transaction not found
- Validate transaction involves the provided wallet address
- Check for duplicate transactions before inserting
- Added horizonVerification metadata in response

## Validation Steps
1. Transaction hash must exist on Horizon
2. Transaction must involve the wallet address
3. Transaction must not already exist in database

## Response Examples

**Success (201):**
```json
{
  "success": true,
  "message": "Transaction verified and recorded successfully",
  "transaction": {
    "id": 1,
    "hash": "abc123...",
    "walletAddress": "GA7QY...",
    "amount": "100",
    "operationType": "payment",
    "ledger": 12345,
    "createdAt": "2024-01-01T00:00:00Z"
  },
  "horizonVerification": {
    "verified": true,
    "sourceAccount": "GA7QY...",
    "successful": true,
    "ledger": 12345
  }
}

closes #28