### PR TITLE
fix(database): add NOT NULL to created_at on all tables

### DIFF
--- a/novaRewards/database/001_create_merchants.sql
+++ b/novaRewards/database/001_create_merchants.sql
@@ -7,5 +7,5 @@ CREATE TABLE IF NOT EXISTS merchants (
   wallet_address    VARCHAR(56)  NOT NULL UNIQUE,
   business_category VARCHAR(100),
   api_key           VARCHAR(64)  NOT NULL UNIQUE,
-  created_at        TIMESTAMPTZ  DEFAULT NOW()
+  created_at        TIMESTAMPTZ  NOT NULL DEFAULT NOW()
 );

--- a/novaRewards/database/002_create_users.sql
+++ b/novaRewards/database/002_create_users.sql
@@ -4,5 +4,5 @@
 CREATE TABLE IF NOT EXISTS users (
   id             SERIAL PRIMARY KEY,
   wallet_address VARCHAR(56) NOT NULL UNIQUE,
-  created_at     TIMESTAMPTZ DEFAULT NOW()
+  created_at     TIMESTAMPTZ NOT NULL DEFAULT NOW()
 );

--- a/novaRewards/database/003_create_campaigns.sql
+++ b/novaRewards/database/003_create_campaigns.sql
@@ -9,7 +9,7 @@ CREATE TABLE IF NOT EXISTS campaigns (
   start_date  DATE        NOT NULL,
   end_date    DATE        NOT NULL CHECK (end_date > start_date),
   is_active   BOOLEAN     DEFAULT TRUE,
-  created_at  TIMESTAMPTZ DEFAULT NOW()
+  created_at  TIMESTAMPTZ NOT NULL DEFAULT NOW()
 );
 
 CREATE INDEX IF NOT EXISTS idx_campaigns_merchant_id ON campaigns (merchant_id);

--- a/novaRewards/database/004_create_transactions.sql
+++ b/novaRewards/database/004_create_transactions.sql
@@ -11,7 +11,7 @@ CREATE TABLE IF NOT EXISTS transactions (
   merchant_id    INTEGER       NOT NULL REFERENCES merchants(id),
   campaign_id    INTEGER       REFERENCES campaigns(id),
   stellar_ledger INTEGER,
-  created_at     TIMESTAMPTZ   DEFAULT NOW()
+  created_at     TIMESTAMPTZ   NOT NULL DEFAULT NOW()
 );
 
 -- B-tree indexes on wallet columns to avoid full table scans when querying by address


### PR DESCRIPTION
### Summary

All four SQL migration files defined created_at as TIMESTAMPTZ DEFAULT NOW() without a 
NOT NULL constraint, allowing the column to be explicitly set to NULL. This fixes that 
across every table.

### Changes

| File | Before | After |
|---|---|---|
| 001_create_merchants.sql | TIMESTAMPTZ DEFAULT NOW() | TIMESTAMPTZ NOT NULL DEFAULT NOW()
|
| 002_create_users.sql | TIMESTAMPTZ DEFAULT NOW() | TIMESTAMPTZ NOT NULL DEFAULT NOW() |
| 003_create_campaigns.sql | TIMESTAMPTZ DEFAULT NOW() | TIMESTAMPTZ NOT NULL DEFAULT NOW()
|
| 004_create_transactions.sql | TIMESTAMPTZ DEFAULT NOW() | 
TIMESTAMPTZ NOT NULL DEFAULT NOW() |

closes #120 