### PR TITLE
feat: add Dockerfile for backend service (#125)

### DIFF
--- a/novaRewards/backend/Dockerfile
+++ b/novaRewards/backend/Dockerfile
@@ -1,0 +1,15 @@
+# Use lightweight Node.js 20 Alpine base
+FROM node:20-alpine
+
+WORKDIR /app
+
+# Copy package files and install production dependencies only
+COPY package.json package-lock.json ./
+RUN npm ci --omit=dev
+
+# Copy application source files
+COPY . .
+
+EXPOSE 4000
+
+CMD ["node", "server.js"]


### PR DESCRIPTION

## Summary
Closes #125 

Adds a Dockerfile for the `novaRewards/backend` service as requested in the DevOps issue.

## Changes
- Base image: `node:20-alpine` for a lightweight production image
- Copies `package.json` and `package-lock.json`, then runs `npm ci --omit=dev` to install only production dependencies
- Copies application source files into `/app`
- Exposes port `4000`
- Starts the server with `CMD ["node", "server.js"]`

## How to test
docker build -t nova-rewards-backend ./novaRewards/backend
docker run -p 4000:4000 --env-file novaRewards/.env nova-rewards-backend