### PR TITLE
feat: deploy-contracts.sh + deployment docs

### DIFF
--- a/docs/deployment.md
+++ b/docs/deployment.md
@@ -1,0 +1,122 @@
+# Deployment Guide
+
+## Prerequisites
+
+### 1. Install Rust + wasm32 target
+
+```bash
+curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh
+rustup target add wasm32-unknown-unknown
+```
+
+### 2. Install wasm-opt
+
+```bash
+# macOS
+brew install binaryen
+
+# Ubuntu / Debian
+sudo apt install binaryen
+
+# Or via cargo
+cargo install wasm-opt
+```
+
+### 3. Install Stellar CLI
+
+```bash
+cargo install --locked stellar-cli --features opt
+```
+
+Verify: `stellar --version`
+
+### 4. Fund the deployer account
+
+On testnet, use Friendbot:
+
+```bash
+curl "https://friendbot.stellar.org?addr=<DEPLOYER_PUBLIC_KEY>"
+```
+
+On mainnet, fund the account via an exchange or existing wallet before deploying.
+
+---
+
+## Environment Variables
+
+Create a `.env.testnet` or `.env.mainnet` file (or export variables in your shell):
+
+| Variable | Required | Description |
+|---|---|---|
+| `DEPLOYER_SECRET` | ✅ | Secret key (`S...`) of the account paying fees |
+| `ADMIN_ADDRESS` | ✅ | Public key (`G...`) set as contract admin |
+| `NETWORK` | — | `testnet` (default) or `mainnet` |
+| `TESTNET_RPC_URL` | — | Override testnet RPC (default: `https://soroban-testnet.stellar.org`) |
+| `MAINNET_RPC_URL` | — | Override mainnet RPC (default: `https://soroban-rpc.stellar.org`) |
+| `ADMIN_SIGNERS` | — | Space-separated list of multisig signer addresses (default: `ADMIN_ADDRESS`) |
+| `ADMIN_THRESHOLD` | — | Multisig approval threshold (default: `1`) |
+
+---
+
+## Usage
+
+### Deploy to testnet
+
+```bash
+export DEPLOYER_SECRET=S...
+export ADMIN_ADDRESS=G...
+NETWORK=testnet bash scripts/deploy-contracts.sh
+```
+
+### Deploy to mainnet
+
+```bash
+export DEPLOYER_SECRET=S...
+export ADMIN_ADDRESS=G...
+NETWORK=mainnet bash scripts/deploy-contracts.sh
+```
+
+### Dry run (simulate without broadcasting)
+
+```bash
+export DEPLOYER_SECRET=S...
+export ADMIN_ADDRESS=G...
+NETWORK=testnet bash scripts/deploy-contracts.sh --dry-run
+```
+
+Dry run prints every command that would be executed and exits without submitting any transactions.
+
+---
+
+## What the script does
+
+For each contract — **NovaToken**, **RewardPool**, **ClaimDistribution** (vesting), **Staking** (referral), **AdminRoles** — the script:
+
+1. Builds the contract with `cargo build --target wasm32-unknown-unknown --release`
+2. Optimises the `.wasm` binary with `wasm-opt -Oz --strip-debug`
+3. Uploads the binary with `stellar contract upload` and captures the wasm hash
+4. Deploys a contract instance with `stellar contract deploy` and captures the contract ID
+5. Writes the contract ID to `.env.<NETWORK>` (e.g. `NOVA_TOKEN_CONTRACT_ID=C...`)
+6. Calls `initialize` on the contract with the appropriate arguments
+
+---
+
+## Output
+
+After a successful run, `.env.testnet` (or `.env.mainnet`) will contain:
+
+```
+NOVA_TOKEN_CONTRACT_ID=C...
+REWARD_POOL_CONTRACT_ID=C...
+CLAIM_DISTRIBUTION_CONTRACT_ID=C...
+STAKING_CONTRACT_ID=C...
+ADMIN_ROLES_CONTRACT_ID=C...
+```
+
+These values are automatically upserted — re-running the script after an upgrade will overwrite existing entries.
+
+---
+
+## Re-deploying / Upgrading
+
+To upgrade a single contract, comment out the other `deploy` calls in `scripts/deploy-contracts.sh` and re-run. The new contract ID will overwrite the old one in the env file.

--- a/scripts/deploy-contracts.sh
+++ b/scripts/deploy-contracts.sh
@@ -1,0 +1,147 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+# ── Config ────────────────────────────────────────────────────────────────────
+NETWORK="${NETWORK:-testnet}"
+DRY_RUN=false
+[[ "${1:-}" == "--dry-run" ]] && DRY_RUN=true
+
+CONTRACTS_DIR="$(cd "$(dirname "$0")/../contracts" && pwd)"
+ENV_FILE="$(cd "$(dirname "$0")/.." && pwd)/.env.${NETWORK}"
+
+if [[ "$NETWORK" == "mainnet" ]]; then
+  NETWORK_PASSPHRASE="Public Global Stellar Network ; September 2015"
+  RPC_URL="${MAINNET_RPC_URL:-https://soroban-rpc.stellar.org}"
+else
+  NETWORK_PASSPHRASE="Test SDF Network ; September 2015"
+  RPC_URL="${TESTNET_RPC_URL:-https://soroban-testnet.stellar.org}"
+fi
+
+# Required env vars
+: "${DEPLOYER_SECRET:?DEPLOYER_SECRET is required}"
+: "${ADMIN_ADDRESS:?ADMIN_ADDRESS is required}"
+
+# admin_roles extra args (signers is a space-separated list of addresses)
+: "${ADMIN_SIGNERS:=${ADMIN_ADDRESS}}"
+: "${ADMIN_THRESHOLD:=1}"
+
+# ── Helpers ───────────────────────────────────────────────────────────────────
+log() { echo "[deploy] $*"; }
+
+run() {
+  log "$ $*"
+  $DRY_RUN && return 0
+  eval "$@"
+}
+
+write_env() {
+  local key="$1" val="$2"
+  if grep -q "^${key}=" "$ENV_FILE" 2>/dev/null; then
+    sed -i "s|^${key}=.*|${key}=${val}|" "$ENV_FILE"
+  else
+    echo "${key}=${val}" >> "$ENV_FILE"
+  fi
+}
+
+build_contract() {
+  local pkg="$1"
+  log "Building ${pkg}..."
+  run cargo build --manifest-path "${CONTRACTS_DIR}/Cargo.toml" \
+    --target wasm32-unknown-unknown --release \
+    -p "${pkg}"
+}
+
+optimize_wasm() {
+  local pkg="$1"
+  local wasm="${CONTRACTS_DIR}/target/wasm32-unknown-unknown/release/${pkg}.wasm"
+  local opt="${CONTRACTS_DIR}/target/wasm32-unknown-unknown/release/${pkg}.optimized.wasm"
+  log "Optimising ${pkg}.wasm..."
+  run wasm-opt -Oz --strip-debug "$wasm" -o "$opt"
+}
+
+upload_contract() {
+  local pkg="$1"
+  local wasm="${CONTRACTS_DIR}/target/wasm32-unknown-unknown/release/${pkg}.optimized.wasm"
+  log "Uploading ${pkg}..."
+  if $DRY_RUN; then echo "DRY_RUN_HASH_${pkg}"; return; fi
+  stellar contract upload \
+    --wasm "$wasm" \
+    --network-passphrase "${NETWORK_PASSPHRASE}" \
+    --rpc-url "${RPC_URL}" \
+    --source "${DEPLOYER_SECRET}"
+}
+
+deploy_contract() {
+  local pkg="$1" wasm_hash="$2"
+  log "Deploying ${pkg} (hash: ${wasm_hash})..."
+  if $DRY_RUN; then echo "DRY_RUN_CONTRACT_ID_${pkg}"; return; fi
+  stellar contract deploy \
+    --wasm-hash "$wasm_hash" \
+    --network-passphrase "${NETWORK_PASSPHRASE}" \
+    --rpc-url "${RPC_URL}" \
+    --source "${DEPLOYER_SECRET}"
+}
+
+invoke_init() {
+  local contract_id="$1"; shift
+  log "Initialising ${contract_id}..."
+  if $DRY_RUN; then return; fi
+  stellar contract invoke \
+    --id "$contract_id" \
+    --network-passphrase "${NETWORK_PASSPHRASE}" \
+    --rpc-url "${RPC_URL}" \
+    --source "${DEPLOYER_SECRET}" \
+    -- initialize "$@"
+}
+
+# deploy <pkg> <ENV_KEY> [init args...]
+deploy() {
+  local pkg="$1" env_key="$2"; shift 2
+
+  build_contract "$pkg"
+  optimize_wasm  "$pkg"
+  local hash; hash=$(upload_contract "$pkg")
+  local id;   id=$(deploy_contract "$pkg" "$hash")
+
+  write_env "$env_key" "$id"
+  log "${env_key}=${id}"
+
+  invoke_init "$id" "$@"
+}
+
+# ── Deploy contracts ──────────────────────────────────────────────────────────
+
+# NovaToken → initialize(admin)
+deploy nova_token NOVA_TOKEN_CONTRACT_ID \
+  --admin "${ADMIN_ADDRESS}"
+
+# RewardPool → initialize(admin)
+deploy reward_pool REWARD_POOL_CONTRACT_ID \
+  --admin "${ADMIN_ADDRESS}"
+
+# ClaimDistribution (vesting) → initialize(admin)
+deploy vesting CLAIM_DISTRIBUTION_CONTRACT_ID \
+  --admin "${ADMIN_ADDRESS}"
+
+# Staking (referral) → initialize(admin)
+deploy referral STAKING_CONTRACT_ID \
+  --admin "${ADMIN_ADDRESS}"
+
+# AdminRoles → initialize(admin, signers, threshold)
+# Build signers JSON array from space-separated ADMIN_SIGNERS
+SIGNERS_JSON="["
+first=true
+for addr in $ADMIN_SIGNERS; do
+  $first || SIGNERS_JSON+=","
+  SIGNERS_JSON+="\"${addr}\""
+  first=false
+done
+SIGNERS_JSON+="]"
+
+deploy admin_roles ADMIN_ROLES_CONTRACT_ID \
+  --admin "${ADMIN_ADDRESS}" \
+  --signers "${SIGNERS_JSON}" \
+  --threshold "${ADMIN_THRESHOLD}"
+
+log "All contracts deployed. IDs written to ${ENV_FILE}"
+$DRY_RUN && log "(dry-run: no transactions were broadcast)"


### PR DESCRIPTION
Closes #230

---

## Summary

Closes the deploy automation task.

### Changes
- `scripts/deploy-contracts.sh` — builds, optimises (wasm-opt), uploads, and deploys all contracts to Stellar testnet/mainnet
- `docs/deployment.md` — prerequisite setup and usage guide

### Contracts covered
| Contract | Cargo package | Env key |
|---|---|---|
| NovaToken | `nova_token` | `NOVA_TOKEN_CONTRACT_ID` |
| RewardPool | `reward_pool` | `REWARD_POOL_CONTRACT_ID` |
| ClaimDistribution | `vesting` | `CLAIM_DISTRIBUTION_CONTRACT_ID` |
| Staking | `referral` | `STAKING_CONTRACT_ID` |
| AdminRoles | `admin_roles` | `ADMIN_ROLES_CONTRACT_ID` |

### Usage
```bash
# testnet
DEPLOYER_SECRET=S... ADMIN_ADDRESS=G... NETWORK=testnet bash scripts/deploy-contracts.sh

# dry run
DEPLOYER_SECRET=S... ADMIN_ADDRESS=G... bash scripts/deploy-contracts.sh --dry-run
```