### PR TITLE
feat: add real-time total refresh after reward issuance

### DIFF
--- a/novaRewards/frontend/components/IssueRewardForm.js
+++ b/novaRewards/frontend/components/IssueRewardForm.js
@@ -1,61 +1,70 @@
-'use client';
-import { useState } from 'react';
-import { StrKey } from 'stellar-sdk';
-import api from '../lib/api';
+"use client";
+import { useState } from "react";
+import { StrKey } from "stellar-sdk";
+import api from "../lib/api";
 
 /**
  * Form for issuing NOVA rewards to a customer wallet.
  * Requirements: 10.4, 10.5, 3.1
  */
-export default function IssueRewardForm({ merchantId, apiKey, campaigns, onSuccess }) {
-  const [customerWallet, setCustomerWallet] = useState('');
-  const [amount, setAmount] = useState('');
-  const [campaignId, setCampaignId] = useState('');
-  const [status, setStatus] = useState('idle');
-  const [message, setMessage] = useState('');
-  const [txHash, setTxHash] = useState('');
+export default function IssueRewardForm({
+  merchantId,
+  apiKey,
+  campaigns,
+  onSuccess,
+}) {
+  const [customerWallet, setCustomerWallet] = useState("");
+  const [amount, setAmount] = useState("");
+  const [campaignId, setCampaignId] = useState("");
+  const [status, setStatus] = useState("idle");
+  const [message, setMessage] = useState("");
+  const [txHash, setTxHash] = useState("");
 
   function isValidAddress(addr) {
-    try { return StrKey.isValidEd25519PublicKey(addr); } catch { return false; }
+    try {
+      return StrKey.isValidEd25519PublicKey(addr);
+    } catch {
+      return false;
+    }
   }
 
   async function handleIssue(e) {
     e.preventDefault();
-    setMessage('');
-    setTxHash('');
+    setMessage("");
+    setTxHash("");
 
     // Client-side validation — Requirements 10.5
     if (!isValidAddress(customerWallet)) {
-      setMessage('Customer wallet must be a valid Stellar public key.');
-      setStatus('error');
+      setMessage("Customer wallet must be a valid Stellar public key.");
+      setStatus("error");
       return;
     }
     if (!amount || isNaN(Number(amount)) || Number(amount) <= 0) {
-      setMessage('Amount must be a positive number.');
-      setStatus('error');
+      setMessage("Amount must be a positive number.");
+      setStatus("error");
       return;
     }
     if (!campaignId) {
-      setMessage('Please select a campaign.');
-      setStatus('error');
+      setMessage("Please select a campaign.");
+      setStatus("error");
       return;
     }
 
-    setStatus('loading');
+    setStatus("loading");
     try {
       const { data } = await api.post(
-        '/api/rewards/distribute',
+        "/api/rewards/distribute",
         { customerWallet, amount, campaignId: Number(campaignId) },
-        { headers: { 'x-api-key': apiKey } }
+        { headers: { "x-api-key": apiKey } },
       );
-      setStatus('done');
+      setStatus("done");
       setTxHash(data.data.txHash);
-      setMessage('Rewards issued successfully.');
-      setCustomerWallet('');
-      setAmount('');
-      onSuccess?.();
+      setMessage("Rewards issued successfully.");
+      setCustomerWallet("");
+      setAmount("");
+      await onSuccess?.();
     } catch (err) {
-      setStatus('error');
+      setStatus("error");
       setMessage(err.response?.data?.message || err.message);
     }
   }
@@ -69,7 +78,7 @@ export default function IssueRewardForm({ merchantId, apiKey, campaigns, onSucce
         className="input"
         value={campaignId}
         onChange={(e) => setCampaignId(e.target.value)}
-        disabled={status === 'loading'}
+        disabled={status === "loading"}
       >
         <option value="">Select a campaign…</option>
         {activeCampaigns.map((c) => (
@@ -85,7 +94,7 @@ export default function IssueRewardForm({ merchantId, apiKey, campaigns, onSucce
         value={customerWallet}
         onChange={(e) => setCustomerWallet(e.target.value)}
         placeholder="G..."
-        disabled={status === 'loading'}
+        disabled={status === "loading"}
       />
 
       <label className="label">Amount (NOVA)</label>
@@ -97,16 +106,29 @@ export default function IssueRewardForm({ merchantId, apiKey, campaigns, onSucce
         value={amount}
         onChange={(e) => setAmount(e.target.value)}
         placeholder="10"
-        disabled={status === 'loading'}
+        disabled={status === "loading"}
       />
 
-      <button className="btn btn-primary" type="submit" disabled={status === 'loading' || activeCampaigns.length === 0}>
-        {status === 'loading' ? 'Issuing…' : 'Issue Rewards'}
+      <button
+        className="btn btn-primary"
+        type="submit"
+        disabled={status === "loading" || activeCampaigns.length === 0}
+      >
+        {status === "loading" ? "Issuing…" : "Issue Rewards"}
       </button>
 
-      {message && <p className={status === 'error' ? 'error' : 'success'}>{message}</p>}
+      {message && (
+        <p className={status === "error" ? "error" : "success"}>{message}</p>
+      )}
       {txHash && (
-        <p style={{ fontSize: '0.8rem', color: '#94a3b8', marginTop: '0.5rem', fontFamily: 'monospace' }}>
+        <p
+          style={{
+            fontSize: "0.8rem",
+            color: "#94a3b8",
+            marginTop: "0.5rem",
+            fontFamily: "monospace",
+          }}
+        >
           Tx: {txHash}
         </p>
       )}

--- a/novaRewards/frontend/pages/merchant.js
+++ b/novaRewards/frontend/pages/merchant.js
@@ -1,7 +1,7 @@
-import { useState, useEffect, useCallback } from 'react';
-import CampaignForm from '../components/CampaignForm';
-import IssueRewardForm from '../components/IssueRewardForm';
-import api from '../lib/api';
+import { useState, useEffect, useCallback } from "react";
+import CampaignForm from "../components/CampaignForm";
+import IssueRewardForm from "../components/IssueRewardForm";
+import api from "../lib/api";
 
 /**
  * Merchant dashboard — registration, campaigns, reward issuance, totals.
@@ -9,28 +9,52 @@ import api from '../lib/api';
  */
 export default function MerchantDashboard() {
   // Registration state
-  const [regForm, setRegForm] = useState({ name: '', walletAddress: '', businessCategory: '' });
+  const [regForm, setRegForm] = useState({
+    name: "",
+    walletAddress: "",
+    businessCategory: "",
+  });
   const [merchant, setMerchant] = useState(null);
-  const [apiKey, setApiKey] = useState('');
-  const [regStatus, setRegStatus] = useState('idle');
-  const [regMessage, setRegMessage] = useState('');
+  const [apiKey, setApiKey] = useState("");
+  const [regStatus, setRegStatus] = useState("idle");
+  const [regMessage, setRegMessage] = useState("");
 
   // Dashboard state
   const [campaigns, setCampaigns] = useState([]);
-  const [totals, setTotals] = useState({ totalDistributed: 0, totalRedeemed: 0 });
+  const [totals, setTotals] = useState({
+    totalDistributed: 0,
+    totalRedeemed: 0,
+  });
+  const [totalsLoading, setTotalsLoading] = useState(false);
 
-  const loadDashboard = useCallback(async (mid) => {
+  const getMerchantTotals = useCallback(async (mid) => {
+    setTotalsLoading(true);
     try {
-      const [campRes, totalsRes] = await Promise.all([
-        api.get(`/api/campaigns/${mid}`),
-        api.get(`/api/transactions/merchant-totals/${mid}`).catch(() => ({ data: { data: { totalDistributed: 0, totalRedeemed: 0 } } })),
-      ]);
-      setCampaigns(campRes.data.data || []);
-      setTotals(totalsRes.data.data || { totalDistributed: 0, totalRedeemed: 0 });
+      const totalsRes = await api.get(
+        `/api/transactions/merchant-totals/${mid}`,
+      );
+      setTotals(
+        totalsRes.data.data || { totalDistributed: 0, totalRedeemed: 0 },
+      );
     } catch {
-      // silently ignore on first load
+      setTotals({ totalDistributed: 0, totalRedeemed: 0 });
+    } finally {
+      setTotalsLoading(false);
     }
   }, []);
+
+  const loadDashboard = useCallback(
+    async (mid) => {
+      try {
+        const [campRes] = await Promise.all([api.get(`/api/campaigns/${mid}`)]);
+        setCampaigns(campRes.data.data || []);
+        await getMerchantTotals(mid);
+      } catch {
+        // silently ignore on first load
+      }
+    },
+    [getMerchantTotals],
+  );
 
   useEffect(() => {
     if (merchant?.id) loadDashboard(merchant.id);
@@ -38,20 +62,21 @@ export default function MerchantDashboard() {
 
   async function handleRegister(e) {
     e.preventDefault();
-    setRegMessage('');
-    setRegStatus('loading');
+    setRegMessage("");
+    setRegStatus("loading");
     try {
-      const { data } = await api.post('/api/merchants/register', regForm);
+      const { data } = await api.post("/api/merchants/register", regForm);
       setMerchant(data.data);
       setApiKey(data.data.api_key);
-      setRegStatus('done');
+      setRegStatus("done");
     } catch (err) {
-      setRegStatus('error');
+      setRegStatus("error");
       setRegMessage(err.response?.data?.message || err.message);
     }
   }
 
-  const setReg = (field) => (e) => setRegForm((f) => ({ ...f, [field]: e.target.value }));
+  const setReg = (field) => (e) =>
+    setRegForm((f) => ({ ...f, [field]: e.target.value }));
 
   return (
     <>
@@ -63,24 +88,54 @@ export default function MerchantDashboard() {
       </nav>
 
       <div className="container">
-        <h1 style={{ marginBottom: '1.5rem', fontSize: '1.8rem', fontWeight: 700 }}>Merchant Portal</h1>
+        <h1
+          style={{
+            marginBottom: "1.5rem",
+            fontSize: "1.8rem",
+            fontWeight: 700,
+          }}
+        >
+          Merchant Portal
+        </h1>
 
         {/* Registration */}
         {!merchant ? (
           <div className="card">
-            <h2 style={{ marginBottom: '1rem' }}>Register as a Merchant</h2>
+            <h2 style={{ marginBottom: "1rem" }}>Register as a Merchant</h2>
             <form onSubmit={handleRegister}>
               <label className="label">Business Name</label>
-              <input className="input" value={regForm.name} onChange={setReg('name')} placeholder="Acme Coffee" disabled={regStatus === 'loading'} />
+              <input
+                className="input"
+                value={regForm.name}
+                onChange={setReg("name")}
+                placeholder="Acme Coffee"
+                disabled={regStatus === "loading"}
+              />
 
               <label className="label">Stellar Wallet Address</label>
-              <input className="input" value={regForm.walletAddress} onChange={setReg('walletAddress')} placeholder="G..." disabled={regStatus === 'loading'} />
+              <input
+                className="input"
+                value={regForm.walletAddress}
+                onChange={setReg("walletAddress")}
+                placeholder="G..."
+                disabled={regStatus === "loading"}
+              />
 
               <label className="label">Business Category (optional)</label>
-              <input className="input" value={regForm.businessCategory} onChange={setReg('businessCategory')} placeholder="Food & Beverage" disabled={regStatus === 'loading'} />
+              <input
+                className="input"
+                value={regForm.businessCategory}
+                onChange={setReg("businessCategory")}
+                placeholder="Food & Beverage"
+                disabled={regStatus === "loading"}
+              />
 
-              <button className="btn btn-primary" type="submit" disabled={regStatus === 'loading'}>
-                {regStatus === 'loading' ? 'Registering…' : 'Register'}
+              <button
+                className="btn btn-primary"
+                type="submit"
+                disabled={regStatus === "loading"}
+              >
+                {regStatus === "loading" ? "Registering…" : "Register"}
               </button>
               {regMessage && <p className="error">{regMessage}</p>}
             </form>
@@ -89,48 +144,94 @@ export default function MerchantDashboard() {
           <>
             {/* Merchant info + API key */}
             <div className="card">
-              <p style={{ color: '#94a3b8', fontSize: '0.85rem' }}>Logged in as</p>
-              <p style={{ fontWeight: 700, fontSize: '1.1rem' }}>{merchant.name}</p>
-              <p style={{ fontFamily: 'monospace', fontSize: '0.8rem', color: '#94a3b8', marginTop: '0.3rem' }}>
-                API Key: <span style={{ color: '#7c3aed' }}>{apiKey}</span>
+              <p style={{ color: "#94a3b8", fontSize: "0.85rem" }}>
+                Logged in as
               </p>
-              <p style={{ fontSize: '0.75rem', color: '#64748b', marginTop: '0.3rem' }}>
+              <p style={{ fontWeight: 700, fontSize: "1.1rem" }}>
+                {merchant.name}
+              </p>
+              <p
+                style={{
+                  fontFamily: "monospace",
+                  fontSize: "0.8rem",
+                  color: "#94a3b8",
+                  marginTop: "0.3rem",
+                }}
+              >
+                API Key: <span style={{ color: "#7c3aed" }}>{apiKey}</span>
+              </p>
+              <p
+                style={{
+                  fontSize: "0.75rem",
+                  color: "#64748b",
+                  marginTop: "0.3rem",
+                }}
+              >
                 Keep this key secret — it authorises reward distributions.
               </p>
             </div>
 
             {/* Totals summary — Requirements 10.2 */}
-            <div className="card" style={{ display: 'flex', gap: '2rem' }}>
-              <div>
-                <p style={{ color: '#94a3b8', fontSize: '0.85rem' }}>Total Distributed</p>
-                <p style={{ fontSize: '1.8rem', fontWeight: 700, color: '#7c3aed' }}>
-                  {parseFloat(totals.totalDistributed).toFixed(2)}
+            <div className="card">
+              {totalsLoading && (
+                <p
+                  style={{
+                    color: "#94a3b8",
+                    fontSize: "0.8rem",
+                    marginBottom: "0.5rem",
+                  }}
+                >
+                  Refreshing totals…
                 </p>
-                <p style={{ color: '#94a3b8', fontSize: '0.8rem' }}>NOVA</p>
-              </div>
-              <div>
-                <p style={{ color: '#94a3b8', fontSize: '0.85rem' }}>Total Redeemed</p>
-                <p style={{ fontSize: '1.8rem', fontWeight: 700, color: '#34d399' }}>
-                  {parseFloat(totals.totalRedeemed).toFixed(2)}
-                </p>
-                <p style={{ color: '#94a3b8', fontSize: '0.8rem' }}>NOVA</p>
+              )}
+              <div style={{ display: "flex", gap: "2rem" }}>
+                <div>
+                  <p style={{ color: "#94a3b8", fontSize: "0.85rem" }}>
+                    Total Distributed
+                  </p>
+                  <p
+                    style={{
+                      fontSize: "1.8rem",
+                      fontWeight: 700,
+                      color: "#7c3aed",
+                    }}
+                  >
+                    {parseFloat(totals.totalDistributed).toFixed(2)}
+                  </p>
+                  <p style={{ color: "#94a3b8", fontSize: "0.8rem" }}>NOVA</p>
+                </div>
+                <div>
+                  <p style={{ color: "#94a3b8", fontSize: "0.85rem" }}>
+                    Total Redeemed
+                  </p>
+                  <p
+                    style={{
+                      fontSize: "1.8rem",
+                      fontWeight: 700,
+                      color: "#34d399",
+                    }}
+                  >
+                    {parseFloat(totals.totalRedeemed).toFixed(2)}
+                  </p>
+                  <p style={{ color: "#94a3b8", fontSize: "0.8rem" }}>NOVA</p>
+                </div>
               </div>
             </div>
 
             {/* Issue rewards — Requirements 10.4 */}
             <div className="card">
-              <h2 style={{ marginBottom: '1rem' }}>Issue Rewards</h2>
+              <h2 style={{ marginBottom: "1rem" }}>Issue Rewards</h2>
               <IssueRewardForm
                 merchantId={merchant.id}
                 apiKey={apiKey}
                 campaigns={campaigns}
-                onSuccess={() => loadDashboard(merchant.id)}
+                onSuccess={() => getMerchantTotals(merchant.id)}
               />
             </div>
 
             {/* Create campaign — Requirements 10.3 */}
             <div className="card">
-              <h2 style={{ marginBottom: '1rem' }}>Create Campaign</h2>
+              <h2 style={{ marginBottom: "1rem" }}>Create Campaign</h2>
               <CampaignForm
                 merchantId={merchant.id}
                 apiKey={apiKey}
@@ -140,9 +241,11 @@ export default function MerchantDashboard() {
 
             {/* Campaign list — Requirements 10.1 */}
             <div className="card">
-              <h2 style={{ marginBottom: '1rem' }}>Campaigns</h2>
+              <h2 style={{ marginBottom: "1rem" }}>Campaigns</h2>
               {campaigns.length === 0 ? (
-                <p style={{ color: '#94a3b8' }}>No campaigns yet. Create one above.</p>
+                <p style={{ color: "#94a3b8" }}>
+                  No campaigns yet. Create one above.
+                </p>
               ) : (
                 <table>
                   <thead>
@@ -164,8 +267,10 @@ export default function MerchantDashboard() {
                           <td>{c.start_date?.slice(0, 10)}</td>
                           <td>{c.end_date?.slice(0, 10)}</td>
                           <td>
-                            <span className={`badge ${c.is_active && !expired ? 'badge-green' : 'badge-gray'}`}>
-                              {c.is_active && !expired ? 'Active' : 'Inactive'}
+                            <span
+                              className={`badge ${c.is_active && !expired ? "badge-green" : "badge-gray"}`}
+                            >
+                              {c.is_active && !expired ? "Active" : "Inactive"}
                             </span>
                           </td>
                         </tr>


### PR DESCRIPTION
This PR closes #111 

## Refresh merchant totals immediately after reward issuance

### Description

- Ensures merchant summary totals stay current right after a successful reward distribution, without requiring a full page reload.
- Introduces a dedicated totals refresh flow and wires reward issuance success to trigger that totals re-fetch.
- Awaits the success callback in reward issuance so async refresh completes reliably.
- Adds a lightweight “Refreshing totals…” indicator while totals are being fetched.
- Keeps existing dashboard behavior for campaigns and initial load intact, with no API contract changes.