### PR TITLE
fix(blockchain): resolve NETWORK_PASSPHRASE inside buildTrustlineXDR dynamically

### DIFF
--- a/novaRewards/blockchain/trustline.js
+++ b/novaRewards/blockchain/trustline.js
@@ -7,11 +7,6 @@ const {
 } = require('stellar-sdk');
 const { server, NOVA } = require('./stellarService');
 
-const NETWORK_PASSPHRASE =
-  process.env.STELLAR_NETWORK === 'mainnet'
-    ? Networks.PUBLIC
-    : Networks.TESTNET;
-
 /**
  * Builds an unsigned changeTrust XDR for the NOVA asset.
  * The returned XDR string is intended to be signed client-side via Freighter.
@@ -21,6 +16,11 @@ const NETWORK_PASSPHRASE =
  * @returns {Promise<string>} Unsigned transaction XDR
  */
 async function buildTrustlineXDR(walletAddress) {
+  const NETWORK_PASSPHRASE =
+    process.env.STELLAR_NETWORK === 'mainnet'
+      ? Networks.PUBLIC
+      : Networks.TESTNET;
+
   const account = await server.loadAccount(walletAddress);
 
   const transaction = new TransactionBuilder(account, {


### PR DESCRIPTION

Moved NETWORK_PASSPHRASE resolution from module load time into the buildTrustlineXDR function body so that STELLAR_NETWORK changes after module load (e.g. in tests) are picked up correctly.

Closes #13