### PR TITLE
feat: leaderboard aggregation, admin dashboard API, rate limiter, daily login bonus cron (#185 #186 #187 #189)

### DIFF
--- a/novaRewards/.env.example
+++ b/novaRewards/.env.example
@@ -19,6 +19,15 @@ POSTGRES_PASSWORD=changeme
 POSTGRES_DB=nova_rewards
 DATABASE_URL=postgresql://nova:changeme@localhost:5432/nova_rewards
 
+# Redis
+REDIS_URL=redis://localhost:6379
+
+# Rate Limiting — comma-separated IPs exempt from rate limits (health-check / monitoring)
+RATE_LIMIT_WHITELIST=127.0.0.1,::1
+
+# Daily Login Bonus
+DAILY_BONUS_POINTS=10
+
 # Backend Server
 PORT=3001
 NODE_ENV=development

--- a/novaRewards/backend/db/adminRepository.js
+++ b/novaRewards/backend/db/adminRepository.js
@@ -1,0 +1,104 @@
+const { query } = require('./index');
+
+/**
+ * Aggregate platform stats for the admin dashboard.
+ * Requirements: #186
+ */
+async function getStats() {
+  const { rows } = await query(`
+    SELECT
+      (SELECT COUNT(*) FROM users WHERE is_deleted = FALSE)                          AS total_users,
+      (SELECT COALESCE(SUM(points), 0) FROM point_transactions WHERE type = 'earned') AS total_points_issued,
+      (SELECT COALESCE(SUM(points), 0) FROM point_transactions WHERE type = 'redeemed') AS total_redemptions,
+      (SELECT COUNT(*) FROM rewards WHERE is_active = TRUE AND is_deleted = FALSE)   AS active_rewards
+  `);
+  return rows[0];
+}
+
+/**
+ * Paginated user list with optional search by email or name.
+ * @param {{ search?: string, page: number, limit: number }} opts
+ */
+async function listUsers({ search, page, limit }) {
+  const offset = (page - 1) * limit;
+  const params = [`%${search || ''}%`, limit, offset];
+
+  const { rows } = await query(
+    `SELECT id, wallet_address, email, first_name, last_name, role, created_at
+     FROM users
+     WHERE is_deleted = FALSE
+       AND (
+         email      ILIKE $1 OR
+         first_name ILIKE $1 OR
+         last_name  ILIKE $1
+       )
+     ORDER BY created_at DESC
+     LIMIT $2 OFFSET $3`,
+    params
+  );
+
+  const { rows: countRows } = await query(
+    `SELECT COUNT(*) AS total FROM users
+     WHERE is_deleted = FALSE
+       AND (email ILIKE $1 OR first_name ILIKE $1 OR last_name ILIKE $1)`,
+    [`%${search || ''}%`]
+  );
+
+  return { users: rows, total: parseInt(countRows[0].total) };
+}
+
+/** Create a new reward. */
+async function createReward({ name, cost, stock, isActive = true }) {
+  const { rows } = await query(
+    `INSERT INTO rewards (name, cost, stock, is_active)
+     VALUES ($1, $2, $3, $4)
+     RETURNING *`,
+    [name, cost, stock ?? 0, isActive]
+  );
+  return rows[0];
+}
+
+/** Update allowed reward fields. */
+async function updateReward(id, { name, cost, stock, isActive }) {
+  const fields = [];
+  const values = [];
+  let i = 1;
+
+  if (name      !== undefined) { fields.push(`name = $${i++}`);      values.push(name); }
+  if (cost      !== undefined) { fields.push(`cost = $${i++}`);      values.push(cost); }
+  if (stock     !== undefined) { fields.push(`stock = $${i++}`);     values.push(stock); }
+  if (isActive  !== undefined) { fields.push(`is_active = $${i++}`); values.push(isActive); }
+
+  if (!fields.length) return getRewardById(id);
+
+  fields.push(`updated_at = NOW()`);
+  values.push(id);
+
+  const { rows } = await query(
+    `UPDATE rewards SET ${fields.join(', ')}
+     WHERE id = $${i} AND is_deleted = FALSE
+     RETURNING *`,
+    values
+  );
+  return rows[0] || null;
+}
+
+/** Soft-delete a reward. */
+async function deleteReward(id) {
+  const { rowCount } = await query(
+    `UPDATE rewards SET is_deleted = TRUE, updated_at = NOW()
+     WHERE id = $1 AND is_deleted = FALSE`,
+    [id]
+  );
+  return rowCount > 0;
+}
+
+async function getRewardById(id) {
+  const { rows } = await query(
+    'SELECT * FROM rewards WHERE id = $1 AND is_deleted = FALSE',
+    [id]
+  );
+  return rows[0] || null;
+}
+
+module.exports = { getStats, listUsers, createReward, updateReward, deleteReward, getRewardById };

--- a/novaRewards/backend/db/leaderboardRepository.js
+++ b/novaRewards/backend/db/leaderboardRepository.js
@@ -1,0 +1,47 @@
+const { query } = require('./index');
+
+const WEEKLY_CUTOFF = `NOW() - INTERVAL '7 days'`;
+
+/**
+ * Returns top N users by total earned points for the given period,
+ * plus the requesting user's rank if they fall outside the top N.
+ *
+ * @param {'weekly'|'alltime'} period
+ * @param {number} limit
+ * @param {number|null} currentUserId
+ * @returns {Promise<{ rankings: object[], currentUser: object|null }>}
+ */
+async function getLeaderboard(period, limit, currentUserId) {
+  const dateFilter = period === 'weekly' ? `AND created_at >= ${WEEKLY_CUTOFF}` : '';
+
+  const rankSql = `
+    SELECT
+      user_id,
+      SUM(points) AS total_points,
+      RANK() OVER (ORDER BY SUM(points) DESC) AS rank
+    FROM point_transactions
+    WHERE type = 'earned' ${dateFilter}
+    GROUP BY user_id
+  `;
+
+  const { rows: rankings } = await query(
+    `SELECT * FROM (${rankSql}) ranked ORDER BY rank LIMIT $1`,
+    [limit]
+  );
+
+  let currentUser = null;
+  if (currentUserId) {
+    const inTop = rankings.some((r) => r.user_id === currentUserId);
+    if (!inTop) {
+      const { rows } = await query(
+        `SELECT * FROM (${rankSql}) ranked WHERE user_id = $1`,
+        [currentUserId]
+      );
+      currentUser = rows[0] || null;
+    }
+  }
+
+  return { rankings, currentUser };
+}
+
+module.exports = { getLeaderboard };

--- a/novaRewards/backend/db/transactionRepository.js
+++ b/novaRewards/backend/db/transactionRepository.js
@@ -1,4 +1,5 @@
 const { query } = require('./index');
+const { client: redisClient } = require('../lib/redis');
 
 /**
  * Records a completed Stellar transaction in the database.
@@ -34,6 +35,15 @@ async function recordTransaction({
      RETURNING *`,
     [txHash, txType, amount, fromWallet, toWallet, merchantId, nullableCampaignId, stellarLedger]
   );
+
+  // Invalidate leaderboard cache when a reward is earned (distribution maps to 'earned')
+  if (txType === 'distribution') {
+    await Promise.all([
+      redisClient.del('leaderboard:weekly'),
+      redisClient.del('leaderboard:alltime'),
+    ]).catch((err) => console.error('[leaderboard] cache invalidation failed', err));
+  }
+
   return result.rows[0];
 }
 

--- a/novaRewards/backend/jobs/dailyLoginBonus.js
+++ b/novaRewards/backend/jobs/dailyLoginBonus.js
@@ -1,0 +1,77 @@
+const { query } = require('../db/index');
+
+/**
+ * Finds users who logged in during the previous calendar day (UTC)
+ * and have not yet received today's bonus, then credits each with
+ * DAILY_BONUS_POINTS as a 'bonus' PointTransaction.
+ *
+ * Exported separately from the scheduler so it can be unit-tested.
+ *
+ * @param {Date} [now=new Date()] - injectable for testing
+ * @returns {Promise<{ credited: number, failed: number }>}
+ */
+async function runDailyLoginBonus(now = new Date()) {
+  const bonusPoints = Number(process.env.DAILY_BONUS_POINTS) || 10;
+
+  // Midnight UTC today and yesterday
+  const todayUTC = new Date(Date.UTC(now.getUTCFullYear(), now.getUTCMonth(), now.getUTCDate()));
+  const yesterdayUTC = new Date(todayUTC.getTime() - 86_400_000);
+
+  // Users who logged in yesterday and haven't received today's bonus yet
+  const { rows: users } = await query(
+    `SELECT id FROM users
+     WHERE is_deleted = FALSE
+       AND last_login_at >= $1
+       AND last_login_at <  $2
+       AND (daily_bonus_granted_at IS NULL OR daily_bonus_granted_at < $2)`,
+    [yesterdayUTC, todayUTC]
+  );
+
+  let credited = 0;
+  let failed = 0;
+
+  for (const user of users) {
+    try {
+      await query(
+        `INSERT INTO point_transactions (user_id, points, type) VALUES ($1, $2, 'bonus')`,
+        [user.id, bonusPoints]
+      );
+      await query(
+        `UPDATE users SET daily_bonus_granted_at = NOW() WHERE id = $1`,
+        [user.id]
+      );
+      credited++;
+    } catch (err) {
+      console.error(`[dailyLoginBonus] failed for user ${user.id}:`, err.message);
+      failed++;
+    }
+  }
+
+  console.log(`[dailyLoginBonus] credited=${credited} failed=${failed}`);
+  return { credited, failed };
+}
+
+/**
+ * Schedules runDailyLoginBonus to fire at midnight UTC every day.
+ * Uses a simple setTimeout loop to avoid adding a cron dependency.
+ */
+function startDailyLoginBonusJob() {
+  function scheduleNext() {
+    const now = new Date();
+    const nextMidnightUTC = new Date(
+      Date.UTC(now.getUTCFullYear(), now.getUTCMonth(), now.getUTCDate() + 1)
+    );
+    const msUntilMidnight = nextMidnightUTC.getTime() - now.getTime();
+
+    setTimeout(async () => {
+      await runDailyLoginBonus();
+      scheduleNext(); // reschedule for the following midnight
+    }, msUntilMidnight);
+
+    console.log(`[dailyLoginBonus] next run in ${Math.round(msUntilMidnight / 1000)}s`);
+  }
+
+  scheduleNext();
+}
+
+module.exports = { runDailyLoginBonus, startDailyLoginBonusJob };

--- a/novaRewards/backend/jobs/leaderboardCacheWarmer.js
+++ b/novaRewards/backend/jobs/leaderboardCacheWarmer.js
@@ -1,0 +1,31 @@
+const { getLeaderboard } = require('../db/leaderboardRepository');
+const { client } = require('../lib/redis');
+
+const CACHE_TTL = 300;
+const PERIODS = ['weekly', 'alltime'];
+
+/**
+ * Pre-warms leaderboard cache for all periods.
+ * Called by cron every 5 minutes and on startup.
+ */
+async function warmLeaderboardCache() {
+  for (const period of PERIODS) {
+    try {
+      const { rankings } = await getLeaderboard(period, 50, null);
+      await client.setEx(`leaderboard:${period}`, CACHE_TTL, JSON.stringify(rankings));
+      console.log(`[leaderboard] cache warmed for period=${period}`);
+    } catch (err) {
+      console.error(`[leaderboard] cache warm failed for period=${period}`, err);
+    }
+  }
+}
+
+/**
+ * Starts the cron job that pre-warms the leaderboard cache every 5 minutes.
+ */
+function startLeaderboardCacheWarmer() {
+  warmLeaderboardCache(); // warm immediately on startup
+  setInterval(warmLeaderboardCache, CACHE_TTL * 1000);
+}
+
+module.exports = { startLeaderboardCacheWarmer, warmLeaderboardCache };

--- a/novaRewards/backend/lib/redis.js
+++ b/novaRewards/backend/lib/redis.js
@@ -1,0 +1,12 @@
+const { createClient } = require('redis');
+
+const client = createClient({ url: process.env.REDIS_URL });
+
+client.on('error', (err) => console.error('[Redis]', err));
+
+// Connect lazily — server.js calls this once at startup
+async function connectRedis() {
+  if (!client.isOpen) await client.connect();
+}
+
+module.exports = { client, connectRedis };

--- a/novaRewards/backend/middleware/rateLimiter.js
+++ b/novaRewards/backend/middleware/rateLimiter.js
@@ -1,0 +1,53 @@
+const rateLimit = require('express-rate-limit');
+const { RedisStore } = require('rate-limit-redis');
+const { client: redisClient } = require('../lib/redis');
+
+// IPs exempt from all rate limiting (health-check / monitoring)
+const WHITELIST = (process.env.RATE_LIMIT_WHITELIST || '')
+  .split(',')
+  .map((ip) => ip.trim())
+  .filter(Boolean);
+
+function skip(req) {
+  return WHITELIST.includes(req.ip);
+}
+
+function makeStore(prefix) {
+  return new RedisStore({
+    sendCommand: (...args) => redisClient.sendCommand(args),
+    prefix,
+  });
+}
+
+function onLimitReached(req, res) {
+  res.setHeader('Retry-After', '60');
+  res.status(429).json({
+    success: false,
+    error: 'too_many_requests',
+    message: 'Rate limit exceeded. Please retry after 60 seconds.',
+  });
+}
+
+/** Default limiter: 100 req / 60 s — applied globally */
+const globalLimiter = rateLimit({
+  windowMs: 60_000,
+  max: 100,
+  standardHeaders: true,
+  legacyHeaders: false,
+  skip,
+  store: makeStore('rl:global:'),
+  handler: onLimitReached,
+});
+
+/** Strict limiter: 5 req / 60 s — applied to auth endpoints */
+const authLimiter = rateLimit({
+  windowMs: 60_000,
+  max: 5,
+  standardHeaders: true,
+  legacyHeaders: false,
+  skip,
+  store: makeStore('rl:auth:'),
+  handler: onLimitReached,
+});
+
+module.exports = { globalLimiter, authLimiter };

--- a/novaRewards/backend/middleware/validateEnv.js
+++ b/novaRewards/backend/middleware/validateEnv.js
@@ -10,6 +10,7 @@ const REQUIRED_ENV_VARS = [
   'STELLAR_NETWORK',
   'HORIZON_URL',
   'DATABASE_URL',
+  'REDIS_URL',
 ];
 
 /**

--- a/novaRewards/backend/package.json
+++ b/novaRewards/backend/package.json
@@ -15,6 +15,8 @@
     "express": "^4.19.2",
     "express-rate-limit": "^8.3.1",
     "pg": "^8.12.0",
+    "rate-limit-redis": "^4.2.0",
+    "redis": "^4.7.0",
     "stellar-sdk": "^12.3.0",
     "uuid": "^10.0.0"
   },

--- a/novaRewards/backend/routes/admin.js
+++ b/novaRewards/backend/routes/admin.js
@@ -1,0 +1,94 @@
+const router = require('express').Router();
+const { authenticateUser, requireAdmin } = require('../middleware/authenticateUser');
+const {
+  getStats, listUsers,
+  createReward, updateReward, deleteReward, getRewardById,
+} = require('../db/adminRepository');
+
+// All admin routes require a valid user token AND admin role
+router.use(authenticateUser, requireAdmin);
+
+/**
+ * GET /api/admin/stats
+ * Aggregate platform counts: users, points issued, redemptions, active rewards.
+ * Requirements: #186
+ */
+router.get('/stats', async (req, res, next) => {
+  try {
+    const stats = await getStats();
+    res.json({ success: true, data: stats });
+  } catch (err) {
+    next(err);
+  }
+});
+
+/**
+ * GET /api/admin/users?search=&page=1&limit=20
+ * Paginated user list, searchable by email or name.
+ * Requirements: #186
+ */
+router.get('/users', async (req, res, next) => {
+  try {
+    const page  = Math.max(1, parseInt(req.query.page)  || 1);
+    const limit = Math.min(100, parseInt(req.query.limit) || 20);
+    const { users, total } = await listUsers({ search: req.query.search, page, limit });
+    res.json({ success: true, data: { users, total, page, limit } });
+  } catch (err) {
+    next(err);
+  }
+});
+
+/**
+ * POST /api/admin/rewards
+ * Create a new reward entry.
+ * Requirements: #186
+ */
+router.post('/rewards', async (req, res, next) => {
+  try {
+    const { name, cost, stock, isActive } = req.body;
+    if (!name || cost == null) {
+      return res.status(400).json({ success: false, error: 'validation_error', message: 'name and cost are required' });
+    }
+    const reward = await createReward({ name, cost, stock, isActive });
+    res.status(201).json({ success: true, data: reward });
+  } catch (err) {
+    next(err);
+  }
+});
+
+/**
+ * PATCH /api/admin/rewards/:id
+ * Update reward details (name, cost, stock, isActive).
+ * Requirements: #186
+ */
+router.patch('/rewards/:id', async (req, res, next) => {
+  try {
+    const id = parseInt(req.params.id);
+    const reward = await updateReward(id, req.body);
+    if (!reward) {
+      return res.status(404).json({ success: false, error: 'not_found', message: 'Reward not found' });
+    }
+    res.json({ success: true, data: reward });
+  } catch (err) {
+    next(err);
+  }
+});
+
+/**
+ * DELETE /api/admin/rewards/:id
+ * Soft-delete a reward.
+ * Requirements: #186
+ */
+router.delete('/rewards/:id', async (req, res, next) => {
+  try {
+    const deleted = await deleteReward(parseInt(req.params.id));
+    if (!deleted) {
+      return res.status(404).json({ success: false, error: 'not_found', message: 'Reward not found' });
+    }
+    res.json({ success: true, message: 'Reward deleted' });
+  } catch (err) {
+    next(err);
+  }
+});
+
+module.exports = router;

--- a/novaRewards/backend/routes/leaderboard.js
+++ b/novaRewards/backend/routes/leaderboard.js
@@ -1,0 +1,53 @@
+const router = require('express').Router();
+const { getLeaderboard } = require('../db/leaderboardRepository');
+const { client } = require('../lib/redis');
+const { authenticateUser } = require('../middleware/authenticateUser');
+
+const CACHE_TTL = 300; // 5 minutes
+const VALID_PERIODS = ['weekly', 'alltime'];
+
+/**
+ * GET /api/leaderboard?period=weekly|alltime&limit=50
+ * Returns top-N users by earned points. Appends current user's rank if outside top N.
+ * Cache key: leaderboard:${period}  TTL: 5 min
+ * Requirements: #185
+ */
+router.get('/', authenticateUser, async (req, res, next) => {
+  try {
+    const period = VALID_PERIODS.includes(req.query.period) ? req.query.period : 'weekly';
+    const limit = Math.min(parseInt(req.query.limit) || 50, 100);
+    const cacheKey = `leaderboard:${period}`;
+
+    // Try cache first (rankings only — current-user rank is always live)
+    const cached = await client.get(cacheKey);
+    let rankings;
+    if (cached) {
+      rankings = JSON.parse(cached);
+    } else {
+      const result = await getLeaderboard(period, limit, null);
+      rankings = result.rankings;
+      await client.setEx(cacheKey, CACHE_TTL, JSON.stringify(rankings));
+    }
+
+    // Always resolve current user's rank live (personalised, not cacheable globally)
+    const inTop = rankings.some((r) => r.user_id === req.user.id);
+    let currentUser = null;
+    if (!inTop) {
+      const result = await getLeaderboard(period, limit, req.user.id);
+      currentUser = result.currentUser;
+    }
+
+    res.json({
+      success: true,
+      data: {
+        period,
+        rankings,
+        ...(currentUser && { currentUser }),
+      },
+    });
+  } catch (err) {
+    next(err);
+  }
+});
+
+module.exports = router;

--- a/novaRewards/backend/server.js
+++ b/novaRewards/backend/server.js
@@ -1,16 +1,16 @@
 require('dotenv').config();
 const { validateEnv } = require('./middleware/validateEnv');
 
-// Validate all required env vars before anything else — halts if any are missing.
-// This MUST run before requiring ./db/index because the Pool constructor reads
-// DATABASE_URL immediately at require-time.
 validateEnv();
 
-// Safe to require db now — DATABASE_URL is guaranteed to be present
 require('./db/index');
 
 const express = require('express');
 const cors = require('cors');
+const { connectRedis } = require('./lib/redis');
+const { startLeaderboardCacheWarmer } = require('./jobs/leaderboardCacheWarmer');
+const { startDailyLoginBonusJob } = require('./jobs/dailyLoginBonus');
+const { globalLimiter, authLimiter } = require('./middleware/rateLimiter');
 
 const app = express();
 
@@ -21,6 +21,11 @@ const corsOptions = process.env.NODE_ENV === 'production' && process.env.ALLOWED
 
 app.use(cors(corsOptions));
 app.use(express.json());
+
+// Rate limiting — global default, stricter on auth endpoints
+app.use(globalLimiter);
+app.use('/api/auth/login', authLimiter);
+app.use('/api/auth/forgot-password', authLimiter);
 
 // Health check
 app.get('/health', (req, res) => {
@@ -34,6 +39,8 @@ app.use('/api/rewards', require('./routes/rewards'));
 app.use('/api/transactions', require('./routes/transactions'));
 app.use('/api/trustline', require('./routes/trustline'));
 app.use('/api/users', require('./routes/users'));
+app.use('/api/leaderboard', require('./routes/leaderboard'));
+app.use('/api/admin', require('./routes/admin'));
 
 // Global error handler — returns consistent error envelope
 app.use((err, req, res, _next) => {
@@ -46,7 +53,10 @@ app.use((err, req, res, _next) => {
 });
 
 const PORT = process.env.PORT || 3001;
-app.listen(PORT, () => {
+app.listen(PORT, async () => {
+  await connectRedis();
+  startLeaderboardCacheWarmer();
+  startDailyLoginBonusJob();
   console.log(`NovaRewards backend running on port ${PORT}`);
 });
 

--- a/novaRewards/backend/tests/dailyLoginBonus.test.js
+++ b/novaRewards/backend/tests/dailyLoginBonus.test.js
@@ -1,0 +1,102 @@
+// Feature: Daily Login Bonus cron job
+// Validates: Requirements #189
+// Verifies correct cohort selection, point crediting, and double-grant prevention.
+
+jest.mock('../db/index', () => ({ query: jest.fn() }));
+
+const { query } = require('../db/index');
+const { runDailyLoginBonus } = require('../jobs/dailyLoginBonus');
+
+beforeEach(() => {
+  jest.clearAllMocks();
+  process.env.DAILY_BONUS_POINTS = '10';
+});
+
+// Fixed "now" = 2026-03-27T06:00:00Z  →  yesterday window: 2026-03-26T00:00Z – 2026-03-27T00:00Z
+const NOW = new Date('2026-03-27T06:00:00.000Z');
+const YESTERDAY_START = new Date('2026-03-26T00:00:00.000Z');
+const TODAY_START     = new Date('2026-03-27T00:00:00.000Z');
+
+describe('runDailyLoginBonus — cohort selection', () => {
+  test('queries users with last_login_at in the previous calendar day (UTC)', async () => {
+    query.mockResolvedValue({ rows: [] }); // no users → nothing to credit
+
+    await runDailyLoginBonus(NOW);
+
+    expect(query).toHaveBeenCalledTimes(1);
+    const [sql, params] = query.mock.calls[0];
+    expect(sql).toMatch(/last_login_at\s*>=\s*\$1/);
+    expect(sql).toMatch(/last_login_at\s*<\s*\$2/);
+    expect(params[0]).toEqual(YESTERDAY_START);
+    expect(params[1]).toEqual(TODAY_START);
+  });
+
+  test('excludes users whose daily_bonus_granted_at is already today', async () => {
+    query.mockResolvedValue({ rows: [] });
+
+    await runDailyLoginBonus(NOW);
+
+    const [sql] = query.mock.calls[0];
+    expect(sql).toMatch(/daily_bonus_granted_at/);
+  });
+});
+
+describe('runDailyLoginBonus — crediting', () => {
+  test('inserts a bonus PointTransaction and updates dailyBonusGrantedAt for each qualifying user', async () => {
+    // First call = SELECT users; subsequent calls = INSERT + UPDATE per user
+    query
+      .mockResolvedValueOnce({ rows: [{ id: 1 }, { id: 2 }] }) // cohort query
+      .mockResolvedValue({ rows: [] });                          // INSERT + UPDATE calls
+
+    const result = await runDailyLoginBonus(NOW);
+
+    expect(result.credited).toBe(2);
+    expect(result.failed).toBe(0);
+
+    // Each user gets an INSERT into point_transactions
+    const insertCalls = query.mock.calls.filter(([sql]) => sql.includes('INSERT INTO point_transactions'));
+    expect(insertCalls).toHaveLength(2);
+    insertCalls.forEach(([sql, params]) => {
+      expect(sql).toMatch(/type.*bonus|bonus.*type/i);
+      expect(params[1]).toBe(10); // DAILY_BONUS_POINTS
+    });
+
+    // Each user gets an UPDATE to daily_bonus_granted_at
+    const updateCalls = query.mock.calls.filter(([sql]) => sql.includes('UPDATE users SET daily_bonus_granted_at'));
+    expect(updateCalls).toHaveLength(2);
+  });
+
+  test('counts failures without throwing when a single user credit fails', async () => {
+    query
+      .mockResolvedValueOnce({ rows: [{ id: 10 }, { id: 11 }] })
+      .mockRejectedValueOnce(new Error('db error')) // user 10 INSERT fails
+      .mockResolvedValue({ rows: [] });              // user 11 succeeds
+
+    const result = await runDailyLoginBonus(NOW);
+
+    expect(result.credited).toBe(1);
+    expect(result.failed).toBe(1);
+  });
+
+  test('returns credited=0 when no users qualify', async () => {
+    query.mockResolvedValueOnce({ rows: [] });
+
+    const result = await runDailyLoginBonus(NOW);
+
+    expect(result.credited).toBe(0);
+    expect(result.failed).toBe(0);
+    expect(query).toHaveBeenCalledTimes(1); // only the SELECT
+  });
+
+  test('uses DAILY_BONUS_POINTS from env', async () => {
+    process.env.DAILY_BONUS_POINTS = '25';
+    query
+      .mockResolvedValueOnce({ rows: [{ id: 5 }] })
+      .mockResolvedValue({ rows: [] });
+
+    await runDailyLoginBonus(NOW);
+
+    const [, params] = query.mock.calls.find(([sql]) => sql.includes('INSERT INTO point_transactions'));
+    expect(params[1]).toBe(25);
+  });
+});

--- a/novaRewards/backend/tests/rateLimiter.test.js
+++ b/novaRewards/backend/tests/rateLimiter.test.js
@@ -1,0 +1,150 @@
+// Feature: Rate Limiter middleware
+// Validates: Requirements #187
+// Asserts 429 + Retry-After on (n+1)th request for both global and auth limiters.
+
+const request = require('supertest');
+const express = require('express');
+
+// ---------------------------------------------------------------------------
+// Build a self-contained test app — no Redis, no DB, no env deps.
+// We override the store with the in-memory default by NOT passing a store,
+// which is what express-rate-limit uses when no store is provided.
+// ---------------------------------------------------------------------------
+function buildApp({ globalMax, authMax }) {
+  const rateLimit = require('express-rate-limit');
+
+  const globalLimiter = rateLimit({
+    windowMs: 60_000,
+    max: globalMax,
+    standardHeaders: true,
+    legacyHeaders: false,
+    handler: (req, res) => {
+      res.setHeader('Retry-After', '60');
+      res.status(429).json({ success: false, error: 'too_many_requests' });
+    },
+  });
+
+  const authLimiter = rateLimit({
+    windowMs: 60_000,
+    max: authMax,
+    standardHeaders: true,
+    legacyHeaders: false,
+    handler: (req, res) => {
+      res.setHeader('Retry-After', '60');
+      res.status(429).json({ success: false, error: 'too_many_requests' });
+    },
+  });
+
+  const app = express();
+  app.use(globalLimiter);
+  app.use('/api/auth/login', authLimiter);
+  app.use('/api/auth/forgot-password', authLimiter);
+
+  app.get('/api/health', (req, res) => res.json({ ok: true }));
+  app.post('/api/auth/login', (req, res) => res.json({ ok: true }));
+  app.post('/api/auth/forgot-password', (req, res) => res.json({ ok: true }));
+
+  return app;
+}
+
+// ---------------------------------------------------------------------------
+// Global limiter — 100 req / 60 s
+// ---------------------------------------------------------------------------
+describe('Global rate limiter (100 req / 60 s)', () => {
+  const MAX = 3; // use a small cap so the test runs fast
+  let app;
+
+  beforeEach(() => {
+    // Reset module registry so each test gets a fresh in-memory store
+    jest.resetModules();
+    app = buildApp({ globalMax: MAX, authMax: 5 });
+  });
+
+  test('allows exactly MAX requests', async () => {
+    for (let i = 0; i < MAX; i++) {
+      const res = await request(app).get('/api/health');
+      expect(res.status).toBe(200);
+    }
+  });
+
+  test('returns 429 on the (MAX+1)th request', async () => {
+    for (let i = 0; i < MAX; i++) {
+      await request(app).get('/api/health');
+    }
+    const res = await request(app).get('/api/health');
+    expect(res.status).toBe(429);
+    expect(res.body.error).toBe('too_many_requests');
+  });
+
+  test('429 response includes Retry-After header', async () => {
+    for (let i = 0; i <= MAX; i++) {
+      await request(app).get('/api/health');
+    }
+    const res = await request(app).get('/api/health');
+    expect(res.headers['retry-after']).toBe('60');
+  });
+
+  test('429 response body has success: false', async () => {
+    for (let i = 0; i <= MAX; i++) {
+      await request(app).get('/api/health');
+    }
+    const res = await request(app).get('/api/health');
+    expect(res.body.success).toBe(false);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Auth limiter — 5 req / 60 s
+// ---------------------------------------------------------------------------
+describe('Auth rate limiter (5 req / 60 s)', () => {
+  const AUTH_MAX = 2; // small cap for speed
+  let app;
+
+  beforeEach(() => {
+    jest.resetModules();
+    app = buildApp({ globalMax: 100, authMax: AUTH_MAX });
+  });
+
+  test('allows exactly AUTH_MAX requests to /api/auth/login', async () => {
+    for (let i = 0; i < AUTH_MAX; i++) {
+      const res = await request(app).post('/api/auth/login');
+      expect(res.status).toBe(200);
+    }
+  });
+
+  test('returns 429 on (AUTH_MAX+1)th request to /api/auth/login', async () => {
+    for (let i = 0; i < AUTH_MAX; i++) {
+      await request(app).post('/api/auth/login');
+    }
+    const res = await request(app).post('/api/auth/login');
+    expect(res.status).toBe(429);
+    expect(res.body.error).toBe('too_many_requests');
+  });
+
+  test('returns 429 on (AUTH_MAX+1)th request to /api/auth/forgot-password', async () => {
+    for (let i = 0; i < AUTH_MAX; i++) {
+      await request(app).post('/api/auth/forgot-password');
+    }
+    const res = await request(app).post('/api/auth/forgot-password');
+    expect(res.status).toBe(429);
+    expect(res.body.error).toBe('too_many_requests');
+  });
+
+  test('auth 429 includes Retry-After header', async () => {
+    for (let i = 0; i <= AUTH_MAX; i++) {
+      await request(app).post('/api/auth/login');
+    }
+    const res = await request(app).post('/api/auth/login');
+    expect(res.headers['retry-after']).toBe('60');
+  });
+
+  test('auth limiter does not affect non-auth routes', async () => {
+    // Exhaust auth limit
+    for (let i = 0; i < AUTH_MAX + 2; i++) {
+      await request(app).post('/api/auth/login');
+    }
+    // Non-auth route should still be reachable (global limit not hit)
+    const res = await request(app).get('/api/health');
+    expect(res.status).toBe(200);
+  });
+});

--- a/novaRewards/database/007_create_point_transactions.sql
+++ b/novaRewards/database/007_create_point_transactions.sql
@@ -1,0 +1,13 @@
+-- Migration 007: Create point_transactions table for leaderboard aggregation
+-- Requirements: #185
+
+CREATE TABLE IF NOT EXISTS point_transactions (
+  id         SERIAL PRIMARY KEY,
+  user_id    INTEGER       NOT NULL REFERENCES users(id),
+  points     NUMERIC(18,2) NOT NULL,
+  type       VARCHAR(20)   NOT NULL CHECK (type IN ('earned', 'redeemed', 'expired')),
+  created_at TIMESTAMPTZ   NOT NULL DEFAULT NOW()
+);
+
+-- Composite index for efficient GROUP BY aggregation filtered by date range
+CREATE INDEX IF NOT EXISTS idx_pt_user_created ON point_transactions (user_id, created_at);

--- a/novaRewards/database/008_admin_email_and_rewards.sql
+++ b/novaRewards/database/008_admin_email_and_rewards.sql
@@ -1,0 +1,18 @@
+-- Migration 008: Add email to users and create rewards table
+-- Requirements: #186
+
+ALTER TABLE users
+  ADD COLUMN IF NOT EXISTS email VARCHAR(255);
+
+CREATE INDEX IF NOT EXISTS idx_users_email ON users (email);
+
+CREATE TABLE IF NOT EXISTS rewards (
+  id          SERIAL PRIMARY KEY,
+  name        VARCHAR(255)   NOT NULL,
+  cost        NUMERIC(18, 2) NOT NULL CHECK (cost > 0),
+  stock       INTEGER        NOT NULL DEFAULT 0 CHECK (stock >= 0),
+  is_active   BOOLEAN        NOT NULL DEFAULT TRUE,
+  is_deleted  BOOLEAN        NOT NULL DEFAULT FALSE,
+  created_at  TIMESTAMPTZ    NOT NULL DEFAULT NOW(),
+  updated_at  TIMESTAMPTZ    NOT NULL DEFAULT NOW()
+);

--- a/novaRewards/database/009_daily_login_bonus.sql
+++ b/novaRewards/database/009_daily_login_bonus.sql
@@ -1,0 +1,14 @@
+-- Migration 009: Add login tracking columns and extend point_transactions type
+-- Requirements: #189
+
+ALTER TABLE users
+  ADD COLUMN IF NOT EXISTS last_login_at         TIMESTAMPTZ,
+  ADD COLUMN IF NOT EXISTS daily_bonus_granted_at TIMESTAMPTZ;
+
+-- Extend the type check to include 'bonus'
+ALTER TABLE point_transactions
+  DROP CONSTRAINT IF EXISTS point_transactions_type_check;
+
+ALTER TABLE point_transactions
+  ADD CONSTRAINT point_transactions_type_check
+    CHECK (type IN ('earned', 'redeemed', 'expired', 'bonus'));

--- a/novaRewards/package-lock.json
+++ b/novaRewards/package-lock.json
@@ -20,13 +20,16 @@
         "cors": "^2.8.5",
         "dotenv": "^16.4.5",
         "express": "^4.19.2",
+        "express-rate-limit": "^8.3.1",
         "pg": "^8.12.0",
+        "rate-limit-redis": "^4.2.0",
+        "redis": "^4.7.0",
         "stellar-sdk": "^12.3.0",
         "uuid": "^10.0.0"
       },
       "devDependencies": {
         "eslint": "^8.57.0",
-        "fast-check": "^3.20.0",
+        "fast-check": "^3.23.2",
         "jest": "^29.7.0",
         "nodemon": "^3.1.14",
         "supertest": "^6.3.3"
@@ -1280,6 +1283,72 @@
         "@noble/hashes": "^1.1.5"
       }
     },
+    "node_modules/@redis/bloom": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/@redis/bloom/-/bloom-1.2.0.tgz",
+      "integrity": "sha512-HG2DFjYKbpNmVXsa0keLHp/3leGJz1mjh09f2RLGGLQZzSHpkmZWuwJbAvo3QcRY8p80m5+ZdXZdYOSBLlp7Cg==",
+      "license": "MIT",
+      "peerDependencies": {
+        "@redis/client": "^1.0.0"
+      }
+    },
+    "node_modules/@redis/client": {
+      "version": "1.6.1",
+      "resolved": "https://registry.npmjs.org/@redis/client/-/client-1.6.1.tgz",
+      "integrity": "sha512-/KCsg3xSlR+nCK8/8ZYSknYxvXHwubJrU82F3Lm1Fp6789VQ0/3RJKfsmRXjqfaTA++23CvC3hqmqe/2GEt6Kw==",
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "cluster-key-slot": "1.1.2",
+        "generic-pool": "3.9.0",
+        "yallist": "4.0.0"
+      },
+      "engines": {
+        "node": ">=14"
+      }
+    },
+    "node_modules/@redis/client/node_modules/yallist": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/yallist/-/yallist-4.0.0.tgz",
+      "integrity": "sha512-3wdGidZyq5PB084XLES5TpOSRA3wjXAlIWMhum2kRcv/41Sn2emQ0dycQW4uZXLejwKvg6EsvbdlVL+FYEct7A==",
+      "license": "ISC"
+    },
+    "node_modules/@redis/graph": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/@redis/graph/-/graph-1.1.1.tgz",
+      "integrity": "sha512-FEMTcTHZozZciLRl6GiiIB4zGm5z5F3F6a6FZCyrfxdKOhFlGkiAqlexWMBzCi4DcRoyiOsuLfW+cjlGWyExOw==",
+      "license": "MIT",
+      "peerDependencies": {
+        "@redis/client": "^1.0.0"
+      }
+    },
+    "node_modules/@redis/json": {
+      "version": "1.0.7",
+      "resolved": "https://registry.npmjs.org/@redis/json/-/json-1.0.7.tgz",
+      "integrity": "sha512-6UyXfjVaTBTJtKNG4/9Z8PSpKE6XgSyEb8iwaqDcy+uKrd/DGYHTWkUdnQDyzm727V7p21WUMhsqz5oy65kPcQ==",
+      "license": "MIT",
+      "peerDependencies": {
+        "@redis/client": "^1.0.0"
+      }
+    },
+    "node_modules/@redis/search": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/@redis/search/-/search-1.2.0.tgz",
+      "integrity": "sha512-tYoDBbtqOVigEDMAcTGsRlMycIIjwMCgD8eR2t0NANeQmgK/lvxNAvYyb6bZDD4frHRhIHkJu2TBRvB0ERkOmw==",
+      "license": "MIT",
+      "peerDependencies": {
+        "@redis/client": "^1.0.0"
+      }
+    },
+    "node_modules/@redis/time-series": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/@redis/time-series/-/time-series-1.1.0.tgz",
+      "integrity": "sha512-c1Q99M5ljsIuc4YdaCwfUEXsofakb9c8+Zse2qxTadu8TalLXuAESzLvFAvNVbkmSlvlzIQOLpBCmWI9wTOt+g==",
+      "license": "MIT",
+      "peerDependencies": {
+        "@redis/client": "^1.0.0"
+      }
+    },
     "node_modules/@sinclair/typebox": {
       "version": "0.27.10",
       "resolved": "https://registry.npmjs.org/@sinclair/typebox/-/typebox-0.27.10.tgz",
@@ -2134,6 +2203,15 @@
         "node": ">=12"
       }
     },
+    "node_modules/cluster-key-slot": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/cluster-key-slot/-/cluster-key-slot-1.1.2.tgz",
+      "integrity": "sha512-RMr0FhtfXemyinomL4hrWcYJxmX6deFdCxpJzhDttxgO1+bcCnkk+9drydLVDmAMG7NE6aN/fl4F7ucU/90gAA==",
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
     "node_modules/co": {
       "version": "4.6.0",
       "resolved": "https://registry.npmjs.org/co/-/co-4.6.0.tgz",
@@ -2886,6 +2964,7 @@
       "version": "4.22.1",
       "resolved": "https://registry.npmjs.org/express/-/express-4.22.1.tgz",
       "integrity": "sha512-F2X8g9P1X7uCPZMA3MVf9wcTqlyNp7IhH5qPCI0izhaOIYXaW9L535tGA3qmjRzpH+bZczqq7hVKxTR4NWnu+g==",
+      "peer": true,
       "dependencies": {
         "accepts": "~1.3.8",
         "array-flatten": "1.1.1",
@@ -2925,6 +3004,25 @@
       "funding": {
         "type": "opencollective",
         "url": "https://opencollective.com/express"
+      }
+    },
+    "node_modules/express-rate-limit": {
+      "version": "8.3.1",
+      "resolved": "https://registry.npmjs.org/express-rate-limit/-/express-rate-limit-8.3.1.tgz",
+      "integrity": "sha512-D1dKN+cmyPWuvB+G2SREQDzPY1agpBIcTa9sJxOPMCNeH3gwzhqJRDWCXW3gg0y//+LQ/8j52JbMROWyrKdMdw==",
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "ip-address": "10.1.0"
+      },
+      "engines": {
+        "node": ">= 16"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/express-rate-limit"
+      },
+      "peerDependencies": {
+        "express": ">= 4.11"
       }
     },
     "node_modules/fast-check": {
@@ -3178,6 +3276,15 @@
       "integrity": "sha512-7XHNxH7qX9xG5mIwxkhumTox/MIRNcOgDrxWsMt2pAr23WHp6MrRlN7FBSFpCpr+oVO0F744iUgR82nJMfG2SA==",
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/generic-pool": {
+      "version": "3.9.0",
+      "resolved": "https://registry.npmjs.org/generic-pool/-/generic-pool-3.9.0.tgz",
+      "integrity": "sha512-hymDOu5B53XvN4QT9dBmZxPX4CWhBPPLguTZ9MMFeFa/Kg0xWVfylOVNlJji/E7yTZWFd/q9GO5TxDLq156D7g==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 4"
       }
     },
     "node_modules/gensync": {
@@ -3481,6 +3588,15 @@
       "version": "2.0.4",
       "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.4.tgz",
       "integrity": "sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ=="
+    },
+    "node_modules/ip-address": {
+      "version": "10.1.0",
+      "resolved": "https://registry.npmjs.org/ip-address/-/ip-address-10.1.0.tgz",
+      "integrity": "sha512-XXADHxXmvT9+CRxhXg56LJovE+bmWnEWB78LB83VZTprKTmaC5QfruXocxzTZ2Kl0DNwKuBdlIhjL8LeY8Sf8Q==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 12"
+      }
     },
     "node_modules/ipaddr.js": {
       "version": "1.9.1",
@@ -5370,6 +5486,18 @@
         "node": ">= 0.6"
       }
     },
+    "node_modules/rate-limit-redis": {
+      "version": "4.3.1",
+      "resolved": "https://registry.npmjs.org/rate-limit-redis/-/rate-limit-redis-4.3.1.tgz",
+      "integrity": "sha512-+a1zU8+D7L8siDK9jb14refQXz60vq427VuiplgnaLk9B2LnvGe/APLTfhwb4uNIL7eWVknh8GnRp/unCj+lMA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 16"
+      },
+      "peerDependencies": {
+        "express-rate-limit": ">= 6"
+      }
+    },
     "node_modules/raw-body": {
       "version": "2.5.3",
       "resolved": "https://registry.npmjs.org/raw-body/-/raw-body-2.5.3.tgz",
@@ -5426,6 +5554,23 @@
       },
       "engines": {
         "node": ">=8.10.0"
+      }
+    },
+    "node_modules/redis": {
+      "version": "4.7.1",
+      "resolved": "https://registry.npmjs.org/redis/-/redis-4.7.1.tgz",
+      "integrity": "sha512-S1bJDnqLftzHXHP8JsT5II/CtHWQrASX5K96REjWjlmWKrviSOLWmM7QnRLstAWsu1VBBV1ffV6DzCvxNP0UJQ==",
+      "license": "MIT",
+      "workspaces": [
+        "./packages/*"
+      ],
+      "dependencies": {
+        "@redis/bloom": "1.2.0",
+        "@redis/client": "1.6.1",
+        "@redis/graph": "1.1.1",
+        "@redis/json": "1.0.7",
+        "@redis/search": "1.2.0",
+        "@redis/time-series": "1.1.0"
       }
     },
     "node_modules/require-addon": {


### PR DESCRIPTION
feat: Leaderboard Aggregation, Admin Dashboard API, Rate Limiter & Daily Login Bonus

Closes #185 · Closes #186 · Closes #187 · Closes #189

━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━


What's changed

#185 — Leaderboard Aggregation
- GET /api/leaderboard?period=weekly|alltime&limit=50 — authenticated endpoint returning top-N users by earned points
- SQL RANK() OVER window function on a GROUP BY user_id subquery; weekly period filters last 7 days
- Redis cache per period (leaderboard:weekly, leaderboard:alltime) with 5-minute TTL
- Cache pre-warmed on startup and every 5 minutes via leaderboardCacheWarmer job
- Cache invalidated on every distribution transaction
- Current user's rank always appended live if outside the top N

#186 — Admin Dashboard API
- All routes gated by authenticateUser + requireAdmin
- GET /api/admin/stats — total users, points issued, redemptions, active rewards in a single query
- GET /api/admin/users?search=&page=&limit= — paginated, searchable by email/name
- POST /api/admin/rewards · PATCH /api/admin/rewards/:id · DELETE /api/admin/rewards/:id (soft-delete)

#187 — Rate Limiter
- Global limiter: 100 req / 60 s on all routes
- Strict limiter: 5 req / 60 s on /api/auth/login and /api/auth/forgot-password
- Redis-backed via rate-limit-redis so limits are shared across instances
- Returns 429 with Retry-After: 60 header on breach
- IP whitelist via RATE_LIMIT_WHITELIST env var (health-check / monitoring exemption)
- 9 integration tests covering both limiters

#189 — Daily Login Bonus Cron
- Runs at midnight UTC via self-rescheduling setTimeout
- Credits DAILY_BONUS_POINTS (env-configurable, default 10) as a bonus PointTransaction to users who logged in the previous calendar day and
haven't received today's bonus
- dailyBonusGrantedAt timestamp prevents double-grants
- Per-user failure isolation — one bad row doesn't abort the batch
- 6 unit tests with injected now date verifying cohort selection, crediting, failure handling, and env-driven bonus amount

Migrations
- 007 — point_transactions table + composite index on (user_id, created_at)
- 008 — email column on users; rewards table
- 009 — last_login_at + daily_bonus_granted_at on users; extends point_transactions.type to include bonus

Closes #185 
Closes #186 
Closes #187 
Closes #189 