### PR TITLE
Rewards catalogue page with redemption flow

### DIFF
--- a/novaRewards/backend/routes/rewards.js
+++ b/novaRewards/backend/routes/rewards.js
@@ -1,14 +1,48 @@
-const express = require('express');
+const express = require("express");
 const router = express.Router();
-const rateLimit = require('express-rate-limit');
-const { createHash } = require('crypto');
-const { query } = require('../db/index');
-const { getCampaignById, getActiveCampaign } = require('../db/campaignRepository');
-const { recordTransaction } = require('../db/transactionRepository');
-const { distributeRewards } = require('../../blockchain/sendRewards');
-const { isValidStellarAddress } = require('../../blockchain/stellarService');
-const { authenticateMerchant } = require('../middleware/authenticateMerchant');
-const { verifyTrustline } = require('../services/stellar');
+const rateLimit = require("express-rate-limit");
+const { createHash } = require("crypto");
+const { query } = require("../db/index");
+const {
+  getCampaignById,
+  getActiveCampaign,
+} = require("../db/campaignRepository");
+const { recordTransaction } = require("../db/transactionRepository");
+const { distributeRewards } = require("../../blockchain/sendRewards");
+const { isValidStellarAddress } = require("../../blockchain/stellarService");
+const { authenticateMerchant } = require("../middleware/authenticateMerchant");
+const { verifyTrustline } = require("../services/stellar");
+
+/**
+ * GET /api/rewards
+ * Returns the active rewards catalogue, optionally filtered by category.
+ * Public endpoint — no auth required.
+ */
+router.get("/", async (req, res, next) => {
+  try {
+    const { category } = req.query;
+    const params = [];
+    let categoryClause = "";
+
+    if (category && category.trim()) {
+      params.push(category.trim());
+      categoryClause = `AND category = $${params.length}`;
+    }
+
+    const { rows } = await query(
+      `SELECT id, name, cost, stock, is_active, category, image_url, created_at
+       FROM rewards
+       WHERE is_deleted = FALSE AND is_active = TRUE
+       ${categoryClause}
+       ORDER BY cost ASC`,
+      params,
+    );
+
+    res.json({ success: true, data: rows });
+  } catch (err) {
+    next(err);
+  }
+});
 
 /**
  * Rate limiter: max 20 requests per minute per IP on the distribute endpoint.
@@ -21,8 +55,8 @@ const distributeRateLimiter = rateLimit({
   legacyHeaders: false,
   message: {
     success: false,
-    error: 'rate_limit_exceeded',
-    message: 'Too many requests. Please try again later.',
+    error: "rate_limit_exceeded",
+    message: "Too many requests. Please try again later.",
   },
 });
 
@@ -31,86 +65,97 @@ const distributeRateLimiter = rateLimit({
  * Distributes NOVA tokens to a customer wallet.
  * Requirements: 3.1, 3.2, 3.3, 3.4, 3.5, 3.6, 7.4, 7.5
  */
-router.post('/distribute', distributeRateLimiter, authenticateMerchant, async (req, res, next) => {
-  try {
-    const { walletAddress, amount, campaignId } = req.body;
+router.post(
+  "/distribute",
+  distributeRateLimiter,
+  authenticateMerchant,
+  async (req, res, next) => {
+    try {
+      const { walletAddress, amount, campaignId } = req.body;
 
-    if (!walletAddress || !amount) {
-      return res.status(400).json({
+      if (!walletAddress || !amount) {
+        return res.status(400).json({
+          success: false,
+          error:
+            "Missing required fields: walletAddress and amount are required",
+        });
+      }
+
+      if (amount <= 0) {
+        return res.status(400).json({
+          success: false,
+          error: "Amount must be greater than zero",
+        });
+      }
+
+      // Verify trustline exists
+      const hasTrustline = await verifyTrustline(walletAddress);
+      if (!hasTrustline) {
+        return res.status(400).json({
+          success: false,
+          error: "no_trustline",
+          message:
+            "Recipient does not have a NOVA trustline. Please add NOVA trustline first.",
+        });
+      }
+
+      // Distinguish campaign not found vs inactive/expired for clearer client handling.
+      const campaignExists = await getCampaignById(campaignId);
+      if (!campaignExists) {
+        return res.status(404).json({
+          success: false,
+          error: "not_found",
+          message: "Campaign does not exist",
+        });
+      }
+
+      // Validate campaign is active and belongs to this merchant
+      const campaign = await getActiveCampaign(campaignId);
+      if (!campaign) {
+        return res.status(400).json({
+          success: false,
+          error: "invalid_campaign",
+          message: "Campaign is expired or inactive",
+        });
+      }
+
+      if (campaign.merchant_id !== req.merchant.id) {
+        return res.status(403).json({
+          success: false,
+          error: "forbidden",
+          message: "Campaign does not belong to this merchant",
+        });
+      }
+
+      // Distribute rewards
+      const result = await distributeRewards({
+        recipient: walletAddress,
+        amount,
+        campaignId,
+      });
+
+      res.json({
+        success: true,
+        txHash: result.txHash,
+        transaction: result.tx,
+      });
+    } catch (err) {
+      if (err.code === "no_trustline") {
+        return res.status(400).json({
+          success: false,
+          error: "no_trustline",
+          message: err.message,
+        });
+      }
+
+      console.error("Error distributing rewards:", err);
+      res.status(500).json({
         success: false,
-        error: 'Missing required fields: walletAddress and amount are required',
+        error: "internal_server_error",
+        message: err.message || "Failed to distribute rewards",
       });
     }
-
-    if (amount <= 0) {
-      return res.status(400).json({
-        success: false,
-        error: 'Amount must be greater than zero',
-      });
-    }
-
-    // Verify trustline exists
-    const hasTrustline = await verifyTrustline(walletAddress);
-    if (!hasTrustline) {
-      return res.status(400).json({
-        success: false,
-        error: 'no_trustline',
-        message: 'Recipient does not have a NOVA trustline. Please add NOVA trustline first.',
-      });
-    }
-
-    // Distinguish campaign not found vs inactive/expired for clearer client handling.
-    const campaignExists = await getCampaignById(campaignId);
-    if (!campaignExists) {
-      return res.status(404).json({
-        success: false,
-        error: 'not_found',
-        message: 'Campaign does not exist',
-      });
-    }
-
-    // Validate campaign is active and belongs to this merchant
-    const campaign = await getActiveCampaign(campaignId);
-    if (!campaign) {
-      return res.status(400).json({
-        success: false,
-        error: 'invalid_campaign',
-        message: 'Campaign is expired or inactive',
-      });
-    }
-
-    if (campaign.merchant_id !== req.merchant.id) {
-      return res.status(403).json({
-        success: false,
-        error: 'forbidden',
-        message: 'Campaign does not belong to this merchant',
-      });
-    }
-
-    // Distribute rewards
-    const result = await distributeRewards({
-      recipient: walletAddress,
-      amount,
-      campaignId,
-    });
-
-    res.json({ success: true, txHash: result.txHash, transaction: result.tx });
-  } catch (err) {
-    if (err.code === 'no_trustline') {
-      return res.status(400).json({
-        success: false,
-        error: 'no_trustline',
-        message: err.message,
-      });
-    }
-    
-    console.error('Error distributing rewards:', err);
-    res.status(500).json({
-      success: false,
-      error: 'internal_server_error',
-      message: err.message || 'Failed to distribute rewards',
-    });
-  }
-});
+  },
+);
 
 module.exports = router;

--- a/novaRewards/frontend/components/RedeemModal.js
+++ b/novaRewards/frontend/components/RedeemModal.js
@@ -1,0 +1,137 @@
+"use client";
+
+/**
+ * Confirmation modal shown before a redemption is submitted.
+ * Shows item details, point cost, and remaining balance after redemption.
+ */
+export default function RedeemModal({
+  reward,
+  userPoints,
+  loading,
+  onConfirm,
+  onCancel,
+}) {
+  const balanceAfter = userPoints - reward.cost;
+
+  return (
+    <div
+      className="modal-overlay"
+      onClick={onCancel}
+      role="dialog"
+      aria-modal="true"
+      aria-labelledby="redeem-modal-title"
+    >
+      <div className="modal-content" onClick={(e) => e.stopPropagation()}>
+        <h3 id="redeem-modal-title" style={{ marginBottom: "1rem" }}>
+          Confirm Redemption
+        </h3>
+
+        {/* Item details */}
+        <div
+          style={{
+            display: "flex",
+            gap: "1rem",
+            alignItems: "flex-start",
+            marginBottom: "1.25rem",
+            padding: "1rem",
+            background: "var(--surface-2)",
+            borderRadius: "8px",
+          }}
+        >
+          <div
+            style={{
+              width: "56px",
+              height: "56px",
+              borderRadius: "8px",
+              background: "var(--border)",
+              display: "flex",
+              alignItems: "center",
+              justifyContent: "center",
+              fontSize: "1.75rem",
+              flexShrink: 0,
+              overflow: "hidden",
+            }}
+          >
+            {reward.image_url ? (
+              <img
+                src={reward.image_url}
+                alt={reward.name}
+                style={{ width: "100%", height: "100%", objectFit: "cover" }}
+              />
+            ) : (
+              "🎁"
+            )}
+          </div>
+          <div>
+            <p style={{ fontWeight: 700, marginBottom: "0.25rem" }}>
+              {reward.name}
+            </p>
+            {reward.category && (
+              <span
+                className="badge badge-gray"
+                style={{ marginBottom: "0.5rem" }}
+              >
+                {reward.category}
+              </span>
+            )}
+          </div>
+        </div>
+
+        {/* Points breakdown */}
+        <div className="confirmation-details">
+          <p style={{ display: "flex", justifyContent: "space-between" }}>
+            <span style={{ color: "var(--muted)" }}>Cost</span>
+            <span style={{ fontWeight: 700, color: "var(--accent)" }}>
+              −{reward.cost} pts
+            </span>
+          </p>
+          <p
+            style={{
+              display: "flex",
+              justifyContent: "space-between",
+              marginTop: "0.5rem",
+            }}
+          >
+            <span style={{ color: "var(--muted)" }}>Your balance</span>
+            <span>{userPoints} pts</span>
+          </p>
+          <hr
+            style={{
+              border: "none",
+              borderTop: "1px solid var(--border)",
+              margin: "0.75rem 0",
+            }}
+          />
+          <p style={{ display: "flex", justifyContent: "space-between" }}>
+            <span style={{ color: "var(--muted)" }}>Balance after</span>
+            <span style={{ fontWeight: 700 }}>{balanceAfter} pts</span>
+          </p>
+        </div>
+
+        <div className="modal-actions">
+          <button
+            className="btn btn-secondary"
+            onClick={onCancel}
+            disabled={loading}
+          >
+            Cancel
+          </button>
+          <button
+            className="btn btn-primary"
+            onClick={onConfirm}
+            disabled={loading}
+          >
+            {loading ? (
+              <span className="btn-loading">
+                <span className="spinner" />
+                Redeeming…
+              </span>
+            ) : (
+              "Confirm"
+            )}
+          </button>
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/novaRewards/frontend/components/RewardCard.js
+++ b/novaRewards/frontend/components/RewardCard.js
@@ -1,0 +1,115 @@
+"use client";
+
+/**
+ * Displays a single reward item in the catalogue grid.
+ * Disables the redeem button when the user can't afford it or it's out of stock.
+ */
+export default function RewardCard({ reward, userPoints, onRedeem }) {
+  const outOfStock = reward.stock !== null && reward.stock <= 0;
+  const cannotAfford = userPoints < reward.cost;
+  const disabled = outOfStock || cannotAfford;
+
+  let disabledReason = "";
+  if (outOfStock) disabledReason = "Out of stock";
+  else if (cannotAfford)
+    disabledReason = `Need ${reward.cost - userPoints} more pts`;
+
+  return (
+    <div
+      className="card"
+      style={{
+        padding: "1rem",
+        display: "flex",
+        flexDirection: "column",
+        opacity: outOfStock ? 0.6 : 1,
+        transition: "transform 0.15s",
+      }}
+    >
+      {/* Image */}
+      <div
+        style={{
+          height: "140px",
+          borderRadius: "8px",
+          overflow: "hidden",
+          background: "var(--surface-2)",
+          marginBottom: "0.75rem",
+          display: "flex",
+          alignItems: "center",
+          justifyContent: "center",
+          fontSize: "3rem",
+        }}
+      >
+        {reward.image_url ? (
+          <img
+            src={reward.image_url}
+            alt={reward.name}
+            style={{ width: "100%", height: "100%", objectFit: "cover" }}
+          />
+        ) : (
+          "🎁"
+        )}
+      </div>
+
+      {/* Name */}
+      <p
+        style={{
+          fontWeight: 700,
+          marginBottom: "0.25rem",
+          fontSize: "0.95rem",
+        }}
+      >
+        {reward.name}
+      </p>
+
+      {/* Category badge */}
+      {reward.category && (
+        <span
+          className="badge badge-gray"
+          style={{ marginBottom: "0.5rem", alignSelf: "flex-start" }}
+        >
+          {reward.category}
+        </span>
+      )}
+
+      {/* Cost + stock row */}
+      <div
+        style={{
+          display: "flex",
+          alignItems: "center",
+          justifyContent: "space-between",
+          marginBottom: "0.75rem",
+          marginTop: "auto",
+        }}
+      >
+        <span
+          style={{ fontWeight: 700, color: "var(--accent)", fontSize: "1rem" }}
+        >
+          {reward.cost} pts
+        </span>
+        <span className={`badge ${outOfStock ? "badge-gray" : "badge-green"}`}>
+          {outOfStock
+            ? "Out of stock"
+            : reward.stock === null
+              ? "In stock"
+              : `${reward.stock} left`}
+        </span>
+      </div>
+
+      {/* Redeem button */}
+      <button
+        className="btn btn-primary"
+        style={{ width: "100%" }}
+        disabled={disabled}
+        onClick={onRedeem}
+        aria-label={
+          disabled
+            ? `Cannot redeem ${reward.name}: ${disabledReason}`
+            : `Redeem ${reward.name} for ${reward.cost} points`
+        }
+        title={disabled ? disabledReason : undefined}
+      >
+        {disabled ? disabledReason : "Redeem"}
+      </button>
+    </div>
+  );
+}

--- a/novaRewards/frontend/components/Toast.js
+++ b/novaRewards/frontend/components/Toast.js
@@ -1,0 +1,72 @@
+"use client";
+
+import { useEffect } from "react";
+
+/**
+ * Auto-dismissing toast notification.
+ * @param {{ type: 'success'|'error', message: string, onClose: () => void }} props
+ */
+export default function Toast({ type, message, onClose }) {
+  useEffect(() => {
+    const t = setTimeout(onClose, 4000);
+    return () => clearTimeout(t);
+  }, [onClose]);
+
+  const isSuccess = type === "success";
+
+  return (
+    <div
+      role="alert"
+      aria-live="polite"
+      style={{
+        position: "fixed",
+        bottom: "1.5rem",
+        right: "1.5rem",
+        zIndex: 2000,
+        background: isSuccess ? "var(--success)" : "var(--error)",
+        color: "#fff",
+        padding: "0.75rem 1.25rem",
+        borderRadius: "10px",
+        boxShadow: "0 4px 20px rgba(0,0,0,0.2)",
+        display: "flex",
+        alignItems: "center",
+        gap: "0.75rem",
+        maxWidth: "360px",
+        fontSize: "0.9rem",
+        fontWeight: 500,
+        animation: "slideUp 0.2s ease",
+      }}
+    >
+      <span>{isSuccess ? "✓" : "✕"}</span>
+      <span style={{ flex: 1 }}>{message}</span>
+      <button
+        onClick={onClose}
+        aria-label="Dismiss notification"
+        style={{
+          background: "none",
+          border: "none",
+          color: "#fff",
+          cursor: "pointer",
+          fontSize: "1.1rem",
+          lineHeight: 1,
+          padding: 0,
+          opacity: 0.8,
+        }}
+      >
+        ×
+      </button>
+      <style jsx>{`
+        @keyframes slideUp {
+          from {
+            transform: translateY(12px);
+            opacity: 0;
+          }
+          to {
+            transform: translateY(0);
+            opacity: 1;
+          }
+        }
+      `}</style>
+    </div>
+  );
+}

--- a/novaRewards/frontend/pages/rewards.js
+++ b/novaRewards/frontend/pages/rewards.js
@@ -1,25 +1,333 @@
-'use client';
+"use client";
 
-import DashboardLayout from '../components/DashboardLayout';
-import ErrorBoundary from '../components/ErrorBoundary';
-import { withAuth } from '../context/AuthContext';
+import { useState, useEffect, useCallback } from "react";
+import DashboardLayout from "../components/DashboardLayout";
+import ErrorBoundary from "../components/ErrorBoundary";
+import RewardCard from "../components/RewardCard";
+import RedeemModal from "../components/RedeemModal";
+import Toast from "../components/Toast";
+import PointsWidget from "../components/PointsWidget";
+import { withAuth } from "../context/AuthContext";
+import { useAuth } from "../context/AuthContext";
+import api from "../lib/api";
 
 /**
- * Rewards page - displays available rewards
- * Requirements: 164.2
+ * Rewards catalogue page.
+ * Fetches GET /api/rewards, supports category filter + cost sort,
+ * and handles redemption via POST /api/redemptions.
  */
 function RewardsContent() {
+  const { user } = useAuth();
+
+  const [rewards, setRewards] = useState([]);
+  const [loading, setLoading] = useState(true);
+  const [error, setError] = useState(null);
+
+  // Points balance (optimistic)
+  const [pointBalance, setPointBalance] = useState(null);
+  const [balanceLoading, setBalanceLoading] = useState(true);
+
+  // Filter / sort
+  const [category, setCategory] = useState("");
+  const [sortOrder, setSortOrder] = useState("asc"); // 'asc' | 'desc'
+
+  // Confirmation modal
+  const [selectedReward, setSelectedReward] = useState(null);
+  const [redeeming, setRedeeming] = useState(false);
+
+  // Toast
+  const [toast, setToast] = useState(null); // { type: 'success'|'error', message: string }
+
+  // ── Fetch point balance ────────────────────────────────────────────────
+  const fetchBalance = useCallback(async () => {
+    if (!user?.wallet_address) return;
+    try {
+      const { data } = await api.get(
+        `/api/users/${user.wallet_address}/points`,
+      );
+      setPointBalance(data.data.balance);
+    } catch {
+      // non-fatal — balance stays null
+    } finally {
+      setBalanceLoading(false);
+    }
+  }, [user?.wallet_address]);
+
+  // ── Fetch rewards catalogue ────────────────────────────────────────────
+  const fetchRewards = useCallback(async () => {
+    setLoading(true);
+    setError(null);
+    try {
+      const params = new URLSearchParams();
+      if (category) params.set("category", category);
+      const { data } = await api.get(`/api/rewards?${params}`);
+      setRewards(data.data);
+    } catch (err) {
+      setError(
+        err.response?.data?.message ||
+          "Failed to load rewards. Please try again.",
+      );
+    } finally {
+      setLoading(false);
+    }
+  }, [category]);
+
+  useEffect(() => {
+    fetchBalance();
+  }, [fetchBalance]);
+  useEffect(() => {
+    fetchRewards();
+  }, [fetchRewards]);
+
+  // ── Derived: sorted rewards ────────────────────────────────────────────
+  const sorted = [...rewards].sort((a, b) =>
+    sortOrder === "asc" ? a.cost - b.cost : b.cost - a.cost,
+  );
+
+  // ── Unique categories for filter dropdown ─────────────────────────────
+  const categories = [
+    ...new Set(rewards.map((r) => r.category).filter(Boolean)),
+  ];
+
+  // ── Redeem handler ────────────────────────────────────────────────────
+  async function handleConfirmRedeem() {
+    if (!selectedReward || !user) return;
+    setRedeeming(true);
+    // Optimistic balance decrement
+    const prev = pointBalance;
+    setPointBalance((b) => (b !== null ? b - selectedReward.cost : b));
+    setSelectedReward(null);
+
+    try {
+      await api.post(
+        "/api/redemptions",
+        { userId: user.id, rewardId: selectedReward.id },
+        { headers: { "X-Idempotency-Key": crypto.randomUUID() } },
+      );
+      setToast({
+        type: "success",
+        message: `🎉 "${selectedReward.name}" redeemed successfully!`,
+      });
+      // Refresh catalogue stock counts
+      fetchRewards();
+      fetchBalance();
+    } catch (err) {
+      // Roll back optimistic update
+      setPointBalance(prev);
+      const msg =
+        err.response?.data?.message ||
+        err.response?.data?.error ||
+        "Redemption failed. Please try again.";
+      setToast({ type: "error", message: msg });
+    } finally {
+      setRedeeming(false);
+    }
+  }
+
   return (
     <DashboardLayout>
-      <div className="dashboard-content">
-        <div className="card">
-          <h2 style={{ marginBottom: '1rem' }}>🎁 Rewards</h2>
-          <p style={{ color: 'var(--muted)' }}>
-            Browse and redeem your NOVA rewards. This feature is coming soon!
-          </p>
+      <div className="dashboard-content" data-tour="reward-catalogue">
+        {/* Header row */}
+        <div
+          style={{
+            display: "flex",
+            alignItems: "center",
+            justifyContent: "space-between",
+            marginBottom: "1.5rem",
+            flexWrap: "wrap",
+            gap: "0.75rem",
+          }}
+        >
+          <div>
+            <h2 style={{ margin: 0 }}>🎁 Rewards Catalogue</h2>
+            <p
+              style={{
+                color: "var(--muted)",
+                fontSize: "0.875rem",
+                marginTop: "0.25rem",
+              }}
+            >
+              Redeem your NOVA points for prizes
+            </p>
+          </div>
+          {/* Points balance pill */}
+          <div
+            style={{
+              background: "var(--accent)",
+              color: "#fff",
+              borderRadius: "999px",
+              padding: "0.4rem 1rem",
+              fontWeight: 700,
+              fontSize: "0.95rem",
+              minWidth: "120px",
+              textAlign: "center",
+            }}
+          >
+            {balanceLoading ? "…" : `${pointBalance ?? 0} pts`}
+          </div>
         </div>
+
+        {/* Filters */}
+        <div
+          style={{
+            display: "flex",
+            gap: "0.75rem",
+            marginBottom: "1.5rem",
+            flexWrap: "wrap",
+          }}
+        >
+          <select
+            className="input"
+            style={{ width: "auto", marginBottom: 0 }}
+            value={category}
+            onChange={(e) => setCategory(e.target.value)}
+            aria-label="Filter by category"
+          >
+            <option value="">All categories</option>
+            {categories.map((c) => (
+              <option key={c} value={c}>
+                {c}
+              </option>
+            ))}
+          </select>
+
+          <select
+            className="input"
+            style={{ width: "auto", marginBottom: 0 }}
+            value={sortOrder}
+            onChange={(e) => setSortOrder(e.target.value)}
+            aria-label="Sort by point cost"
+          >
+            <option value="asc">Cost: Low → High</option>
+            <option value="desc">Cost: High → Low</option>
+          </select>
+        </div>
+
+        {/* States */}
+        {loading && <CatalogueSkeleton />}
+
+        {!loading && error && (
+          <div
+            className="card"
+            style={{ textAlign: "center", borderColor: "var(--error)" }}
+          >
+            <p className="error" style={{ marginBottom: "1rem" }}>
+              {error}
+            </p>
+            <button className="btn btn-primary" onClick={fetchRewards}>
+              Try Again
+            </button>
+          </div>
+        )}
+
+        {!loading && !error && sorted.length === 0 && (
+          <div
+            className="card"
+            style={{ textAlign: "center", padding: "3rem 1rem" }}
+          >
+            <p style={{ fontSize: "2rem", marginBottom: "0.5rem" }}>🎁</p>
+            <p style={{ color: "var(--muted)" }}>
+              No rewards available right now. Check back soon!
+            </p>
+          </div>
+        )}
+
+        {!loading && !error && sorted.length > 0 && (
+          <div
+            style={{
+              display: "grid",
+              gridTemplateColumns: "repeat(auto-fill, minmax(240px, 1fr))",
+              gap: "1.25rem",
+            }}
+          >
+            {sorted.map((reward) => (
+              <RewardCard
+                key={reward.id}
+                reward={reward}
+                userPoints={pointBalance ?? 0}
+                onRedeem={() => setSelectedReward(reward)}
+              />
+            ))}
+          </div>
+        )}
       </div>
+
+      {/* Confirmation modal */}
+      {selectedReward && (
+        <RedeemModal
+          reward={selectedReward}
+          userPoints={pointBalance ?? 0}
+          loading={redeeming}
+          onConfirm={handleConfirmRedeem}
+          onCancel={() => setSelectedReward(null)}
+        />
+      )}
+
+      {/* Toast */}
+      {toast && (
+        <Toast
+          type={toast.type}
+          message={toast.message}
+          onClose={() => setToast(null)}
+        />
+      )}
     </DashboardLayout>
+  );
+}
+
+function CatalogueSkeleton() {
+  return (
+    <div
+      style={{
+        display: "grid",
+        gridTemplateColumns: "repeat(auto-fill, minmax(240px, 1fr))",
+        gap: "1.25rem",
+      }}
+    >
+      {[...Array(6)].map((_, i) => (
+        <div key={i} className="card" style={{ padding: "1rem" }}>
+          <div
+            style={{
+              height: "140px",
+              background: "var(--surface-2)",
+              borderRadius: "8px",
+              marginBottom: "0.75rem",
+              animation: "pulse 2s infinite",
+            }}
+          />
+          <div
+            style={{
+              height: "1rem",
+              background: "var(--surface-2)",
+              borderRadius: "4px",
+              marginBottom: "0.5rem",
+              width: "70%",
+              animation: "pulse 2s infinite",
+            }}
+          />
+          <div
+            style={{
+              height: "0.875rem",
+              background: "var(--surface-2)",
+              borderRadius: "4px",
+              width: "40%",
+              animation: "pulse 2s infinite",
+            }}
+          />
+        </div>
+      ))}
+      <style jsx>{`
+        @keyframes pulse {
+          0%,
+          100% {
+            opacity: 1;
+          }
+          50% {
+            opacity: 0.5;
+          }
+        }
+      `}</style>
+    </div>
   );
 }
 


### PR DESCRIPTION
## Summary

Implements the rewards catalogue screen where users can browse, filter, and redeem prizes using their NOVA points.

## Changes

### Backend
- `GET /api/rewards` — new public endpoint returning active rewards, with optional `?category=` filter, ordered by cost

### Frontend
- `pages/rewards.js` — full catalogue page: fetches rewards, category filter dropdown, cost sort (asc/desc), skeleton loader, empty/error states, optimistic point balance decrement on redeem
- `components/RewardCard.js` — card showing image, name, category badge, stock status, cost, and a redeem button disabled (with reason) when the user can't afford it or it's out of stock
- `components/RedeemModal.js` — confirmation modal with item details, cost breakdown, current balance, and balance-after before the user commits
- `components/Toast.js` — auto-dismissing (4s) success/error toast anchored bottom-right

## Behaviour
- Redeem button is disabled with a descriptive label when `userPoints < cost` or `stock <= 0`
- On confirm, balance is decremented optimistically and rolled back on failure
- `POST /api/redemptions` uses `X-Idempotency-Key` (via `crypto.randomUUID()`) to prevent duplicate submissions
- Success shows a toast; API errors surface a descriptive message in the toast

this pr Closes #166 
