### PR TITLE
feat(database): add --rollback flag to migrate.js

### DIFF
--- a/novaRewards/database/migrate.js
+++ b/novaRewards/database/migrate.js
@@ -25,7 +25,32 @@ async function migrate() {
   }
 }
 
-migrate().catch((err) => {
-  console.error('Migration failed:', err.message);
+async function rollback() {
+  const files = fs.readdirSync(__dirname)
+    .filter(f => f.endsWith('.sql'))
+    .sort()
+    .reverse();
+
+  // Derive table names from filenames: e.g. "001_create_merchants.sql" -> "merchants"
+  const tables = files.map(f => f.replace(/^\d+_create_/, '').replace(/\.sql$/, ''));
+
+  const client = await pool.connect();
+  try {
+    for (const table of tables) {
+      console.log(`Dropping table: ${table}`);
+      await client.query(`DROP TABLE IF EXISTS ${table} CASCADE`);
+      console.log(`  Done.`);
+    }
+    console.log('Rollback complete.');
+  } finally {
+    client.release();
+    await pool.end();
+  }
+}
+
+const isRollback = process.argv.includes('--rollback');
+
+(isRollback ? rollback() : migrate()).catch((err) => {
+  console.error(`${isRollback ? 'Rollback' : 'Migration'} failed:`, err.message);
   process.exit(1);
 });

--- a/novaRewards/package.json
+++ b/novaRewards/package.json
@@ -12,6 +12,7 @@
     "test": "npm test -w backend",
     "setup:new": "node scripts/setup.js",
     "setup": "node scripts/setup.js --use-env",
-    "migrate": "node database/migrate.js"
+    "migrate": "node database/migrate.js",
+    "migrate:rollback": "node database/migrate.js --rollback"
   }
 }


### PR DESCRIPTION

### Summary

Extends novaRewards/database/migrate.js with a --rollback flag that drops all tables in 
reverse migration order. Useful for resetting the local database during development without
manually dropping tables.

### What it does

- Reads the same .sql migration files, sorts them in reverse order, and derives the table 
name from each filename (e.g. 004_create_transactions.sql → transactions)
- Drops each table with DROP TABLE IF EXISTS ... CASCADE to handle foreign key dependencies
- Reverse order ensures dependent tables are dropped before their parents: transactions → 
campaigns → users → merchants

### Usage

bash
# From novaRewards/
npm run migrate:rollback

# Or directly
node database/migrate.js --rollback


Running npm run migrate afterwards re-applies all migrations from scratch.

### Changes

- novaRewards/database/migrate.js — added rollback() function and --rollback flag handling
- novaRewards/package.json — added migrate:rollback npm script

closes #119 