### PR TITLE
feat(#206): Soroban contract upgradability pattern (upgrade + migrate)

### DIFF
--- a/contracts/Cargo.toml
+++ b/contracts/Cargo.toml
@@ -1,0 +1,13 @@
+[workspace]
+resolver = "2"
+members = ["nova-rewards"]
+
+[profile.release]
+opt-level = "z"
+overflow-checks = true
+debug = 0
+strip = "symbols"
+debug-assertions = false
+panic = "abort"
+codegen-units = 1
+lto = true

--- a/contracts/nova-rewards/Cargo.toml
+++ b/contracts/nova-rewards/Cargo.toml
@@ -1,0 +1,16 @@
+[package]
+name = "nova-rewards"
+version = "1.0.0"
+edition = "2021"
+
+[lib]
+crate-type = ["cdylib"]
+
+[dependencies]
+soroban-sdk = { version = "21.0.0", features = [] }
+
+[dev-dependencies]
+soroban-sdk = { version = "21.0.0", features = ["testutils"] }
+
+[features]
+testutils = ["soroban-sdk/testutils"]

--- a/contracts/nova-rewards/src/lib.rs
+++ b/contracts/nova-rewards/src/lib.rs
@@ -1,0 +1,126 @@
+#![no_std]
+
+use soroban_sdk::{
+    contract, contractimpl, contracttype, symbol_short,
+    Address, BytesN, Env,
+};
+
+// ---------------------------------------------------------------------------
+// Storage keys
+// ---------------------------------------------------------------------------
+
+#[contracttype]
+pub enum DataKey {
+    Admin,
+    Balance(Address),
+    MigratedVersion,
+}
+
+// Current code version — bump this with every upgrade that needs a migration.
+const CONTRACT_VERSION: u32 = 1;
+
+// ---------------------------------------------------------------------------
+// Contract
+// ---------------------------------------------------------------------------
+
+#[contract]
+pub struct NovaRewardsContract;
+
+#[contractimpl]
+impl NovaRewardsContract {
+    // -----------------------------------------------------------------------
+    // Initialisation
+    // -----------------------------------------------------------------------
+
+    /// Must be called once after first deployment to set the admin.
+    pub fn initialize(env: Env, admin: Address) {
+        if env.storage().instance().has(&DataKey::Admin) {
+            panic!("already initialized");
+        }
+        env.storage().instance().set(&DataKey::Admin, &admin);
+        env.storage().instance().set(&DataKey::MigratedVersion, &0u32);
+    }
+
+    // -----------------------------------------------------------------------
+    // Upgrade (Issue #206)
+    // -----------------------------------------------------------------------
+
+    /// Replaces the contract WASM with `new_wasm_hash`.
+    /// Only the admin may call this.
+    /// Emits: topics=(upgrade, old_hash, new_hash), data=migration_version
+    pub fn upgrade(env: Env, new_wasm_hash: BytesN<32>) {
+        let admin: Address = env
+            .storage()
+            .instance()
+            .get(&DataKey::Admin)
+            .expect("not initialized");
+        admin.require_auth();
+
+        let old_wasm_hash = env.current_contract_address();
+        let migration_version: u32 = env
+            .storage()
+            .instance()
+            .get(&DataKey::MigratedVersion)
+            .unwrap_or(0);
+
+        env.deployer()
+            .update_current_contract_wasm(new_wasm_hash.clone());
+
+        env.events().publish(
+            (symbol_short!("upgrade"), old_wasm_hash, new_wasm_hash),
+            migration_version,
+        );
+    }
+
+    /// Runs data migrations for the current code version.
+    /// Safe to call multiple times — only executes once per version bump.
+    pub fn migrate(env: Env) {
+        let admin: Address = env
+            .storage()
+            .instance()
+            .get(&DataKey::Admin)
+            .expect("not initialized");
+        admin.require_auth();
+
+        let stored_version: u32 = env
+            .storage()
+            .instance()
+            .get(&DataKey::MigratedVersion)
+            .unwrap_or(0);
+
+        if CONTRACT_VERSION <= stored_version {
+            panic!("migration already applied");
+        }
+
+        // --- place version-specific migration logic here ---
+        // e.g. backfill new fields, rename keys, etc.
+
+        env.storage()
+            .instance()
+            .set(&DataKey::MigratedVersion, &CONTRACT_VERSION);
+    }
+
+    // -----------------------------------------------------------------------
+    // State helpers (used by tests to verify state survives upgrade)
+    // -----------------------------------------------------------------------
+
+    pub fn set_balance(env: Env, user: Address, amount: i128) {
+        env.storage()
+            .instance()
+            .set(&DataKey::Balance(user), &amount);
+    }
+
+    pub fn get_balance(env: Env, user: Address) -> i128 {
+        env.storage()
+            .instance()
+            .get(&DataKey::Balance(user))
+            .unwrap_or(0)
+    }
+
+    pub fn get_migrated_version(env: Env) -> u32 {
+        env.storage()
+            .instance()
+            .get(&DataKey::MigratedVersion)
+            .unwrap_or(0)
+    }
+}

--- a/contracts/nova-rewards/tests/upgrade.rs
+++ b/contracts/nova-rewards/tests/upgrade.rs
@@ -1,0 +1,104 @@
+#![cfg(test)]
+
+use soroban_sdk::{
+    testutils::{Address as _, AuthorizedFunction, AuthorizedInvocation, Events},
+    Address, BytesN, Env, IntoVal, Symbol,
+};
+
+use nova_rewards::{NovaRewardsContract, NovaRewardsContractClient};
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+fn deploy(env: &Env) -> (NovaRewardsContractClient, Address) {
+    let admin = Address::generate(env);
+    let contract_id = env.register_contract(None, NovaRewardsContract);
+    let client = NovaRewardsContractClient::new(env, &contract_id);
+    client.initialize(&admin);
+    (client, admin)
+}
+
+/// Returns a dummy 32-byte hash (simulates a new WASM hash).
+fn dummy_hash(env: &Env, seed: u8) -> BytesN<32> {
+    BytesN::from_array(env, &[seed; 32])
+}
+
+// ---------------------------------------------------------------------------
+// Tests
+// ---------------------------------------------------------------------------
+
+#[test]
+fn test_upgrade_preserves_state_and_emits_event() {
+    let env = Env::default();
+    env.mock_all_auths();
+
+    let (client, admin) = deploy(&env);
+
+    // Store dummy balance in V1
+    let user = Address::generate(&env);
+    client.set_balance(&user, &500_i128);
+    assert_eq!(client.get_balance(&user), 500_i128);
+
+    // Perform upgrade with a mock new WASM hash
+    let new_hash = dummy_hash(&env, 0xAB);
+    client.upgrade(&new_hash);
+
+    // State must still be intact after upgrade
+    assert_eq!(client.get_balance(&user), 500_i128);
+
+    // Verify the "upgrade" event was emitted
+    let events = env.events().all();
+    let upgrade_event = events
+        .iter()
+        .find(|(_, topics, _)| {
+            // topics is a Vec<Val>; first topic is the symbol "upgrade"
+            if let Some(first) = topics.first() {
+                let sym: Result<Symbol, _> = first.clone().try_into_val(&env);
+                sym.map(|s| s == Symbol::new(&env, "upgrade"))
+                    .unwrap_or(false)
+            } else {
+                false
+            }
+        });
+    assert!(upgrade_event.is_some(), "upgrade event not emitted");
+}
+
+#[test]
+fn test_migrate_increments_version_and_is_idempotent() {
+    let env = Env::default();
+    env.mock_all_auths();
+
+    let (client, _admin) = deploy(&env);
+
+    assert_eq!(client.get_migrated_version(), 0);
+
+    client.migrate();
+
+    assert_eq!(client.get_migrated_version(), 1);
+}
+
+#[test]
+#[should_panic(expected = "migration already applied")]
+fn test_migrate_cannot_be_called_twice_for_same_version() {
+    let env = Env::default();
+    env.mock_all_auths();
+
+    let (client, _admin) = deploy(&env);
+
+    client.migrate();
+    client.migrate(); // must panic
+}
+
+#[test]
+#[should_panic]
+fn test_upgrade_requires_admin_auth() {
+    let env = Env::default();
+    // Do NOT mock auths — non-admin call must fail
+
+    let (client, _admin) = deploy(&env);
+    let new_hash = dummy_hash(&env, 0x01);
+
+    // Calling without auth should panic
+    client.upgrade(&new_hash);
+}

--- a/docs/upgrade-guide.md
+++ b/docs/upgrade-guide.md
@@ -1,0 +1,99 @@
+# Nova Rewards Contract — Upgrade Guide (Issue #206)
+
+## Overview
+
+The `nova-rewards` Soroban contract supports in-place WASM upgrades via
+`env.deployer().update_current_contract_wasm()`. All instance storage
+(balances, admin, migration version) persists across upgrades.
+
+---
+
+## Prerequisites
+
+```bash
+# Install Rust + wasm32 target
+curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh
+rustup target add wasm32-unknown-unknown
+
+# Install Soroban CLI
+cargo install --locked soroban-cli
+```
+
+---
+
+## Step 1 — Build the new WASM
+
+```bash
+cd contracts
+cargo build --release --target wasm32-unknown-unknown
+
+# Optimised binary is at:
+# target/wasm32-unknown-unknown/release/nova_rewards.wasm
+```
+
+---
+
+## Step 2 — Get the WASM hash
+
+```bash
+soroban contract install \
+  --network testnet \
+  --source <ADMIN_SECRET_KEY> \
+  --wasm target/wasm32-unknown-unknown/release/nova_rewards.wasm
+```
+
+This prints the 64-character hex WASM hash, e.g.:
+```
+abc123...def456
+```
+
+---
+
+## Step 3 — Trigger the upgrade
+
+```bash
+soroban contract invoke \
+  --network testnet \
+  --source <ADMIN_SECRET_KEY> \
+  --id <CONTRACT_ID> \
+  -- \
+  upgrade \
+  --new_wasm_hash <WASM_HASH_FROM_STEP_2>
+```
+
+The contract emits an `upgrade` event on success.
+
+---
+
+## Step 4 — Run the migration
+
+Call `migrate` immediately after upgrading. This is idempotent — calling it
+again for the same version is a no-op (panics with "migration already applied").
+
+```bash
+soroban contract invoke \
+  --network testnet \
+  --source <ADMIN_SECRET_KEY> \
+  --id <CONTRACT_ID> \
+  -- \
+  migrate
+```
+
+---
+
+## Version tracking
+
+| Key | Storage | Description |
+|-----|---------|-------------|
+| `MigratedVersion` | `instance()` | Last successfully applied migration version |
+
+`CONTRACT_VERSION` in `src/lib.rs` must be bumped for each release that
+requires a migration. The `migrate` function is a no-op if
+`CONTRACT_VERSION <= stored MigratedVersion`.
+
+---
+
+## Security
+
+- Only the `admin` address set during `initialize` may call `upgrade` or `migrate`.
+- Attempting either without admin auth panics immediately.


### PR DESCRIPTION

## Summary
Closes #206 

Implements the upgradability pattern for the `nova-rewards` Soroban contract using Soroban's native `update_current_contract_wasm` mechanism, with a versioned migration system that ensures state is never lost across WASM swaps.

## New Files

| File | Purpose |
|------|---------|
| `contracts/Cargo.toml` | Workspace root for all Soroban contracts |
| `contracts/nova-rewards/Cargo.toml` | Contract crate manifest (soroban-sdk 21) |
| `contracts/nova-rewards/src/lib.rs` | Contract implementation |
| `contracts/nova-rewards/tests/upgrade.rs` | Upgrade test suite |
| `docs/upgrade-guide.md` | Operator runbook |

## Contract Functions

### `initialize(env, admin)`
One-time setup. Sets the admin address and `MigratedVersion = 0` in instance storage.

### `upgrade(env, new_wasm_hash)`
- Requires `admin.require_auth()`
- Calls `env.deployer().update_current_contract_wasm(new_wasm_hash)`
- Emits event: `topics = (Symbol("upgrade"), old_contract_address, new_wasm_hash)`, `data = migration_version`

### `migrate(env)`
- Requires `admin.require_auth()`
- Checks `CONTRACT_VERSION > stored MigratedVersion` — panics with `"migration already applied"` if already run for this version
- Executes migration logic, then writes `MigratedVersion = CONTRACT_VERSION` to `instance()` storage
- Safe to call immediately after every upgrade; no-op if version hasn't changed

## Storage Strategy
All versioning metadata uses `env.storage().instance()` — persists across WASM swaps and is tied to the contract instance lifetime.

## Tests (`tests/upgrade.rs`)
| Test | Assertion |
|------|-----------|
| `test_upgrade_preserves_state_and_emits_event` | Dummy balance set pre-upgrade is readable post-upgrade; `upgrade` event is emitted |
| `test_migrate_increments_version_and_is_idempotent` | `MigratedVersion` goes from 0 → 1 after `migrate()` |
| `test_migrate_cannot_be_called_twice_for_same_version` | Second `migrate()` call panics with `"migration already applied"` |
| `test_upgrade_requires_admin_auth` | Calling `upgrade` without mocked auth panics |

## Build & Run Tests
bash
# Requires: rustup target add wasm32-unknown-unknown
cd contracts
cargo test --features testutils
cargo build --release --target wasm32-unknown-unknown

See `docs/upgrade-guide.md` for the full operator runbook including `soroban contract invoke` commands.

