### PR TITLE
feat: add api-401-interceptor spec (requirements, design, tasks)

### DIFF
--- a/.kiro/specs/api-401-interceptor/.config.kiro
+++ b/.kiro/specs/api-401-interceptor/.config.kiro
@@ -1,0 +1,1 @@
+{"specId": "81866527-6ff7-498c-9c4f-3f00230f8a07", "workflowType": "requirements-first", "specType": "feature"}

--- a/.kiro/specs/api-401-interceptor/design.md
+++ b/.kiro/specs/api-401-interceptor/design.md
@@ -1,0 +1,176 @@
+# Design Document: API 401 Interceptor
+
+## Overview
+
+This feature adds a response interceptor to the central axios instance in `novaRewards/frontend/lib/api.js`. When any API call returns HTTP 401 (Unauthorized), the interceptor automatically redirects the merchant to a `/reauth` page, giving them a clear recovery path. All other responses — successes and non-401 errors — pass through unchanged so existing error handling is unaffected.
+
+The interceptor is registered once at module initialisation time. Because ES modules are singletons in Node/Next.js, the module body runs exactly once per application session, making idempotency a natural consequence of the module system rather than something that needs runtime guards.
+
+## Architecture
+
+```mermaid
+sequenceDiagram
+    participant Page as Merchant Page
+    participant API as api.js (axios instance)
+    participant Backend as Backend API
+    participant Router as Next.js Router
+    participant Reauth as /reauth page
+
+    Page->>API: api.post('/api/merchants/register', ...)
+    API->>Backend: HTTP request
+    Backend-->>API: 401 Unauthorized
+    API->>Router: router.push('/reauth')
+    API-->>Page: Promise.reject(error)
+
+    Note over Page: Existing catch blocks still run
+```
+
+```mermaid
+flowchart TD
+    A[Response received] --> B{Status 2xx?}
+    B -- yes --> C[Return response unchanged]
+    B -- no --> D{Status 401?}
+    D -- yes --> E[router.push '/reauth']
+    E --> F[Promise.reject error]
+    D -- no --> G{Has response object?}
+    G -- yes --> H[Re-throw original error]
+    G -- no --> H
+```
+
+## Components and Interfaces
+
+### 1. `novaRewards/frontend/lib/api.js` (modified)
+
+The axios instance gains a single response interceptor. The interceptor needs access to the Next.js router, but `next/router` can only be used inside React components or after the router is initialised. The standard pattern for using the router outside React is to import `Router` directly from `next/router` (the singleton) and call `Router.push(...)`.
+
+```js
+import axios from 'axios';
+import Router from 'next/router';
+
+const api = axios.create({
+  baseURL: process.env.NEXT_PUBLIC_API_URL || 'http://localhost:3001',
+  headers: { 'Content-Type': 'application/json' },
+});
+
+api.interceptors.response.use(
+  (response) => response,                          // 2xx: pass through
+  (error) => {
+    if (error.response?.status === 401) {
+      Router.push('/reauth');
+    }
+    return Promise.reject(error);                  // always reject
+  }
+);
+
+export default api;
+```
+
+Key design decisions:
+- `Router` (capital R) from `next/router` is the singleton router, usable outside components.
+- `Promise.reject(error)` is returned unconditionally — the redirect and the rejection are not mutually exclusive.
+- No runtime guard is needed for idempotency; the module body runs once.
+
+### 2. `novaRewards/frontend/pages/reauth.js` (new)
+
+A minimal static page. It requires no props, no API calls, and no authenticated state.
+
+```
+/reauth
+  - Heading: "Session Expired"
+  - Body: explanation that the API key is invalid or expired
+  - Link: "Return to Merchant Portal" → /merchant
+```
+
+## Data Models
+
+No new data models are introduced. The interceptor operates on the existing axios response/error objects:
+
+```
+AxiosResponse { status, data, headers, config, request }
+AxiosError    { message, response?: AxiosResponse, request, config }
+```
+
+The interceptor reads `error.response?.status` (optional chaining handles network errors where `response` is undefined).
+
+## Correctness Properties
+
+*A property is a characteristic or behavior that should hold true across all valid executions of a system — essentially, a formal statement about what the system should do. Properties serve as the bridge between human-readable specifications and machine-verifiable correctness guarantees.*
+
+### Property 1: 2xx responses pass through unchanged
+
+*For any* axios response with a status code in the range 200–299, the interceptor's success handler should return the exact same response object it received, without modification.
+
+**Validates: Requirements 1.2**
+
+### Property 2: 401 errors trigger a redirect
+
+*For any* axios error whose `response.status` is 401, the interceptor's error handler should call `Router.push` with the argument `'/reauth'`.
+
+**Validates: Requirements 1.3**
+
+### Property 3: Non-401 errors are re-thrown unchanged
+
+*For any* axios error whose `response.status` is a value other than 401 (e.g. 400, 403, 404, 500), the interceptor should re-throw the original error object — the same reference, unmodified — and should not call `Router.push`.
+
+**Validates: Requirements 1.4, 4.1**
+
+### Property 4: 401 handling always rejects the promise
+
+*For any* axios error whose `response.status` is 401, the interceptor should return a rejected promise (i.e. `Promise.reject`) regardless of whether the redirect was triggered, so that awaiting callers receive a rejection rather than hanging.
+
+**Validates: Requirements 4.3**
+
+## Error Handling
+
+| Scenario | Interceptor behaviour |
+|---|---|
+| 2xx response | Pass through to caller unchanged |
+| 401 response | `Router.push('/reauth')` then `Promise.reject(error)` |
+| Non-401 error response (4xx/5xx) | `Promise.reject(error)` — original error, no modification |
+| Network error (no `response`) | `Promise.reject(error)` — `error.response` is undefined, 401 check is false via optional chaining |
+
+The optional chaining `error.response?.status` is the single guard that handles both network errors and HTTP errors uniformly without branching.
+
+## Testing Strategy
+
+### Unit tests (Jest + React Testing Library)
+
+Unit tests cover specific examples and edge cases:
+
+- **Example A — Single interceptor registration**: After importing `api.js`, assert that `api.interceptors.response.handlers` has exactly one entry. This covers Requirements 1.1, 3.1, 3.2.
+- **Example B — Network error passthrough**: Create an `AxiosError` with no `response` property, pass it to the error handler, assert `Router.push` was not called and the promise rejects. Covers Requirement 4.2.
+- **Example C — Reauth page renders correctly**: Render `<ReauthPage />` with no props, assert the explanatory message is present and a link to `/merchant` exists. Covers Requirements 2.1, 2.2, 2.3.
+
+### Property-based tests (fast-check)
+
+fast-check is the recommended PBT library for JavaScript/TypeScript. Install with:
+
+```
+npm install --save-dev fast-check
+```
+
+Each property test runs a minimum of 100 iterations. Tests are tagged with a comment referencing the design property.
+
+**Property 1 test** — `Feature: api-401-interceptor, Property 1: 2xx responses pass through unchanged`
+Generate random integers in [200, 299] and random response body objects. Construct a mock `AxiosResponse` and pass it through the success handler. Assert the returned value is the same reference.
+
+**Property 2 test** — `Feature: api-401-interceptor, Property 2: 401 errors trigger a redirect`
+Generate random `AxiosError` objects with `response.status = 401` and varying bodies/headers. Pass each to the error handler. Assert `Router.push` was called with `'/reauth'` for every generated input.
+
+**Property 3 test** — `Feature: api-401-interceptor, Property 3: Non-401 errors are re-thrown unchanged`
+Generate random HTTP error status codes excluding 401 (e.g. from the set {400, 402–599}). Construct mock `AxiosError` objects. Pass each to the error handler. Assert the rejected value is the same object reference and `Router.push` was not called.
+
+**Property 4 test** — `Feature: api-401-interceptor, Property 4: 401 handling always rejects the promise`
+Generate random `AxiosError` objects with `response.status = 401`. Pass each to the error handler. Assert the return value is a rejected promise (check with `await expect(...).rejects`).
+
+### Test configuration
+
+```js
+// jest.config.js addition for frontend
+testEnvironment: 'jsdom'
+```
+
+Mock `next/router` in tests:
+```js
+jest.mock('next/router', () => ({ push: jest.fn() }));
+```

--- a/.kiro/specs/api-401-interceptor/requirements.md
+++ b/.kiro/specs/api-401-interceptor/requirements.md
@@ -1,0 +1,55 @@
+# Requirements Document
+
+## Introduction
+
+This feature adds a response interceptor to the central axios instance (`novaRewards/frontend/lib/api.js`) in the NovaRewards frontend. When any backend call returns a 401 (Unauthorized) status — indicating an invalid or expired API key — the interceptor redirects the merchant to a re-authentication page so they can obtain a fresh API key. This prevents merchants from silently operating with an invalid key and provides a clear recovery path.
+
+## Glossary
+
+- **Interceptor**: An axios response interceptor that runs on every HTTP response before it reaches the calling code.
+- **API_Client**: The axios instance exported from `novaRewards/frontend/lib/api.js`.
+- **Reauth_Page**: The dedicated Next.js page (`/reauth`) that informs the merchant their session is invalid and prompts them to re-register or return to the merchant portal.
+- **Merchant**: A business user who has registered on the merchant portal and holds an API key used to authorise reward distributions.
+- **Router**: The Next.js `next/router` instance used for client-side navigation.
+
+## Requirements
+
+### Requirement 1: Attach Response Interceptor to API Client
+
+**User Story:** As a merchant, I want invalid API key errors to be handled automatically, so that I am not left in a broken state when my session expires.
+
+#### Acceptance Criteria
+
+1. THE API_Client SHALL attach exactly one response interceptor at module initialisation time.
+2. WHEN a response with HTTP status 200–299 is received, THE API_Client SHALL pass the response through to the calling code unchanged.
+3. WHEN a response with HTTP status 401 is received, THE Interceptor SHALL redirect the browser to the `/reauth` route using the Next.js Router.
+4. WHEN a response with an HTTP status other than 401 is received and the status is outside 200–299, THE Interceptor SHALL re-throw the error so the calling code can handle it normally.
+
+### Requirement 2: Re-authentication Page
+
+**User Story:** As a merchant, I want a clear re-authentication page, so that I understand why I was redirected and know how to recover access.
+
+#### Acceptance Criteria
+
+1. THE Reauth_Page SHALL render a human-readable message explaining that the API key is invalid or has expired.
+2. THE Reauth_Page SHALL provide a navigation link that returns the merchant to `/merchant` so they can re-register and obtain a new API key.
+3. THE Reauth_Page SHALL NOT require any authenticated state or API key to render.
+
+### Requirement 3: Interceptor Idempotency
+
+**User Story:** As a developer, I want the interceptor to be registered only once, so that 401 responses do not trigger multiple redirects.
+
+#### Acceptance Criteria
+
+1. THE API_Client SHALL register the response interceptor exactly once across the lifetime of the module.
+2. WHEN the module is imported multiple times within the same application session, THE API_Client SHALL NOT attach duplicate interceptors.
+
+### Requirement 4: Non-Interference with Existing Error Handling
+
+**User Story:** As a developer, I want non-401 errors to continue propagating normally, so that existing try/catch blocks in the application are not broken.
+
+#### Acceptance Criteria
+
+1. WHEN a response error with a status code other than 401 is received, THE Interceptor SHALL re-throw the original error object without modification.
+2. WHEN a network error with no response object is received, THE Interceptor SHALL re-throw the error without triggering a redirect.
+3. WHEN a 401 redirect is triggered, THE Interceptor SHALL still reject the original promise so any calling code that awaits the request receives a rejected promise rather than hanging indefinitely.

--- a/.kiro/specs/api-401-interceptor/tasks.md
+++ b/.kiro/specs/api-401-interceptor/tasks.md
@@ -1,0 +1,79 @@
+# Implementation Plan: API 401 Interceptor
+
+## Overview
+
+Add a response interceptor to the axios instance in `api.js` that redirects to `/reauth` on 401 responses, create the `/reauth` page, install fast-check, and add unit + property-based tests.
+
+## Tasks
+
+- [ ] 1. Install fast-check as a dev dependency
+  - Run `npm install --save-dev fast-check` inside `novaRewards/frontend`
+  - Verify it appears in `package.json` devDependencies
+  - _Requirements: 1.1_
+
+- [ ] 2. Add the 401 response interceptor to `novaRewards/frontend/lib/api.js`
+  - [ ] 2.1 Import `Router` from `next/router` and register the interceptor
+    - Add `import Router from 'next/router'` at the top of `api.js`
+    - Register `api.interceptors.response.use(successHandler, errorHandler)` immediately after `api` is created
+    - Success handler: return the response unchanged
+    - Error handler: if `error.response?.status === 401`, call `Router.push('/reauth')`; always `return Promise.reject(error)`
+    - _Requirements: 1.1, 1.2, 1.3, 1.4, 3.1, 3.2, 4.3_
+
+  - [ ]* 2.2 Write property test — Property 1: 2xx responses pass through unchanged
+    - File: `novaRewards/frontend/__tests__/api.interceptor.test.js`
+    - Mock `next/router` with `jest.mock('next/router', () => ({ push: jest.fn() }))`
+    - Extract the success handler from `api.interceptors.response.handlers[0].fulfilled`
+    - Use `fc.integer({ min: 200, max: 299 })` and `fc.object()` to generate mock responses
+    - Assert the returned value is the same reference as the input
+    - **Property 1: 2xx responses pass through unchanged**
+    - **Validates: Requirements 1.2**
+
+  - [ ]* 2.3 Write property test — Property 2: 401 errors trigger a redirect
+    - File: `novaRewards/frontend/__tests__/api.interceptor.test.js`
+    - Extract the error handler from `api.interceptors.response.handlers[0].rejected`
+    - Use `fc.record({ response: fc.record({ status: fc.constant(401), data: fc.object() }) })` to generate mock errors
+    - Assert `Router.push` was called with `'/reauth'` for every generated input
+    - **Property 2: 401 errors trigger a redirect**
+    - **Validates: Requirements 1.3**
+
+  - [ ]* 2.4 Write property test — Property 3: Non-401 errors are re-thrown unchanged
+    - File: `novaRewards/frontend/__tests__/api.interceptor.test.js`
+    - Generate status codes from the set {400, 402–599} using `fc.integer({ min: 400, max: 599 }).filter(s => s !== 401)`
+    - Assert the rejected value is the same object reference and `Router.push` was not called
+    - **Property 3: Non-401 errors are re-thrown unchanged**
+    - **Validates: Requirements 1.4, 4.1**
+
+  - [ ]* 2.5 Write property test — Property 4: 401 handling always rejects the promise
+    - File: `novaRewards/frontend/__tests__/api.interceptor.test.js`
+    - Generate `AxiosError`-shaped objects with `response.status = 401`
+    - Assert the return value is a rejected promise using `await expect(handler(error)).rejects.toBe(error)`
+    - **Property 4: 401 handling always rejects the promise**
+    - **Validates: Requirements 4.3**
+
+  - [ ]* 2.6 Write unit tests — example-based cases for the interceptor
+    - File: `novaRewards/frontend/__tests__/api.interceptor.test.js`
+    - Example A: assert `api.interceptors.response.handlers` has exactly one entry after import — covers Requirements 1.1, 3.1, 3.2
+    - Example B: create an error with no `response` property, pass to error handler, assert `Router.push` not called and promise rejects — covers Requirement 4.2
+    - _Requirements: 1.1, 3.1, 3.2, 4.2_
+
+- [ ] 3. Checkpoint — ensure all interceptor tests pass
+  - Ensure all tests pass, ask the user if questions arise.
+
+- [ ] 4. Create `novaRewards/frontend/pages/reauth.js`
+  - [ ] 4.1 Implement the reauth page component
+    - Create a default-exported React component with no props and no API calls
+    - Render a heading "Session Expired"
+    - Render a short explanatory paragraph stating the API key is invalid or has expired
+    - Render a link (`<a href="/merchant">`) with text "Return to Merchant Portal"
+    - _Requirements: 2.1, 2.2, 2.3_
+
+  - [ ]* 4.2 Write unit tests for the reauth page
+    - File: `novaRewards/frontend/__tests__/ReauthPage.test.js`
+    - Render `<ReauthPage />` with no props
+    - Assert the explanatory message is present in the document
+    - Assert a link pointing to `/merchant` exists
+    - Example C from design testing strategy
+    - _Requirements: 2.1, 2.2, 2.3_
+
+- [ ] 5. Final checkpoint — ensure all tests pass
+  - Ensure all tests pass, ask the user if questions arise.


### PR DESCRIPTION
feat: add API 401 interceptor spec

Adds the full spec for automatically handling 401 (Unauthorized) responses from the backend.

What this covers:

Response interceptor on the central axios instance in api.js that catches 401s and redirects to /reauth
New /reauth page with a clear message and a link back to the merchant portal
Non-401 errors and network errors continue propagating normally to existing catch blocks
Promise always rejects on 401 so awaiting callers don't hang
Files added:

requirements.md — 4 requirements with user stories and acceptance criteria
design.md — architecture diagrams, component design, correctness properties, and testing strategy (fast-check PBT + Jest unit tests)
tasks.md — implementation plan broken into actionable tasks
Testing approach:

4 property-based tests via fast-check covering: 2xx passthrough, 401 redirect, non-401 re-throw, promise rejection
Unit tests for interceptor registration, network error passthrough, and the reauth page render

Closes #113