### PR TITLE
feat: add HorizonService with retry logic and Redis caching

### DIFF
--- a/novaRewards/backend/services/horizonService.js
+++ b/novaRewards/backend/services/horizonService.js
@@ -1,0 +1,123 @@
+'use strict';
+
+const { Horizon } = require('stellar-sdk');
+const { getRedisClient } = require('../cache/redisClient');
+
+const DEFAULT_TTL = {
+  balance: parseInt(process.env.HORIZON_CACHE_TTL_BALANCE, 10) || 30,
+  transactions: parseInt(process.env.HORIZON_CACHE_TTL_TX, 10) || 60,
+  operations: parseInt(process.env.HORIZON_CACHE_TTL_OPS, 10) || 60,
+};
+
+const MAX_RETRIES = 3;
+const BASE_DELAY_MS = 500;
+
+/**
+ * Executes fn with exponential backoff on 429 responses.
+ * @param {Function} fn - async function to retry
+ * @returns {Promise<*>}
+ */
+async function withRetry(fn) {
+  for (let attempt = 0; attempt <= MAX_RETRIES; attempt++) {
+    try {
+      return await fn();
+    } catch (err) {
+      const is429 = err?.response?.status === 429 || err?.status === 429;
+      if (!is429 || attempt === MAX_RETRIES) throw err;
+      const delay = BASE_DELAY_MS * 2 ** attempt;
+      await new Promise((res) => setTimeout(res, delay));
+    }
+  }
+}
+
+class HorizonService {
+  constructor(horizonUrl) {
+    this.server = new Horizon.Server(
+      horizonUrl || process.env.HORIZON_URL || 'https://horizon-testnet.stellar.org'
+    );
+  }
+
+  /**
+   * Returns cached value or fetches fresh data, caching the result.
+   * Falls back to fetching if Redis is unavailable.
+   */
+  async _cached(key, ttl, fetchFn) {
+    const redis = getRedisClient();
+    if (redis) {
+      const cached = await redis.get(key);
+      if (cached) return JSON.parse(cached);
+    }
+    const data = await withRetry(fetchFn);
+    if (redis) await redis.set(key, JSON.stringify(data), 'EX', ttl);
+    return data;
+  }
+
+  /**
+   * Fetches all balances for a Stellar account.
+   * @param {string} accountId - Stellar public key
+   * @returns {Promise<Array>} balances array
+   */
+  async getAccountBalance(accountId) {
+    return this._cached(
+      `horizon:balance:${accountId}`,
+      DEFAULT_TTL.balance,
+      async () => {
+        const account = await this.server.loadAccount(accountId);
+        return account.balances;
+      }
+    );
+  }
+
+  /**
+   * Fetches transaction history for a Stellar account.
+   * @param {string} accountId - Stellar public key
+   * @param {object} [opts] - { limit, cursor, order }
+   * @returns {Promise<Array>} transactions array
+   */
+  async getTransactionHistory(accountId, opts = {}) {
+    const { limit = 10, cursor, order = 'desc' } = opts;
+    const cacheKey = `horizon:tx:${accountId}:${limit}:${cursor || ''}:${order}`;
+    return this._cached(
+      cacheKey,
+      DEFAULT_TTL.transactions,
+      async () => {
+        let builder = this.server
+          .transactions()
+          .forAccount(accountId)
+          .limit(limit)
+          .order(order);
+        if (cursor) builder = builder.cursor(cursor);
+        const result = await builder.call();
+        return result.records;
+      }
+    );
+  }
+
+  /**
+   * Fetches operations for a Stellar account.
+   * @param {string} accountId - Stellar public key
+   * @param {object} [opts] - { limit, cursor, order }
+   * @returns {Promise<Array>} operations array
+   */
+  async getOperations(accountId, opts = {}) {
+    const { limit = 10, cursor, order = 'desc' } = opts;
+    const cacheKey = `horizon:ops:${accountId}:${limit}:${cursor || ''}:${order}`;
+    return this._cached(
+      cacheKey,
+      DEFAULT_TTL.operations,
+      async () => {
+        let builder = this.server
+          .operations()
+          .forAccount(accountId)
+          .limit(limit)
+          .order(order);
+        if (cursor) builder = builder.cursor(cursor);
+        const result = await builder.call();
+        return result.records;
+      }
+    );
+  }
+}
+
+module.exports = new HorizonService();
+module.exports.HorizonService = HorizonService;

--- a/novaRewards/backend/tests/horizonService.test.js
+++ b/novaRewards/backend/tests/horizonService.test.js
@@ -1,0 +1,197 @@
+'use strict';
+
+jest.mock('stellar-sdk');
+jest.mock('../cache/redisClient');
+
+const { Horizon } = require('stellar-sdk');
+const { getRedisClient } = require('../cache/redisClient');
+const { HorizonService } = require('../services/horizonService');
+
+// ── Fixtures ──────────────────────────────────────────────────────────────
+const ACCOUNT_ID = 'GAAZI4TCR3TY5OJHCTJC2A4QSY6CJWJH5IAJTGKIN2ER7LBNVKOCCWN';
+
+const BALANCES = [
+  { asset_type: 'native', balance: '10.0000000' },
+  { asset_type: 'credit_alphanum4', asset_code: 'NOVA', asset_issuer: 'GISSUER', balance: '500.0000000' },
+];
+
+const TX_RECORDS = [{ id: 'tx1', hash: 'abc123' }];
+const OP_RECORDS = [{ id: 'op1', type: 'payment' }];
+
+// ── Helpers ───────────────────────────────────────────────────────────────
+function makeRedis({ getVal = null } = {}) {
+  return {
+    get: jest.fn().mockResolvedValue(getVal ? JSON.stringify(getVal) : null),
+    set: jest.fn().mockResolvedValue('OK'),
+  };
+}
+
+function makeServer({ balances = BALANCES, txRecords = TX_RECORDS, opRecords = OP_RECORDS } = {}) {
+  const callFn = (records) => jest.fn().mockResolvedValue({ records });
+  const chainable = (records) => {
+    const obj = {
+      forAccount: jest.fn().mockReturnThis(),
+      limit: jest.fn().mockReturnThis(),
+      order: jest.fn().mockReturnThis(),
+      cursor: jest.fn().mockReturnThis(),
+      call: callFn(records),
+    };
+    return obj;
+  };
+
+  return {
+    loadAccount: jest.fn().mockResolvedValue({ balances }),
+    transactions: jest.fn(() => chainable(txRecords)),
+    operations: jest.fn(() => chainable(opRecords)),
+  };
+}
+
+function makeService(serverOverride) {
+  const svc = new HorizonService('https://horizon-testnet.stellar.org');
+  svc.server = serverOverride || makeServer();
+  return svc;
+}
+
+// ── Tests ─────────────────────────────────────────────────────────────────
+describe('HorizonService', () => {
+  beforeEach(() => {
+    getRedisClient.mockReturnValue(makeRedis());
+    Horizon.Server.mockImplementation(() => makeServer());
+  });
+
+  // ── getAccountBalance ────────────────────────────────────────────────────
+  describe('getAccountBalance', () => {
+    it('returns balances from Horizon', async () => {
+      const svc = makeService();
+      const result = await svc.getAccountBalance(ACCOUNT_ID);
+      expect(result).toEqual(BALANCES);
+      expect(svc.server.loadAccount).toHaveBeenCalledWith(ACCOUNT_ID);
+    });
+
+    it('returns cached value without calling Horizon', async () => {
+      getRedisClient.mockReturnValue(makeRedis({ getVal: BALANCES }));
+      const svc = makeService();
+      const result = await svc.getAccountBalance(ACCOUNT_ID);
+      expect(result).toEqual(BALANCES);
+      expect(svc.server.loadAccount).not.toHaveBeenCalled();
+    });
+
+    it('caches the Horizon response in Redis', async () => {
+      const redis = makeRedis();
+      getRedisClient.mockReturnValue(redis);
+      const svc = makeService();
+      await svc.getAccountBalance(ACCOUNT_ID);
+      expect(redis.set).toHaveBeenCalledWith(
+        `horizon:balance:${ACCOUNT_ID}`,
+        JSON.stringify(BALANCES),
+        'EX',
+        expect.any(Number)
+      );
+    });
+
+    it('still fetches from Horizon when Redis is unavailable', async () => {
+      getRedisClient.mockReturnValue(null);
+      const svc = makeService();
+      const result = await svc.getAccountBalance(ACCOUNT_ID);
+      expect(result).toEqual(BALANCES);
+    });
+  });
+
+  // ── getTransactionHistory ────────────────────────────────────────────────
+  describe('getTransactionHistory', () => {
+    it('returns transaction records from Horizon', async () => {
+      const svc = makeService();
+      const result = await svc.getTransactionHistory(ACCOUNT_ID);
+      expect(result).toEqual(TX_RECORDS);
+    });
+
+    it('returns cached transactions without calling Horizon', async () => {
+      getRedisClient.mockReturnValue(makeRedis({ getVal: TX_RECORDS }));
+      const svc = makeService();
+      const result = await svc.getTransactionHistory(ACCOUNT_ID);
+      expect(result).toEqual(TX_RECORDS);
+      expect(svc.server.transactions).not.toHaveBeenCalled();
+    });
+
+    it('passes limit, cursor, and order to the builder', async () => {
+      // Capture the builder instance on the first transactions() call
+      const capturedBuilders = [];
+      const server = makeServer();
+      const origTx = server.transactions.bind(server);
+      server.transactions = jest.fn(() => {
+        const b = origTx();
+        capturedBuilders.push(b);
+        return b;
+      });
+      const svc = makeService(server);
+      await svc.getTransactionHistory(ACCOUNT_ID, { limit: 5, cursor: 'cur1', order: 'asc' });
+      const builder = capturedBuilders[0];
+      expect(builder.limit).toHaveBeenCalledWith(5);
+      expect(builder.order).toHaveBeenCalledWith('asc');
+      expect(builder.cursor).toHaveBeenCalledWith('cur1');
+    });
+  });
+
+  // ── getOperations ────────────────────────────────────────────────────────
+  describe('getOperations', () => {
+    it('returns operation records from Horizon', async () => {
+      const svc = makeService();
+      const result = await svc.getOperations(ACCOUNT_ID);
+      expect(result).toEqual(OP_RECORDS);
+    });
+
+    it('returns cached operations without calling Horizon', async () => {
+      getRedisClient.mockReturnValue(makeRedis({ getVal: OP_RECORDS }));
+      const svc = makeService();
+      const result = await svc.getOperations(ACCOUNT_ID);
+      expect(result).toEqual(OP_RECORDS);
+      expect(svc.server.operations).not.toHaveBeenCalled();
+    });
+  });
+
+  // ── Retry logic ──────────────────────────────────────────────────────────
+  describe('retry on 429', () => {
+    it('retries on 429 and succeeds on the next attempt', async () => {
+      jest.useFakeTimers();
+      const err429 = Object.assign(new Error('Too Many Requests'), { response: { status: 429 } });
+      const server = makeServer();
+      server.loadAccount
+        .mockRejectedValueOnce(err429)
+        .mockResolvedValueOnce({ balances: BALANCES });
+
+      const svc = makeService(server);
+      const promise = svc.getAccountBalance(ACCOUNT_ID);
+      await jest.advanceTimersByTimeAsync(600);
+      const result = await promise;
+      expect(result).toEqual(BALANCES);
+      expect(server.loadAccount).toHaveBeenCalledTimes(2);
+      jest.useRealTimers();
+    });
+
+    it('throws after exhausting all retries', async () => {
+      // Use real timers but replace setTimeout to resolve immediately
+      const origSetTimeout = global.setTimeout;
+      jest.spyOn(global, 'setTimeout').mockImplementation((fn) => origSetTimeout(fn, 0));
+
+      const err429 = Object.assign(new Error('Too Many Requests'), { response: { status: 429 } });
+      const server = makeServer();
+      server.loadAccount.mockRejectedValue(err429);
+
+      const svc = makeService(server);
+      await expect(svc.getAccountBalance(ACCOUNT_ID)).rejects.toMatchObject({ response: { status: 429 } });
+      expect(server.loadAccount).toHaveBeenCalledTimes(4); // initial + 3 retries
+
+      jest.restoreAllMocks();
+    });
+
+    it('does not retry on non-429 errors', async () => {
+      const err500 = Object.assign(new Error('Server Error'), { response: { status: 500 } });
+      const server = makeServer();
+      server.loadAccount.mockRejectedValue(err500);
+
+      const svc = makeService(server);
+      await expect(svc.getAccountBalance(ACCOUNT_ID)).rejects.toMatchObject({ response: { status: 500 } });
+      expect(server.loadAccount).toHaveBeenCalledTimes(1);
+    });
+  });
+});


### PR DESCRIPTION
Add HorizonService — Stellar Horizon API wrapper with retry & caching                          
                                                                                                 
  Implements a service layer that wraps the Stellar Horizon API for use by the reward engine and 
  user-facing APIs.                                                                              
                                                                                                 
  What's included:                                                                               
                                                                                                 
  - HorizonService wrapping @stellar/stellar-sdk Horizon client                                  
  - Methods: getAccountBalance, getTransactionHistory, getOperations                             
  - Automatic retry on 429 Too Many Requests with exponential backoff (500ms → 1s → 2s, max 3    
  retries)                                                                                       
  - Redis caching with configurable TTL per method via env vars (HORIZON_CACHE_TTL_BALANCE,      
  HORIZON_CACHE_TTL_TX, HORIZON_CACHE_TTL_OPS); degrades gracefully when Redis is unavailable    
  - 12 unit tests covering cache hit/miss, Horizon fallback, retry exhaustion, and builder option
  forwarding                                                                                     
                                                                                                 
  Env vars (optional, with defaults):                                                            
                                                                                                 
  HORIZON_CACHE_TTL_BALANCE=30                                                                   
  HORIZON_CACHE_TTL_TX=60                                                                        
  HORIZON_CACHE_TTL_OPS=60                                                                       
                                                                                                 
  Closes #574                    '