### PR TITLE
docs: rewrite README as definitive developer entry point                                                                                                             

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,150 +1,241 @@
-# Nova Rewards
-
 <p align="center">
-  <img src="repo_avatar.png" width="300" alt="Nova Rewards Logo">
+  <img src="repo_avatar.png" width="280" alt="Nova Rewards Logo">
 </p>
 
-**Nova Rewards** is a next-generation, blockchain-powered loyalty platform that enables businesses to reward users with tokenized incentives on the Stellar network.
+<h1 align="center">Nova Rewards</h1>
 
-It transforms traditional reward systems into transparent, secure, and interoperable digital experiences.
+<p align="center">
+  A blockchain-powered loyalty platform that lets businesses issue tokenized rewards on the Stellar network.
+</p>
 
----
-
-## Why Nova Rewards?
-
-Traditional loyalty programs are:
-- Fragmented  
-- Hard to manage  
-- Limited in value  
-
-**Nova Rewards fixes this by:**
-- Tokenizing rewards on-chain  
-- Giving users real ownership  
-- Enabling seamless redemption and transfer  
+<p align="center">
+  <a href="https://github.com/barry01-hash/Nova-Rewards/actions/workflows/ci.yml"><img src="https://github.com/barry01-hash/Nova-Rewards/actions/workflows/ci.yml/badge.svg" alt="CI"></a>
+  <a href="docs/audits/wcag-accessibility-audit.md"><img src="https://img.shields.io/badge/WCAG-2.1%20AA-blue" alt="WCAG 2.1 AA"></a>
+  <a href="docs/security/README.md"><img src="https://img.shields.io/badge/security-audited-green" alt="Security Audited"></a>
+</p>
 
 ---
 
-## Key Features
+## Overview
 
-### Tokenized Loyalty System
-Businesses can issue custom reward tokens that users truly own.
+Nova Rewards replaces fragmented, opaque loyalty programs with on-chain token issuance. Merchants create reward campaigns; users earn, hold, and redeem NOVA tokens directly from a crypto wallet. Every transaction is verifiable on Stellar — no black-box points systems.
 
-### Blockchain Transparency
-All reward transactions are verifiable on-chain.
-
-### Fast & Low-Cost Transactions
-Powered by Stellar for near-instant settlements.
-
-### Modular Architecture
-Easily adaptable for different industries and use cases.
-
-### Wallet Integration
-Users can store and manage rewards in their crypto wallets.
+**Who this repo is for:**
+- **Developers** building integrations or contributing features
+- **Merchants** evaluating the platform or self-hosting
+- **Contributors** looking for a starting point
 
 ---
 
 ## Architecture
 
+```mermaid
+graph TD
+    subgraph Client
+        FE["Frontend\nNext.js / React PWA\n:3000"]
+    end
 
-### Components:
-- **Frontend:** User dashboard & merchant interface  
-- **Backend:** Handles business logic & integrations  
-- **Smart Contracts:** Token issuance, rewards logic, redemption  
+    subgraph Backend
+        BE["Backend API\nNode.js / Express\n:3001"]
+        RD["Redis\nCache & Rate Limiting\n:6379"]
+        PG["PostgreSQL\nPrimary Store\n:5432"]
+    end
 
----
+    subgraph "Stellar Network"
+        SC["Soroban Smart Contracts\nnova-rewards · nova_token\nreward_pool · governance\nvesting · referral\ndistribution · admin_roles"]
+        HZ["Horizon RPC"]
+    end
 
-## How It Works
+    subgraph Infra
+        GW["Nginx Gateway\n:8080"]
+        MON["Prometheus + Grafana\nmonitoring/"]
+    end
 
-1. Merchant creates a reward campaign  
-2. User completes an action (purchase, referral, engagement)  
-3. Smart contract issues reward tokens  
-4. User stores tokens in wallet  
-5. Tokens are redeemed for perks or discounts  
+    FE -->|REST / WebSocket| GW
+    GW --> BE
+    BE --> PG
+    BE --> RD
+    BE -->|Stellar SDK| HZ
+    HZ --> SC
+    MON -.->|scrape| BE
+```
+
+**Key directories:**
+
+| Path | What lives there |
+|------|-----------------|
+| `novaRewards/frontend/` | Next.js PWA — pages, components, stores |
+| `novaRewards/backend/` | Express API — routes, services, DB repos |
+| `contracts/` | Soroban smart contracts (Rust) |
+| `novaRewards/database/` | SQL migrations (run in order) |
+| `monitoring/` | Prometheus, Grafana, Alertmanager configs |
+| `infra/` | Terraform modules (VPC, RDS, EC2, ElastiCache) |
+| `k8s/` | Kubernetes manifests + Helm chart |
+| `docs/` | All extended documentation |
 
 ---
 
 ## Tech Stack
 
-- **Blockchain:** Stellar  
-- **Smart Contracts:** Soroban  
-- **Frontend:** React / Next.js  
-- **Backend:** Node.js (optional)  
+| Layer | Technology |
+|-------|-----------|
+| Blockchain | Stellar |
+| Smart Contracts | Soroban (Rust, `wasm32v1-none`) |
+| Frontend | Next.js 14, React, Tailwind CSS, Zustand |
+| Backend | Node.js 20, Express, PostgreSQL 16, Redis 7 |
+| Auth | JWT (access + refresh tokens) |
+| Wallet | Freighter browser extension |
+| Infra | Docker Compose, Kubernetes, Helm, Terraform |
+| Monitoring | Prometheus, Grafana, Alertmanager |
+| CI/CD | GitHub Actions |
 
 ---
 
-## Product
+## Quick Start
 
-For detailed product vision, roadmap, and feature specifications, see the [Product Requirements Document (PRD)](docs/PRD.md).
-
----
-
-## Security
-
-### Security Audits
-
-All smart contracts undergo comprehensive security audits before production deployment. 
-
-📋 **View Audit Reports:** [Security Audit Documentation](docs/audits/)
-
-### Audit Process
-
-- **Independent Auditors:** Third-party security firms review all contract code
-- **Comprehensive Testing:** Static analysis, dynamic testing, and manual review
-- **Findings Tracking:** All issues documented and remediated
-- **Public Reports:** Full transparency with published audit findings
-
-### Security Best Practices
-
-- Regular security updates and patching
-- Multi-signature controls for admin functions
-- Gradual rollout with testing phases
-- Bug bounty program for responsible disclosure
-
----
-
-## Getting Started
+> Gets you running locally in under 15 minutes.
 
 ### Prerequisites
 
-- Node.js
-- Rust `stable`
-- `stellar` CLI
-- Docker Desktop if you want a local standalone Soroban/Stellar network
-- Wallet (e.g., Freighter)
+| Tool | Version | Install |
+|------|---------|---------|
+| Node.js | ≥ 20 | [nodejs.org](https://nodejs.org) |
+| Rust (stable) | see `rust-toolchain.toml` | [rustup.rs](https://rustup.rs) |
+| Stellar CLI | latest | [developers.stellar.org](https://developers.stellar.org/docs/tools/cli/install-cli) |
+| Docker Desktop | latest | [docker.com](https://www.docker.com/products/docker-desktop) |
+| Freighter wallet | latest | [freighter.app](https://www.freighter.app) |
 
-### Installation
+### 1 — Clone
 
 ```bash
 git clone https://github.com/barry01-hash/Nova-Rewards.git
 cd Nova-Rewards
 ```
 
-### Soroban Development Setup
+### 2 — Start infrastructure (Postgres + Redis + Backend + Frontend)
 
-PowerShell:
+```bash
+cd novaRewards
+cp .env.example .env          # fill in secrets — see Environment Setup below
+docker compose up --build
+```
 
+Services come up at:
+- Frontend → http://localhost:3000
+- Backend API → http://localhost:3001
+- Nginx gateway → http://localhost:8080
+
+### 3 — Set up Soroban contracts
+
+**POSIX:**
+```bash
+./scripts/setup-soroban-dev.sh   # installs wasm32v1-none target, adds local network
+./scripts/build-contracts.sh     # compiles all contracts to WASM
+./scripts/test-contracts.sh      # runs contract test suite
+```
+
+**PowerShell:**
 ```powershell
 ./scripts/setup-soroban-dev.ps1
-./scripts/test-contracts.ps1
 ./scripts/build-contracts.ps1
+./scripts/test-contracts.ps1
 ```
 
-POSIX shell:
+### 4 — (Optional) Local Stellar testnet
 
 ```bash
-./scripts/setup-soroban-dev.sh
-./scripts/test-contracts.sh
-./scripts/build-contracts.sh
+./scripts/start-local-testnet.sh      # starts a standalone Soroban/Stellar node
 ```
-
-To run a local standalone testnet with RPC enabled:
-
-```bash
-./scripts/start-local-testnet.sh
-```
-
-PowerShell:
 
 ```powershell
 ./scripts/start-local-testnet.ps1
 ```
+
+### 5 — Run application tests
+
+```bash
+cd novaRewards
+npm run test:backend    # Jest — backend unit + integration
+npm run test:frontend   # Jest — frontend components
+```
+
+---
+
+## Environment Setup
+
+Copy `novaRewards/.env.example` to `novaRewards/.env` and fill in the required values:
+
+```bash
+cp novaRewards/.env.example novaRewards/.env
+```
+
+**Required variables:**
+
+| Variable | Description |
+|----------|-------------|
+| `ISSUER_PUBLIC` / `ISSUER_SECRET` | Stellar issuer keypair (creates NOVA asset) |
+| `DISTRIBUTION_PUBLIC` / `DISTRIBUTION_SECRET` | Stellar distribution keypair |
+| `STELLAR_NETWORK` | `testnet` (dev) or `mainnet` (prod) |
+| `DATABASE_URL` | PostgreSQL connection string |
+| `REDIS_URL` | Redis connection string |
+| `JWT_SECRET` | Long random string for signing JWTs |
+| `NEXT_PUBLIC_API_URL` | Backend URL visible to the browser |
+
+For Vercel deployments see `.env.vercel.example`. For production infrastructure see `infrastructure/.env.example`.
+
+> Never commit `.env` files. They are in `.gitignore`.
+
+---
+
+## Contributing
+
+1. **Find or create an issue** — all work is tracked in GitHub Issues.
+2. **Branch** off `main`:
+   ```
+   feat/<short-description>
+   fix/<short-description>
+   docs/<short-description>
+   ```
+3. **Run checks** before pushing:
+   ```bash
+   npm run lint && npm run test
+   # contracts:
+   cargo fmt --all && cargo clippy -- -D warnings && cargo test
+   ```
+4. **Open a PR** against `main` — fill in the PR template and link the issue.
+5. **Two approvals** required before merge. PRs are squash-merged.
+
+Full details: [docs/pr-process.md](docs/pr-process.md) · [docs/code-style.md](docs/code-style.md)
+
+---
+
+## License
+
+This project is proprietary. All rights reserved © Nova Rewards.  
+See [LICENSE](LICENSE) for terms, or contact the maintainers for licensing inquiries.
+
+---
+
+## Documentation Index
+
+| Document | Description |
+|----------|-------------|
+| [docs/PRD.md](docs/PRD.md) | Product requirements and roadmap |
+| [docs/architecture.md](docs/architecture.md) | Detailed system architecture |
+| [docs/contracts.md](docs/contracts.md) | Contract addresses, deploy & upgrade instructions |
+| [docs/abi-reference.md](docs/abi-reference.md) | Full ABI — function signatures, events, integration examples |
+| [docs/error-codes.md](docs/error-codes.md) | Contract error codes and remediation |
+| [docs/api/README.md](docs/api/README.md) | REST API overview |
+| [docs/api/openapi.json](docs/api/openapi.json) | OpenAPI 3.0 spec |
+| [docs/deployment/guides.md](docs/deployment/guides.md) | Deployment guides (Docker, K8s, Vercel) |
+| [docs/security/README.md](docs/security/README.md) | Security overview |
+| [docs/security/threat-model.md](docs/security/threat-model.md) | Threat model |
+| [docs/security/security-best-practices.md](docs/security/security-best-practices.md) | Security best practices |
+| [docs/stellar/integration.md](docs/stellar/integration.md) | Stellar / Horizon integration guide |
+| [docs/tokenomics.md](docs/tokenomics.md) | Token economics |
+| [docs/ops/runbook.md](docs/ops/runbook.md) | Operations runbook |
+| [monitoring/README.md](monitoring/README.md) | Monitoring stack setup |
+| [contracts/README.md](contracts/README.md) | Smart contracts overview |
+| [novaRewards/README.md](novaRewards/README.md) | App-level setup (frontend + backend) |
+| [infrastructure/README_DEVOPS_SETUP.md](infrastructure/README_DEVOPS_SETUP.md) | DevOps / infra setup |
+| [ROADMAP.md](ROADMAP.md) | Issue tracker and priorities |

--- a/contracts/admin_roles/src/lib.rs
+++ b/contracts/admin_roles/src/lib.rs
@@ -1,3 +1,25 @@
+//! # Admin Roles Contract
+//!
+//! Centralized access control for Nova Rewards protocol operations.
+//!
+//! ## Features
+//! - Two-step admin transfer (propose → accept) to prevent accidental ownership loss
+//! - Configurable multisig threshold and signer set
+//! - Privileged stubs for mint, withdraw, rate update, and pause operations
+//!
+//! ## Usage
+//! ```ignore
+//! client.initialize(&admin, &signers_vec, &threshold);
+//!
+//! // Two-step admin transfer
+//! client.propose_admin(&new_admin);
+//! // new_admin calls:
+//! client.accept_admin();
+//!
+//! // Update multisig settings
+//! client.update_signers(&signers_vec);
+//! client.update_threshold(&2);
+//! ```
 #![no_std]
 use soroban_sdk::{contract, contractimpl, contracttype, symbol_short, vec, Address, Env, Vec};
 
@@ -17,6 +39,14 @@ pub struct AdminRolesContract;
 #[contractimpl]
 impl AdminRolesContract {
     /// Initializes the contract with the first admin and optional multisig settings.
+    ///
+    /// # Parameters
+    /// - `admin` – Initial admin address.
+    /// - `signers` – Initial multisig signer set (may be empty).
+    /// - `threshold` – Minimum approvals required for multisig operations.
+    ///
+    /// # Panics
+    /// - `"already initialised"` if called more than once.
     pub fn initialize(env: Env, admin: Address, signers: Vec<Address>, threshold: u32) {
         if env.storage().instance().has(&DataKey::Admin) {
             panic!("already initialised");
@@ -43,6 +73,18 @@ impl AdminRolesContract {
     // ── Two-step admin transfer ───────────────────────────────────────────────
 
     /// Stores a pending admin that can later accept ownership.
+    ///
+    /// The current admin must call this first; the new admin then calls
+    /// [`accept_admin`](AdminRolesContract::accept_admin) to complete the transfer.
+    ///
+    /// # Parameters
+    /// - `new_admin` – Address being proposed as the next admin.
+    ///
+    /// # Authorization
+    /// Requires current admin authorization.
+    ///
+    /// # Events
+    /// Emits `("adm_roles", "adm_prop")` with data `(current_admin: Address, proposed: Address)`.
     pub fn propose_admin(env: Env, new_admin: Address) {
         Self::require_admin(&env);
         env.storage()
@@ -57,6 +99,17 @@ impl AdminRolesContract {
     }
 
     /// Completes the two-step admin transfer for the pending admin.
+    ///
+    /// Must be called by the address previously set via [`propose_admin`](AdminRolesContract::propose_admin).
+    ///
+    /// # Authorization
+    /// Requires pending admin authorization.
+    ///
+    /// # Events
+    /// Emits `("adm_roles", "adm_xfer")` with data `(old_admin: Address, new_admin: Address)`.
+    ///
+    /// # Panics
+    /// - `"no pending admin"` if no admin transfer is in progress.
     pub fn accept_admin(env: Env) {
         let pending: Address = env
             .storage()
@@ -79,6 +132,12 @@ impl AdminRolesContract {
     // ── Multisig threshold ────────────────────────────────────────────────────
 
     /// Updates the multisig approval threshold.
+    ///
+    /// # Parameters
+    /// - `threshold` – New minimum number of signer approvals required.
+    ///
+    /// # Authorization
+    /// Requires admin authorization.
     pub fn update_threshold(env: Env, threshold: u32) {
         Self::require_admin(&env);
         env.storage()
@@ -87,6 +146,12 @@ impl AdminRolesContract {
     }
 
     /// Replaces the configured multisig signer set.
+    ///
+    /// # Parameters
+    /// - `signers` – New list of authorized signer addresses.
+    ///
+    /// # Authorization
+    /// Requires admin authorization.
     pub fn update_signers(env: Env, signers: Vec<Address>) {
         Self::require_admin(&env);
         env.storage().instance().set(&DataKey::Signers, &signers);

--- a/contracts/distribution/src/lib.rs
+++ b/contracts/distribution/src/lib.rs
@@ -1,3 +1,25 @@
+//! # Distribution Contract
+//!
+//! Admin-controlled token distribution with batch support and a 30-day clawback window.
+//!
+//! ## Features
+//! - Single and batch token distribution (up to 50 recipients per call)
+//! - Fixed-point reward calculation via [`calculate_reward`](DistributionContract::calculate_reward)
+//! - 30-day clawback window per distribution
+//!
+//! ## Usage
+//! ```ignore
+//! client.initialize(&admin, &token_id);
+//!
+//! // Single distribution
+//! client.distribute(&recipient, &1_000);
+//!
+//! // Batch distribution
+//! client.distribute_batch(&recipients_vec, &amounts_vec);
+//!
+//! // Clawback within 30 days
+//! client.clawback(&recipient);
+//! ```
 #![no_std]
 
 use soroban_sdk::{
@@ -29,6 +51,13 @@ impl DistributionContract {
     // ── Init ─────────────────────────────────────────────────────────────────
 
     /// One-time setup. `token_id` is the Nova token contract address.
+    ///
+    /// # Parameters
+    /// - `admin` – Address authorized to call distribution and clawback functions.
+    /// - `token_id` – Address of the Nova token contract used for transfers.
+    ///
+    /// # Panics
+    /// - `"already initialized"` if called more than once.
     pub fn initialize(env: Env, admin: Address, token_id: Address) {
         if env.storage().instance().has(&DataKey::Admin) {
             panic!("already initialized");
@@ -84,9 +113,21 @@ impl DistributionContract {
     ///
     /// - Admin-gated.
     /// - Validates `amount > 0` and that the contract holds sufficient balance.
-    /// - Records the distribution for clawback within `CLAWBACK_WINDOW` seconds.
+    /// - Records the distribution for clawback within `CLAWBACK_WINDOW` seconds (30 days).
     ///
-    /// Emits `("dist", recipient)` with data `(amount, deadline)`.
+    /// # Parameters
+    /// - `recipient` – Address to receive the tokens.
+    /// - `amount` – Number of tokens to distribute (must be > 0).
+    ///
+    /// # Authorization
+    /// Requires admin authorization.
+    ///
+    /// # Events
+    /// Emits `("dist", recipient)` with data `(amount: i128, deadline: u64)`.
+    ///
+    /// # Panics
+    /// - `"amount must be positive"` if `amount <= 0`.
+    /// - `"insufficient contract balance"` if the contract holds fewer tokens than `amount`.
     pub fn distribute(env: Env, recipient: Address, amount: i128) {
         Self::require_admin(&env);
         Self::_distribute(&env, &recipient, amount);
@@ -125,7 +166,22 @@ impl DistributionContract {
     /// `recipients` and `amounts` must be the same length (max 50 entries).
     /// The entire batch is validated before any transfer is executed.
     ///
+    /// # Parameters
+    /// - `recipients` – List of recipient addresses (max 50).
+    /// - `amounts` – Corresponding token amounts for each recipient (all must be > 0).
+    ///
+    /// # Authorization
+    /// Requires admin authorization.
+    ///
+    /// # Events
     /// Emits one `("dist", recipient)` event per entry.
+    ///
+    /// # Panics
+    /// - `"recipients and amounts length mismatch"` if lengths differ.
+    /// - `"empty batch"` if the list is empty.
+    /// - `"batch exceeds maximum of 50"` if more than 50 entries are provided.
+    /// - `"amount must be positive"` if any amount is ≤ 0.
+    /// - `"insufficient contract balance for batch"` if the contract cannot cover the total.
     pub fn distribute_batch(
         env: Env,
         recipients: Vec<Address>,
@@ -164,11 +220,23 @@ impl DistributionContract {
 
     /// Reclaim tokens from `recipient` back to the contract.
     ///
-    /// Only callable by admin within `CLAWBACK_WINDOW` seconds of distribution.
+    /// Only callable by admin within `CLAWBACK_WINDOW` (30 days) of distribution.
     /// Requires the recipient to have approved the contract as a spender
     /// (standard token allowance flow).
     ///
-    /// Emits `("clawback", recipient)` with data `amount`.
+    /// # Parameters
+    /// - `recipient` – Address from which tokens are reclaimed.
+    ///
+    /// # Authorization
+    /// Requires admin authorization.
+    ///
+    /// # Events
+    /// Emits `("clawback", recipient)` with data `amount: i128`.
+    ///
+    /// # Panics
+    /// - `"no clawback record for recipient"` if no distribution was recorded.
+    /// - `"clawback window has expired"` if more than 30 days have passed since distribution.
+    /// - `"nothing to clawback"` if the recorded distribution amount is 0.
     pub fn clawback(env: Env, recipient: Address) {
         Self::require_admin(&env);
 
@@ -214,6 +282,7 @@ impl DistributionContract {
 
     // ── View helpers ──────────────────────────────────────────────────────────
 
+    /// Returns the amount originally distributed to `recipient` (0 if none or already clawed back).
     pub fn get_distributed(env: Env, recipient: Address) -> i128 {
         env.storage()
             .persistent()
@@ -221,6 +290,8 @@ impl DistributionContract {
             .unwrap_or(0)
     }
 
+    /// Returns the Unix timestamp (seconds) after which clawback is no longer possible for `recipient`.
+    /// Returns `0` if no active clawback record exists.
     pub fn get_clawback_deadline(env: Env, recipient: Address) -> u64 {
         env.storage()
             .persistent()
@@ -228,6 +299,7 @@ impl DistributionContract {
             .unwrap_or(0)
     }
 
+    /// Returns the current Nova token balance held by this contract.
     pub fn contract_balance(env: Env) -> i128 {
         Self::token(&env).balance(&env.current_contract_address())
     }

--- a/contracts/governance/src/lib.rs
+++ b/contracts/governance/src/lib.rs
@@ -1,3 +1,25 @@
+//! # Governance Contract
+//!
+//! On-chain governance for Nova Rewards protocol parameter changes.
+//!
+//! ## Lifecycle
+//! 1. Any address calls [`create_proposal`](GovernanceContract::create_proposal) to open a vote.
+//! 2. Token holders call [`vote`](GovernanceContract::vote) during the voting period (~7 days).
+//! 3. After the period ends, anyone calls [`finalise`](GovernanceContract::finalise) to tally votes.
+//! 4. The admin calls [`execute`](GovernanceContract::execute) to mark a passed proposal as executed.
+//!
+//! ## Constants
+//! - `VOTING_PERIOD`: 120 960 ledgers (~7 days at 5 s/ledger)
+//! - `QUORUM`: minimum 1 yes-vote required to pass
+//!
+//! ## Usage
+//! ```ignore
+//! let id = client.create_proposal(&proposer, &title, &description);
+//! client.vote(&voter, &id, &true);
+//! // advance ledger past voting period …
+//! client.finalise(&id);
+//! client.execute(&id); // admin only
+//! ```
 #![no_std]
 use soroban_sdk::{
     contract, contractimpl, contracttype, symbol_short, Address, Env, String,
@@ -53,6 +75,12 @@ pub struct GovernanceContract;
 #[contractimpl]
 impl GovernanceContract {
     /// Initialise with an admin address.
+    ///
+    /// # Parameters
+    /// - `admin` – Address authorized to call [`execute`](GovernanceContract::execute).
+    ///
+    /// # Panics
+    /// - `"already initialised"` if called more than once.
     pub fn initialize(env: Env, admin: Address) {
         if env.storage().instance().has(&DataKey::Admin) {
             panic!("already initialised");
@@ -90,7 +118,20 @@ impl GovernanceContract {
     // ── Proposal creation ─────────────────────────────────────────────────────
 
     /// Create a new governance proposal. Any address may propose.
-    /// Returns the new proposal id.
+    ///
+    /// # Parameters
+    /// - `proposer` – Address creating the proposal (must authorize).
+    /// - `title` – Short human-readable title (max ~32 chars recommended).
+    /// - `description` – Full proposal description.
+    ///
+    /// # Returns
+    /// The new proposal id (`u32`), starting at `1`.
+    ///
+    /// # Authorization
+    /// Requires `proposer` authorization.
+    ///
+    /// # Events
+    /// Emits `("gov", "proposed")` with data `(id: u32, proposer: Address, title: String)`.
     pub fn create_proposal(
         env: Env,
         proposer: Address,
@@ -128,7 +169,22 @@ impl GovernanceContract {
     // ── Voting ────────────────────────────────────────────────────────────────
 
     /// Cast a vote on an active proposal. Each address may vote once.
-    /// `support = true` → yes, `support = false` → no.
+    ///
+    /// # Parameters
+    /// - `voter` – Address casting the vote (must authorize).
+    /// - `proposal_id` – Id of the proposal to vote on.
+    /// - `support` – `true` for yes, `false` for no.
+    ///
+    /// # Authorization
+    /// Requires `voter` authorization.
+    ///
+    /// # Events
+    /// Emits `("gov", "voted")` with data `(proposal_id: u32, voter: Address, support: bool)`.
+    ///
+    /// # Panics
+    /// - `"already voted"` if the voter has already cast a vote on this proposal.
+    /// - `"proposal not active"` if the proposal is not in `Active` status.
+    /// - `"voting period ended"` if the current ledger sequence exceeds `end_ledger`.
     pub fn vote(env: Env, voter: Address, proposal_id: u32, support: bool) {
         voter.require_auth();
 
@@ -171,7 +227,19 @@ impl GovernanceContract {
     // ── Finalise ──────────────────────────────────────────────────────────────
 
     /// Finalise a proposal after its voting period ends.
-    /// Updates status to Passed or Rejected based on votes and quorum.
+    ///
+    /// Tallies votes and transitions the proposal to `Passed` or `Rejected`.
+    /// A proposal passes when `yes_votes >= QUORUM && yes_votes > no_votes`.
+    ///
+    /// # Parameters
+    /// - `proposal_id` – Id of the proposal to finalise.
+    ///
+    /// # Events
+    /// Emits `("gov", "finalised")` with data `(proposal_id: u32, passed: bool)`.
+    ///
+    /// # Panics
+    /// - `"proposal not active"` if the proposal is not in `Active` status.
+    /// - `"voting period not ended"` if the current ledger sequence is ≤ `end_ledger`.
     pub fn finalise(env: Env, proposal_id: u32) {
         let mut proposal = Self::load_proposal(&env, proposal_id);
         assert!(
@@ -203,7 +271,22 @@ impl GovernanceContract {
     // ── Execution ─────────────────────────────────────────────────────────────
 
     /// Execute a passed proposal. Admin-gated.
-    /// Marks the proposal as Executed and emits an executed event.
+    ///
+    /// Marks the proposal as `Executed` and emits an event. Actual on-chain
+    /// side-effects (e.g. parameter updates) must be implemented by the caller
+    /// after verifying the emitted event.
+    ///
+    /// # Parameters
+    /// - `proposal_id` – Id of the proposal to execute.
+    ///
+    /// # Authorization
+    /// Requires admin authorization.
+    ///
+    /// # Events
+    /// Emits `("gov", "executed")` with data `(proposal_id: u32, proposer: Address)`.
+    ///
+    /// # Panics
+    /// - `"proposal not passed"` if the proposal status is not `Passed`.
     pub fn execute(env: Env, proposal_id: u32) {
         Self::admin(&env).require_auth();
 
@@ -225,14 +308,20 @@ impl GovernanceContract {
 
     // ── Read-only ─────────────────────────────────────────────────────────────
 
+    /// Returns the full [`Proposal`] struct for a given id.
+    ///
+    /// # Panics
+    /// - `"proposal not found"` if no proposal exists with the given id.
     pub fn get_proposal(env: Env, proposal_id: u32) -> Proposal {
         Self::load_proposal(&env, proposal_id)
     }
 
+    /// Returns the total number of proposals created.
     pub fn proposal_count(env: Env) -> u32 {
         Self::proposal_count(&env)
     }
 
+    /// Returns `true` if `voter` has already voted on `proposal_id`.
     pub fn has_voted(env: Env, proposal_id: u32, voter: Address) -> bool {
         env.storage()
             .persistent()

--- a/contracts/nova-rewards/src/lib.rs
+++ b/contracts/nova-rewards/src/lib.rs
@@ -1,3 +1,26 @@
+//! # Nova Rewards Contract
+//!
+//! Core rewards contract for the Nova Rewards platform. Manages user balances,
+//! staking with yield accrual, cross-asset swaps, emergency recovery, and
+//! contract upgrades.
+//!
+//! ## Features
+//! - User balance management with daily withdrawal limits
+//! - Staking with configurable annual yield (basis points)
+//! - Cross-asset swap: burn Nova points for XLM via a DEX router
+//! - Emergency pause / unpause with optional auto-expiry
+//! - Account snapshot and restore for emergency recovery
+//! - Two-step WASM upgrade with migration versioning
+//!
+//! ## Usage
+//! ```ignore
+//! client.initialize(&admin);
+//! client.set_annual_rate(&500); // 5% APY
+//! client.set_balance(&user, &10_000);
+//! client.stake(&user, &5_000);
+//! // time passes …
+//! let total = client.unstake(&user); // principal + yield
+//! ```
 #![no_std]
 
 pub mod utils;
@@ -317,6 +340,12 @@ impl NovaRewardsContract {
     // -----------------------------------------------------------------------
 
     /// Initializes the contract and records the admin plus migration version state.
+    ///
+    /// # Parameters
+    /// - `admin` – Address authorized for all admin-gated operations.
+    ///
+    /// # Panics
+    /// - `"already initialized"` if called more than once.
     pub fn initialize(env: Env, admin: Address) {
         if env.storage().instance().has(&DataKey::Admin) {
             panic!("already initialized");
@@ -416,7 +445,15 @@ impl NovaRewardsContract {
     }
 
     /// Sets the XLM SAC token address and DEX router address.
-    /// Admin only. Must be called before swap_for_xlm is usable.
+    ///
+    /// Must be called before [`swap_for_xlm`](NovaRewardsContract::swap_for_xlm) is usable.
+    ///
+    /// # Parameters
+    /// - `xlm_token` – Address of the XLM Stellar Asset Contract (SAC).
+    /// - `router` – Address of the DEX router contract for multi-hop swaps.
+    ///
+    /// # Authorization
+    /// Admin only.
     pub fn set_swap_config(env: Env, xlm_token: Address, router: Address) {
         Self::require_admin(&env);
         env.storage().instance().set(&DataKey::XlmToken, &xlm_token);
@@ -424,7 +461,15 @@ impl NovaRewardsContract {
     }
 
     /// Assigns a dedicated recovery operator for emergency procedures.
+    ///
+    /// # Parameters
+    /// - `recovery_admin` – Address authorized to call snapshot/restore/recover functions.
+    ///
+    /// # Authorization
     /// Admin only.
+    ///
+    /// # Events
+    /// Emits `("recovery", "operator")` with data `recovery_admin: Address`.
     pub fn set_recovery_admin(env: Env, recovery_admin: Address) {
         Self::require_admin(&env);
         env.storage()
@@ -483,6 +528,29 @@ impl NovaRewardsContract {
 
     /// Burns `nova_amount` Nova points for the caller and exchanges them for
     /// XLM via the configured DEX router.
+    ///
+    /// # Parameters
+    /// - `user` – Address burning Nova points (must authorize).
+    /// - `nova_amount` – Number of Nova points to burn (must be > 0).
+    /// - `min_xlm_out` – Minimum XLM to receive; reverts if slippage exceeds this.
+    /// - `path` – Swap path as a list of token addresses (max 5 hops).
+    ///
+    /// # Returns
+    /// The amount of XLM received from the swap.
+    ///
+    /// # Authorization
+    /// Requires `user` authorization.
+    ///
+    /// # Events
+    /// Emits `("swap", user)` with data `(nova_amount: i128, xlm_received: i128, path: Vec<Address>)`.
+    ///
+    /// # Panics
+    /// - `"nova_amount must be positive"` if `nova_amount <= 0`.
+    /// - `"min_xlm_out must be non-negative"` if `min_xlm_out < 0`.
+    /// - `"path exceeds maximum of 5 hops"` if `path.len() > 5`.
+    /// - `"insufficient Nova balance"` if the user holds fewer points than `nova_amount`.
+    /// - `"router not configured"` if [`set_swap_config`](NovaRewardsContract::set_swap_config) has not been called.
+    /// - `"slippage: received X < min Y"` if the DEX returns fewer XLM than `min_xlm_out`.
     pub fn swap_for_xlm(
         env: Env,
         user: Address,
@@ -547,11 +615,17 @@ impl NovaRewardsContract {
     /// Replaces the contract WASM with `new_wasm_hash`. Admin only.
     ///
     /// - Increments `migration_version` in instance storage.
-    /// - Stores `new_wasm_hash` so `migrate()` can include it in the event.
+    /// - Stores `new_wasm_hash` so [`migrate`](NovaRewardsContract::migrate) can include it in the event.
     /// - Calls `env.deployer().update_current_contract_wasm(new_wasm_hash)`.
     ///
-    /// After this call the caller must invoke `migrate()` to apply any
+    /// After this call the caller must invoke [`migrate`](NovaRewardsContract::migrate) to apply any
     /// data transformations for the new version.
+    ///
+    /// # Parameters
+    /// - `new_wasm_hash` – 32-byte hash of the new contract WASM.
+    ///
+    /// # Authorization
+    /// Admin only.
     pub fn upgrade(env: Env, new_wasm_hash: BytesN<32>) {
         Self::require_admin(&env);
 
@@ -580,6 +654,16 @@ impl NovaRewardsContract {
     ///
     /// Gated: panics if `migrated_version >= migration_version` (already done).
     /// Emits `upgraded` event with the new WASM hash and migration version.
+    ///
+    /// # Authorization
+    /// Admin only.
+    ///
+    /// # Events
+    /// Emits `("upgraded",)` with data `(wasm_hash: BytesN<32>, migration_version: u32)`.
+    ///
+    /// # Panics
+    /// - `"migration already applied"` if `migrated_version >= migration_version`.
+    /// - `"no pending wasm hash"` if [`upgrade`](NovaRewardsContract::upgrade) was not called first.
     pub fn migrate(env: Env) {
         Self::require_admin(&env);
 
@@ -627,11 +711,21 @@ impl NovaRewardsContract {
     // -----------------------------------------------------------------------
 
     /// Test helper that writes a balance directly into contract storage.
+    ///
+    /// # Parameters
+    /// - `user` – Address to update.
+    /// - `amount` – New balance value.
     pub fn set_balance(env: Env, user: Address, amount: i128) {
         Self::write_balance(&env, &user, amount);
     }
 
     /// Returns the raw Nova balance recorded for a user.
+    ///
+    /// # Parameters
+    /// - `user` – Address to query.
+    ///
+    /// # Returns
+    /// Balance in base units. Returns `0` if no balance is recorded.
     pub fn get_balance(env: Env, user: Address) -> i128 {
         Self::read_balance(&env, &user)
     }
@@ -660,6 +754,15 @@ impl NovaRewardsContract {
     // -----------------------------------------------------------------------
 
     /// Updates the annual staking rate in basis points.
+    ///
+    /// # Parameters
+    /// - `rate` – Annual rate in basis points (0–10 000, where 10 000 = 100%).
+    ///
+    /// # Authorization
+    /// Admin only.
+    ///
+    /// # Panics
+    /// - `"rate must be between 0 and 10000 basis points"` if `rate < 0 || rate > 10000`.
     pub fn set_annual_rate(env: Env, rate: i128) {
         Self::require_admin(&env);
         

--- a/contracts/nova_token/src/lib.rs
+++ b/contracts/nova_token/src/lib.rs
@@ -1,10 +1,28 @@
 //! # Nova Token Contract
 //!
-//! A Soroban token contract implementing ERC20-like functionality with:
+//! A Soroban token contract implementing ERC20-like fungible token functionality.
+//!
+//! ## Features
 //! - Token initialization, mint, burn, and transfer
 //! - Approve/allowance functionality and balance tracking
 //! - Events emitted on all state-changing operations
-//! - transfer_from support for allowance-based transfers
+//! - [`transfer_from`](NovaToken::transfer_from) support for allowance-based transfers
+//!
+//! ## Usage
+//! ```ignore
+//! // Initialize
+//! client.initialize(&admin);
+//!
+//! // Mint tokens to a user
+//! client.mint(&user, &1_000_000);
+//!
+//! // Transfer between accounts
+//! client.transfer(&from, &to, &500_000);
+//!
+//! // Approve a spender and use transfer_from
+//! client.approve(&owner, &spender, &200_000);
+//! client.transfer_from(&spender, &owner, &recipient, &100_000);
+//! ```
 
 #![no_std]
 use soroban_sdk::{contract, contractimpl, contracttype, symbol_short, Address, Env};
@@ -30,6 +48,12 @@ pub struct NovaToken;
 #[contractimpl]
 impl NovaToken {
     /// Initializes the token contract with the admin allowed to mint.
+    ///
+    /// # Parameters
+    /// - `admin` – Address that will be authorized to call [`mint`](NovaToken::mint).
+    ///
+    /// # Panics
+    /// - `"already initialized"` if called more than once.
     pub fn initialize(env: Env, admin: Address) {
         if env.storage().instance().has(&DataKey::Admin) {
             panic!("already initialized");
@@ -72,6 +96,19 @@ impl NovaToken {
     // ========================================
 
     /// Mints new tokens to a recipient.
+    ///
+    /// # Parameters
+    /// - `to` – Recipient address.
+    /// - `amount` – Number of tokens to mint (must be > 0).
+    ///
+    /// # Authorization
+    /// Requires admin authorization.
+    ///
+    /// # Events
+    /// Emits `("nova_tok", "mint")` with data `(to: Address, amount: i128)`.
+    ///
+    /// # Panics
+    /// - `"amount must be positive"` if `amount <= 0`.
     pub fn mint(env: Env, to: Address, amount: i128) {
         Self::admin(&env).require_auth();
         assert!(amount > 0, "amount must be positive");
@@ -86,6 +123,20 @@ impl NovaToken {
     }
 
     /// Burns tokens from the caller's balance.
+    ///
+    /// # Parameters
+    /// - `from` – Address whose tokens are burned.
+    /// - `amount` – Number of tokens to burn (must be > 0).
+    ///
+    /// # Authorization
+    /// Requires `from` authorization.
+    ///
+    /// # Events
+    /// Emits `("nova_tok", "burn")` with data `(from: Address, amount: i128)`.
+    ///
+    /// # Panics
+    /// - `"amount must be positive"` if `amount <= 0`.
+    /// - `"insufficient balance"` if `from` holds fewer tokens than `amount`.
     pub fn burn(env: Env, from: Address, amount: i128) {
         from.require_auth();
         assert!(amount > 0, "amount must be positive");
@@ -102,6 +153,21 @@ impl NovaToken {
     }
 
     /// Transfers tokens between two accounts.
+    ///
+    /// # Parameters
+    /// - `from` – Sender address.
+    /// - `to` – Recipient address.
+    /// - `amount` – Number of tokens to transfer (must be > 0).
+    ///
+    /// # Authorization
+    /// Requires `from` authorization.
+    ///
+    /// # Events
+    /// Emits `("nova_tok", "transfer")` with data `(from: Address, to: Address, amount: i128)`.
+    ///
+    /// # Panics
+    /// - `"amount must be positive"` if `amount <= 0`.
+    /// - `"insufficient balance"` if `from` holds fewer tokens than `amount`.
     pub fn transfer(env: Env, from: Address, to: Address, amount: i128) {
         from.require_auth();
         assert!(amount > 0, "amount must be positive");
@@ -120,7 +186,25 @@ impl NovaToken {
     }
 
     /// Transfer tokens from `from` to `to` using allowance.
-    /// Caller spends allowance from `from`.
+    ///
+    /// The `spender` must have a sufficient allowance granted by `from` via [`approve`](NovaToken::approve).
+    ///
+    /// # Parameters
+    /// - `spender` – Address spending the allowance.
+    /// - `from` – Token owner whose allowance is consumed.
+    /// - `to` – Recipient address.
+    /// - `amount` – Number of tokens to transfer (must be > 0).
+    ///
+    /// # Authorization
+    /// Requires `spender` authorization.
+    ///
+    /// # Events
+    /// Emits `("nova_tok", "transfer_from")` with data `(spender, from, to, amount)`.
+    ///
+    /// # Panics
+    /// - `"amount must be positive"` if `amount <= 0`.
+    /// - `"insufficient allowance"` if spender's allowance is less than `amount`.
+    /// - `"insufficient balance"` if `from` holds fewer tokens than `amount`.
     pub fn transfer_from(env: Env, spender: Address, from: Address, to: Address, amount: i128) {
         spender.require_auth();
         assert!(amount > 0, "amount must be positive");
@@ -160,7 +244,19 @@ impl NovaToken {
     // ========================================
 
     /// Approve `spender` to spend up to `amount` on behalf of `owner`.
-    /// Sets an allowance for a spender on behalf of an owner.
+    ///
+    /// Overwrites any existing allowance. Set `amount` to `0` to revoke.
+    ///
+    /// # Parameters
+    /// - `owner` – Token owner granting the allowance.
+    /// - `spender` – Address authorized to spend.
+    /// - `amount` – Maximum tokens the spender may transfer.
+    ///
+    /// # Authorization
+    /// Requires `owner` authorization.
+    ///
+    /// # Events
+    /// Emits `("nova_tok", "approve")` with data `(owner, spender, amount)`.
     pub fn approve(env: Env, owner: Address, spender: Address, amount: i128) {
         owner.require_auth();
         let key = DataKey::Allowance(owner.clone(), spender.clone());
@@ -177,6 +273,20 @@ impl NovaToken {
     }
 
     /// Increase allowance for `spender` by `amount`.
+    ///
+    /// # Parameters
+    /// - `owner` – Token owner.
+    /// - `spender` – Address whose allowance is increased.
+    /// - `amount` – Amount to add to the existing allowance (must be > 0).
+    ///
+    /// # Authorization
+    /// Requires `owner` authorization.
+    ///
+    /// # Events
+    /// Emits `("nova_tok", "inc_allow")` with data `(owner, spender, new_allowance)`.
+    ///
+    /// # Panics
+    /// - `"amount must be positive"` if `amount <= 0`.
     pub fn increase_allowance(env: Env, owner: Address, spender: Address, amount: i128) {
         owner.require_auth();
         assert!(amount > 0, "amount must be positive");
@@ -197,7 +307,21 @@ impl NovaToken {
         );
     }
 
-    /// Decrease allowance for `spender` by `amount`.
+    /// Decrease allowance for `spender` by `amount`. Saturates at zero.
+    ///
+    /// # Parameters
+    /// - `owner` – Token owner.
+    /// - `spender` – Address whose allowance is decreased.
+    /// - `amount` – Amount to subtract from the existing allowance (must be > 0).
+    ///
+    /// # Authorization
+    /// Requires `owner` authorization.
+    ///
+    /// # Events
+    /// Emits `("nova_tok", "dec_allow")` with data `(owner, spender, new_allowance)`.
+    ///
+    /// # Panics
+    /// - `"amount must be positive"` if `amount <= 0`.
     pub fn decrease_allowance(env: Env, owner: Address, spender: Address, amount: i128) {
         owner.require_auth();
         assert!(amount > 0, "amount must be positive");
@@ -223,11 +347,24 @@ impl NovaToken {
     // ========================================
 
     /// Returns the current token balance for an address.
+    ///
+    /// # Parameters
+    /// - `addr` – Address to query.
+    ///
+    /// # Returns
+    /// Token balance in base units (`i128`). Returns `0` if no balance is recorded.
     pub fn balance(env: Env, addr: Address) -> i128 {
         Self::balance_of(&env, &addr)
     }
 
     /// Returns the remaining allowance recorded for an owner and spender pair.
+    ///
+    /// # Parameters
+    /// - `owner` – Token owner who granted the allowance.
+    /// - `spender` – Address authorized to spend.
+    ///
+    /// # Returns
+    /// Remaining allowance in base units. Returns `0` if no allowance is set.
     pub fn allowance(env: Env, owner: Address, spender: Address) -> i128 {
         let key = DataKey::Allowance(owner, spender);
         let allowance = env.storage().persistent().get(&key).unwrap_or(0);

--- a/contracts/referral/src/lib.rs
+++ b/contracts/referral/src/lib.rs
@@ -1,3 +1,19 @@
+//! # Referral Contract
+//!
+//! Tracks one-time referral relationships and distributes rewards from a funded pool.
+//!
+//! ## Lifecycle
+//! 1. Admin calls [`fund_pool`](ReferralContract::fund_pool) to seed the reward pool.
+//! 2. A new user calls [`register_referral`](ReferralContract::register_referral) to link themselves to a referrer.
+//! 3. Admin calls [`credit_referrer`](ReferralContract::credit_referrer) to pay out the reward.
+//!
+//! ## Usage
+//! ```ignore
+//! client.initialize(&admin);
+//! client.fund_pool(&10_000);
+//! client.register_referral(&referrer, &new_user);
+//! client.credit_referrer(&new_user, &500);
+//! ```
 #![no_std]
 use soroban_sdk::{contract, contractimpl, contracttype, symbol_short, Address, Env};
 
@@ -20,6 +36,13 @@ pub struct ReferralContract;
 #[contractimpl]
 impl ReferralContract {
     /// Initializes the referral contract and resets the reward pool to zero.
+    ///
+    /// # Parameters
+    /// - `admin` – Address authorized to call [`fund_pool`](ReferralContract::fund_pool)
+    ///   and [`credit_referrer`](ReferralContract::credit_referrer).
+    ///
+    /// # Panics
+    /// - `"already initialised"` if called more than once.
     pub fn initialize(env: Env, admin: Address) {
         if env.storage().instance().has(&DataKey::Admin) {
             panic!("already initialised");
@@ -34,6 +57,15 @@ impl ReferralContract {
     }
 
     /// Adds tokens to the referral reward pool.
+    ///
+    /// # Parameters
+    /// - `amount` – Tokens to add (must be > 0).
+    ///
+    /// # Authorization
+    /// Requires admin authorization.
+    ///
+    /// # Panics
+    /// - `"amount must be positive"` if `amount <= 0`.
     pub fn fund_pool(env: Env, amount: i128) {
         Self::admin(&env).require_auth();
         assert!(amount > 0, "amount must be positive");
@@ -48,6 +80,23 @@ impl ReferralContract {
     }
 
     /// Registers a one-time referral relationship for a wallet.
+    ///
+    /// Each wallet can only be referred once. The referred wallet must authorize
+    /// this call to prevent unauthorized referral registration.
+    ///
+    /// # Parameters
+    /// - `referrer` – Address that made the referral.
+    /// - `referred` – New user being referred (must authorize).
+    ///
+    /// # Authorization
+    /// Requires `referred` authorization.
+    ///
+    /// # Events
+    /// Emits `("referral", "ref_reg")` with data `(referrer: Address, referred: Address)`.
+    ///
+    /// # Panics
+    /// - `"cannot refer yourself"` if `referrer == referred`.
+    /// - `"already referred"` if `referred` already has a referrer registered.
     pub fn register_referral(env: Env, referrer: Address, referred: Address) {
         // referred wallet authorises the registration
         referred.require_auth();
@@ -77,6 +126,25 @@ impl ReferralContract {
     }
 
     /// Pays a referral reward from the pool to the stored referrer relationship.
+    ///
+    /// Deducts `reward_amount` from the pool and emits an on-chain credit event.
+    /// In production, the off-chain service listens for this event to trigger
+    /// the actual token transfer.
+    ///
+    /// # Parameters
+    /// - `referred` – The referred wallet whose referrer receives the reward.
+    /// - `reward_amount` – Amount to credit (must be > 0).
+    ///
+    /// # Authorization
+    /// Requires admin authorization.
+    ///
+    /// # Events
+    /// Emits `("referral", "ref_cred")` with data `(referrer: Address, referred: Address, amount: i128)`.
+    ///
+    /// # Panics
+    /// - `"reward_amount must be positive"` if `reward_amount <= 0`.
+    /// - `"no referrer found"` if `referred` has no registered referrer.
+    /// - `"insufficient pool balance"` if the pool holds fewer tokens than `reward_amount`.
     pub fn credit_referrer(env: Env, referred: Address, reward_amount: i128) {
         Self::admin(&env).require_auth();
         assert!(reward_amount > 0, "reward_amount must be positive");

--- a/contracts/reward_pool/src/lib.rs
+++ b/contracts/reward_pool/src/lib.rs
@@ -1,3 +1,22 @@
+//! # Reward Pool Contract
+//!
+//! A shared liquidity pool that merchants deposit into and users withdraw from,
+//! subject to a configurable per-wallet daily withdrawal cap.
+//!
+//! ## Usage
+//! ```ignore
+//! // Admin initializes
+//! client.initialize(&admin);
+//!
+//! // Merchant deposits
+//! client.deposit(&merchant, &50_000);
+//!
+//! // Set a daily limit of 1 000 tokens per wallet
+//! client.set_daily_limit(&1_000);
+//!
+//! // User withdraws
+//! client.withdraw(&user, &500);
+//! ```
 #![no_std]
 use soroban_sdk::{contract, contractimpl, contracttype, symbol_short, Address, Env};
 
@@ -26,6 +45,14 @@ pub struct RewardPoolContract;
 #[contractimpl]
 impl RewardPoolContract {
     /// Initializes the reward pool and stores the admin address.
+    ///
+    /// Sets the initial pool balance to `0` and the daily limit to `i128::MAX` (unlimited).
+    ///
+    /// # Parameters
+    /// - `admin` – Address authorized to call [`set_daily_limit`](RewardPoolContract::set_daily_limit).
+    ///
+    /// # Panics
+    /// - `"already initialised"` if called more than once.
     pub fn initialize(env: Env, admin: Address) {
         if env.storage().instance().has(&DataKey::Admin) {
             panic!("already initialised");
@@ -74,6 +101,19 @@ impl RewardPoolContract {
     }
 
     /// Deposits funds into the shared reward pool.
+    ///
+    /// # Parameters
+    /// - `from` – Address making the deposit (must authorize).
+    /// - `amount` – Amount to deposit (must be > 0).
+    ///
+    /// # Authorization
+    /// Requires `from` authorization.
+    ///
+    /// # Events
+    /// Emits `("rwd_pool", "deposited")` with data `(from: Address, amount: i128)`.
+    ///
+    /// # Panics
+    /// - `"amount must be positive"` if `amount <= 0`.
     pub fn deposit(env: Env, from: Address, amount: i128) {
         from.require_auth();
         assert!(amount > 0, "amount must be positive");
@@ -90,6 +130,24 @@ impl RewardPoolContract {
     }
 
     /// Withdraws funds from the shared reward pool subject to the daily wallet limit.
+    ///
+    /// The 24-hour window resets automatically when 86 400 seconds have elapsed
+    /// since the wallet's last window start.
+    ///
+    /// # Parameters
+    /// - `to` – Recipient address (must authorize).
+    /// - `amount` – Amount to withdraw (must be > 0).
+    ///
+    /// # Authorization
+    /// Requires `to` authorization.
+    ///
+    /// # Events
+    /// Emits `("rwd_pool", "withdrawn")` with data `(to: Address, amount: i128)`.
+    ///
+    /// # Panics
+    /// - `"amount must be positive"` if `amount <= 0`.
+    /// - `"insufficient pool balance"` if the pool holds fewer tokens than `amount`.
+    /// - `"daily withdrawal limit exceeded"` if the wallet's 24-hour usage would exceed the limit.
     pub fn withdraw(env: Env, to: Address, amount: i128) {
         to.require_auth();
         assert!(amount > 0, "amount must be positive");
@@ -121,6 +179,15 @@ impl RewardPoolContract {
     }
 
     /// Updates the per-wallet daily withdrawal cap. Admin only.
+    ///
+    /// # Parameters
+    /// - `limit` – New daily cap in base units (must be > 0).
+    ///
+    /// # Authorization
+    /// Requires admin authorization.
+    ///
+    /// # Panics
+    /// - `"limit must be positive"` if `limit <= 0`.
     pub fn set_daily_limit(env: Env, limit: i128) {
         Self::admin(&env).require_auth();
         assert!(limit > 0, "limit must be positive");

--- a/contracts/vesting/src/lib.rs
+++ b/contracts/vesting/src/lib.rs
@@ -1,3 +1,25 @@
+//! # Vesting Contract
+//!
+//! Linear token vesting with optional cliff periods for beneficiaries.
+//!
+//! ## Lifecycle
+//! 1. Admin calls [`fund_pool`](VestingContract::fund_pool) to deposit tokens.
+//! 2. Admin calls [`create_schedule`](VestingContract::create_schedule) for each beneficiary.
+//! 3. Beneficiary calls [`release`](VestingContract::release) at any time to claim vested tokens.
+//!
+//! ## Vesting Formula
+//! - Before `start_time + cliff_duration`: 0 tokens vested.
+//! - Between cliff and `start_time + total_duration`: linear pro-rata.
+//! - After `start_time + total_duration`: 100% vested.
+//!
+//! ## Usage
+//! ```ignore
+//! client.initialize(&admin);
+//! client.fund_pool(&1_000_000);
+//! let id = client.create_schedule(&beneficiary, &100_000, &start, &cliff, &duration);
+//! // time passes …
+//! let released = client.release(&beneficiary, &id);
+//! ```
 #![no_std]
 use soroban_sdk::{contract, contractimpl, contracttype, symbol_short, Address, Env};
 
@@ -31,6 +53,13 @@ pub struct VestingContract;
 #[contractimpl]
 impl VestingContract {
     /// Initializes the vesting contract and resets its funding pool.
+    ///
+    /// # Parameters
+    /// - `admin` – Address authorized to call [`fund_pool`](VestingContract::fund_pool)
+    ///   and [`create_schedule`](VestingContract::create_schedule).
+    ///
+    /// # Panics
+    /// - `"already initialised"` if called more than once.
     pub fn initialize(env: Env, admin: Address) {
         if env.storage().instance().has(&DataKey::Admin) {
             panic!("already initialised");
@@ -45,6 +74,15 @@ impl VestingContract {
     }
 
     /// Adds tokens to the vesting pool used for future releases.
+    ///
+    /// # Parameters
+    /// - `amount` – Tokens to add to the pool (must be > 0).
+    ///
+    /// # Authorization
+    /// Requires admin authorization.
+    ///
+    /// # Panics
+    /// - `"amount must be positive"` if `amount <= 0`.
     pub fn fund_pool(env: Env, amount: i128) {
         Self::admin(&env).require_auth();
         assert!(amount > 0, "amount must be positive");
@@ -59,6 +97,25 @@ impl VestingContract {
     }
 
     /// Creates a vesting schedule for a beneficiary and returns its schedule id.
+    ///
+    /// Schedule ids are per-beneficiary and start at `0`.
+    ///
+    /// # Parameters
+    /// - `beneficiary` – Address that will receive vested tokens.
+    /// - `total_amount` – Total tokens to vest (must be > 0).
+    /// - `start_time` – Unix timestamp (seconds) when vesting begins.
+    /// - `cliff_duration` – Seconds after `start_time` before any tokens vest.
+    /// - `total_duration` – Total vesting period in seconds (must be > 0).
+    ///
+    /// # Returns
+    /// The new schedule id (`u32`) for this beneficiary.
+    ///
+    /// # Authorization
+    /// Requires admin authorization.
+    ///
+    /// # Panics
+    /// - `"total_duration must be > 0"` if `total_duration == 0`.
+    /// - `"total_amount must be > 0"` if `total_amount <= 0`.
     pub fn create_schedule(
         env: Env,
         beneficiary: Address,
@@ -107,6 +164,24 @@ impl VestingContract {
     }
 
     /// Releases the newly vested portion of a schedule.
+    ///
+    /// Computes the releasable amount (`vested - already_released`) and transfers
+    /// it from the pool to the beneficiary.
+    ///
+    /// # Parameters
+    /// - `beneficiary` – Address that owns the schedule.
+    /// - `schedule_id` – Id of the schedule to release from.
+    ///
+    /// # Returns
+    /// The number of tokens released in this call.
+    ///
+    /// # Events
+    /// Emits `("vesting", "tok_rel")` with data `(beneficiary: Address, amount: i128, timestamp: u64)`.
+    ///
+    /// # Panics
+    /// - `"schedule not found"` if no schedule exists for the given beneficiary and id.
+    /// - `"nothing to release"` if no new tokens have vested since the last release.
+    /// - `"insufficient pool balance"` if the pool holds fewer tokens than the releasable amount.
     pub fn release(env: Env, beneficiary: Address, schedule_id: u32) -> i128 {
         let key = DataKey::Schedule(beneficiary.clone(), schedule_id);
         let mut schedule: VestingSchedule = env
@@ -151,6 +226,9 @@ impl VestingContract {
     }
 
     /// Returns the stored schedule for a beneficiary and schedule id.
+    ///
+    /// # Panics
+    /// - `"schedule not found"` if no schedule exists for the given beneficiary and id.
     pub fn get_schedule(env: Env, beneficiary: Address, schedule_id: u32) -> VestingSchedule {
         let key = DataKey::Schedule(beneficiary, schedule_id);
         let schedule = env

--- a/docs/TABLE_OF_CONTENTS.md
+++ b/docs/TABLE_OF_CONTENTS.md
@@ -20,3 +20,15 @@ Issues related to README, specs, and developer guides.
 
 ## 7. UI/UX Design Issues
 Issues related to wireframes, prototypes, and design systems.
+
+---
+
+## Smart Contract Documentation
+
+| Document | Description |
+|----------|-------------|
+| [contracts.md](contracts.md) | Contract addresses for testnet and mainnet, deploy instructions, and upgrade process |
+| [abi-reference.md](abi-reference.md) | Full function signatures, event schemas (topics + data), and integration examples for all 8 contracts |
+| [error-codes.md](error-codes.md) | Error message reference with description and remediation for every panic in all contracts |
+| [contract-events.md](contract-events.md) | Quick-reference event schema table |
+| [storage-schema.md](storage-schema.md) | On-chain storage key layout for all contracts |

--- a/docs/abi-reference.md
+++ b/docs/abi-reference.md
@@ -1,0 +1,382 @@
+# ABI Reference
+
+Complete function signatures and event schemas for all Nova Rewards Soroban smart contracts.
+
+All events follow the Soroban convention:
+
+```
+topics : (contract_namespace: Symbol, event_type: Symbol)
+data   : tuple of relevant fields
+```
+
+Symbol keys use `symbol_short!` (≤ 9 ASCII chars). No sensitive data is ever included in event payloads.
+
+---
+
+## nova-rewards
+
+**Crate:** `nova-rewards`  
+**Purpose:** Core rewards contract — user balances, staking, cross-asset swaps, emergency recovery, and WASM upgrades.
+
+### Functions
+
+| Function | Signature | Auth | Description |
+|----------|-----------|------|-------------|
+| `initialize` | `(admin: Address)` | — | One-time setup; sets admin and migration state. |
+| `pause` | `(procedure: Symbol)` | Admin | Pauses all state-changing operations. |
+| `resume` | `()` | Admin | Resumes normal operations after recovery. |
+| `emergency_pause` | `(duration_secs: u64)` | Admin | Pauses with auto-expiry after `duration_secs`. |
+| `unpause` | `()` | Admin | Clears the pause flag immediately. |
+| `is_paused` | `() → bool` | — | Returns current pause state. |
+| `set_swap_config` | `(xlm_token: Address, router: Address)` | Admin | Configures XLM SAC and DEX router for swaps. |
+| `set_recovery_admin` | `(recovery_admin: Address)` | Admin | Assigns a dedicated recovery operator. |
+| `get_recovery_admin` | `() → Address` | — | Returns the recovery admin address. |
+| `swap_for_xlm` | `(user: Address, nova_amount: i128, min_xlm_out: i128, path: Vec<Address>) → i128` | `user` | Burns Nova points and swaps for XLM. |
+| `upgrade` | `(new_wasm_hash: BytesN<32>)` | Admin | Replaces contract WASM; increments migration version. |
+| `migrate` | `()` | Admin | Applies data migrations for the pending version. |
+| `set_balance` | `(user: Address, amount: i128)` | — | Test helper: writes balance directly. |
+| `get_balance` | `(user: Address) → i128` | — | Returns user's Nova balance. |
+| `get_migration_version` | `() → u32` | — | Returns target migration version. |
+| `get_migrated_version` | `() → u32` | — | Returns last completed migration version. |
+| `calc_payout` | `(balance: i128, rate: i128) → i128` | — | Fixed-point payout calculation helper. |
+| `set_annual_rate` | `(rate: i128)` | Admin | Sets staking APY in basis points (0–10 000). |
+| `get_annual_rate` | `() → i128` | — | Returns current annual staking rate. |
+| `stake` | `(staker: Address, amount: i128)` | `staker` | Stakes Nova tokens to earn yield. |
+| `unstake` | `(staker: Address) → i128` | `staker` | Unstakes and returns principal + yield. |
+| `get_stake` | `(staker: Address) → Option<StakeRecord>` | — | Returns active stake record. |
+| `calculate_yield` | `(staker: Address) → i128` | — | Computes accrued yield without unstaking. |
+| `snapshot_account` | `(user: Address, operation_id: BytesN<32>) → AccountSnapshot` | Recovery Admin | Captures restorable state snapshot. |
+| `get_account_snapshot` | `(user: Address) → Option<AccountSnapshot>` | — | Returns stored snapshot. |
+| `restore_account` | `(user: Address, operation_id: BytesN<32>) → AccountSnapshot` | Recovery Admin | Restores snapshot (contract must be paused). |
+| `recover_transaction` | `(user: Address, amount_delta: i128, operation_id: BytesN<32>) → i128` | Recovery Admin | Applies compensating balance delta (paused only). |
+| `recover_funds` | `(from: Address, to: Address, amount: i128, operation_id: BytesN<32>)` | Recovery Admin | Moves funds between balances (paused only). |
+| `get_recovery_operation` | `(operation_id: BytesN<32>) → Option<RecoveryOperation>` | — | Returns a recorded recovery operation. |
+
+### Events
+
+| Event | Topics | Data |
+|-------|--------|------|
+| Paused | `("paused",)` | `()` |
+| Unpaused | `("unpaused",)` | `()` |
+| Emergency pause | `("emrg_paus",)` | `expiry: u64` |
+| Recovery operator set | `("recovery", "operator")` | `recovery_admin: Address` |
+| Recovery paused | `("recovery", "paused")` | `(procedure: Symbol, timestamp: u64)` |
+| Recovery resumed | `("recovery", "resumed")` | `timestamp: u64` |
+| Swap | `("swap", user: Address)` | `(nova_amount: i128, xlm_received: i128, path: Vec<Address>)` |
+| Upgraded | `("upgraded",)` | `(wasm_hash: BytesN<32>, migration_version: u32)` |
+| Staked | `("staked", staker: Address)` | `(amount: i128, staked_at: u64)` |
+| Unstaked | `("unstaked", staker: Address)` | `(principal: i128, yield_amount: i128, timestamp: u64)` |
+| Snapshot | `("recovery", "snapshot")` | `(user: Address, balance: i128, captured_at: u64)` |
+| Restore | `("recovery", "restore")` | `(user: Address, balance: i128, timestamp: u64)` |
+| Recover TX | `("recovery", "tx")` | `(user: Address, amount_delta: i128, new_balance: i128)` |
+| Recover funds | `("recovery", "funds")` | `(from: Address, to: Address, amount: i128)` |
+
+---
+
+## nova_token
+
+**Crate:** `nova_token`  
+**Purpose:** ERC20-like fungible token with mint, burn, transfer, and allowance support.
+
+### Functions
+
+| Function | Signature | Auth | Description |
+|----------|-----------|------|-------------|
+| `initialize` | `(admin: Address)` | — | One-time setup; sets the mint admin. |
+| `mint` | `(to: Address, amount: i128)` | Admin | Mints new tokens to `to`. |
+| `burn` | `(from: Address, amount: i128)` | `from` | Burns tokens from `from`'s balance. |
+| `transfer` | `(from: Address, to: Address, amount: i128)` | `from` | Transfers tokens between accounts. |
+| `transfer_from` | `(spender: Address, from: Address, to: Address, amount: i128)` | `spender` | Transfers using spender's allowance. |
+| `approve` | `(owner: Address, spender: Address, amount: i128)` | `owner` | Sets allowance for `spender`. |
+| `increase_allowance` | `(owner: Address, spender: Address, amount: i128)` | `owner` | Adds to existing allowance. |
+| `decrease_allowance` | `(owner: Address, spender: Address, amount: i128)` | `owner` | Subtracts from existing allowance (saturates at 0). |
+| `balance` | `(addr: Address) → i128` | — | Returns token balance. |
+| `allowance` | `(owner: Address, spender: Address) → i128` | — | Returns remaining allowance. |
+
+### Events
+
+| Event | Topics | Data |
+|-------|--------|------|
+| Mint | `("nova_tok", "mint")` | `(to: Address, amount: i128)` |
+| Burn | `("nova_tok", "burn")` | `(from: Address, amount: i128)` |
+| Transfer | `("nova_tok", "transfer")` | `(from: Address, to: Address, amount: i128)` |
+| Transfer From | `("nova_tok", "transfer_from")` | `(spender: Address, from: Address, to: Address, amount: i128)` |
+| Approve | `("nova_tok", "approve")` | `(owner: Address, spender: Address, amount: i128)` |
+| Increase Allowance | `("nova_tok", "inc_allow")` | `(owner: Address, spender: Address, new_allowance: i128)` |
+| Decrease Allowance | `("nova_tok", "dec_allow")` | `(owner: Address, spender: Address, new_allowance: i128)` |
+
+---
+
+## governance
+
+**Crate:** `governance`  
+**Purpose:** On-chain governance for protocol parameter changes via proposal → vote → finalise → execute lifecycle.
+
+### Functions
+
+| Function | Signature | Auth | Description |
+|----------|-----------|------|-------------|
+| `initialize` | `(admin: Address)` | — | One-time setup; sets the execution admin. |
+| `create_proposal` | `(proposer: Address, title: String, description: String) → u32` | `proposer` | Creates a new proposal; returns its id. |
+| `vote` | `(voter: Address, proposal_id: u32, support: bool)` | `voter` | Casts a yes/no vote on an active proposal. |
+| `finalise` | `(proposal_id: u32)` | — | Tallies votes after the voting period ends. |
+| `execute` | `(proposal_id: u32)` | Admin | Marks a passed proposal as executed. |
+| `get_proposal` | `(proposal_id: u32) → Proposal` | — | Returns the full proposal struct. |
+| `proposal_count` | `() → u32` | — | Returns total number of proposals. |
+| `has_voted` | `(proposal_id: u32, voter: Address) → bool` | — | Returns whether an address has voted. |
+
+### Events
+
+| Event | Topics | Data |
+|-------|--------|------|
+| Proposal created | `("gov", "proposed")` | `(id: u32, proposer: Address, title: String)` |
+| Vote cast | `("gov", "voted")` | `(proposal_id: u32, voter: Address, support: bool)` |
+| Finalised | `("gov", "finalised")` | `(proposal_id: u32, passed: bool)` |
+| Executed | `("gov", "executed")` | `(proposal_id: u32, proposer: Address)` |
+
+### Types
+
+```rust
+pub enum ProposalStatus { Active, Passed, Rejected, Executed }
+
+pub struct Proposal {
+    pub id: u32,
+    pub proposer: Address,
+    pub title: String,
+    pub description: String,
+    pub yes_votes: u32,
+    pub no_votes: u32,
+    pub end_ledger: u32,
+    pub status: ProposalStatus,
+}
+```
+
+---
+
+## reward_pool
+
+**Crate:** `reward_pool`  
+**Purpose:** Shared liquidity pool with per-wallet daily withdrawal caps.
+
+### Functions
+
+| Function | Signature | Auth | Description |
+|----------|-----------|------|-------------|
+| `initialize` | `(admin: Address)` | — | One-time setup; sets admin and unlimited daily limit. |
+| `deposit` | `(from: Address, amount: i128)` | `from` | Deposits tokens into the pool. |
+| `withdraw` | `(to: Address, amount: i128)` | `to` | Withdraws tokens subject to daily limit. |
+| `set_daily_limit` | `(limit: i128)` | Admin | Updates per-wallet daily withdrawal cap. |
+| `get_balance` | `() → i128` | — | Returns total pool balance. |
+| `get_daily_limit` | `() → i128` | — | Returns configured daily cap. |
+| `get_daily_usage` | `(wallet: Address) → DailyUsage` | — | Returns wallet's 24-hour usage. |
+
+### Events
+
+| Event | Topics | Data |
+|-------|--------|------|
+| Deposited | `("rwd_pool", "deposited")` | `(from: Address, amount: i128)` |
+| Withdrawn | `("rwd_pool", "withdrawn")` | `(to: Address, amount: i128)` |
+
+### Types
+
+```rust
+pub struct DailyUsage {
+    pub amount: i128,       // tokens withdrawn in current window
+    pub window_start: u64,  // Unix timestamp of window start
+}
+```
+
+---
+
+## vesting
+
+**Crate:** `vesting`  
+**Purpose:** Linear token vesting with optional cliff periods.
+
+### Functions
+
+| Function | Signature | Auth | Description |
+|----------|-----------|------|-------------|
+| `initialize` | `(admin: Address)` | — | One-time setup; resets pool to 0. |
+| `fund_pool` | `(amount: i128)` | Admin | Adds tokens to the vesting pool. |
+| `create_schedule` | `(beneficiary: Address, total_amount: i128, start_time: u64, cliff_duration: u64, total_duration: u64) → u32` | Admin | Creates a vesting schedule; returns schedule id. |
+| `release` | `(beneficiary: Address, schedule_id: u32) → i128` | — | Releases newly vested tokens to beneficiary. |
+| `get_schedule` | `(beneficiary: Address, schedule_id: u32) → VestingSchedule` | — | Returns the stored schedule. |
+| `pool_balance` | `() → i128` | — | Returns remaining pool balance. |
+
+### Events
+
+| Event | Topics | Data |
+|-------|--------|------|
+| Tokens released | `("vesting", "tok_rel")` | `(beneficiary: Address, amount: i128, timestamp: u64)` |
+
+### Types
+
+```rust
+pub struct VestingSchedule {
+    pub beneficiary: Address,
+    pub total_amount: i128,
+    pub start_time: u64,
+    pub cliff_duration: u64,
+    pub total_duration: u64,
+    pub released: i128,
+}
+```
+
+---
+
+## referral
+
+**Crate:** `referral`  
+**Purpose:** One-time referral relationship tracking with reward pool payouts.
+
+### Functions
+
+| Function | Signature | Auth | Description |
+|----------|-----------|------|-------------|
+| `initialize` | `(admin: Address)` | — | One-time setup; resets pool to 0. |
+| `fund_pool` | `(amount: i128)` | Admin | Adds tokens to the reward pool. |
+| `register_referral` | `(referrer: Address, referred: Address)` | `referred` | Registers a one-time referral link. |
+| `get_referrer` | `(referred: Address) → Option<Address>` | — | Returns the referrer for a wallet. |
+| `credit_referrer` | `(referred: Address, reward_amount: i128)` | Admin | Pays reward from pool to referrer. |
+| `total_referrals` | `(referrer: Address) → u32` | — | Returns referrer's total referral count. |
+| `pool_balance` | `() → i128` | — | Returns remaining pool balance. |
+
+### Events
+
+| Event | Topics | Data |
+|-------|--------|------|
+| Referral registered | `("referral", "ref_reg")` | `(referrer: Address, referred: Address)` |
+| Referrer credited | `("referral", "ref_cred")` | `(referrer: Address, referred: Address, amount: i128)` |
+
+---
+
+## distribution
+
+**Crate:** `distribution`  
+**Purpose:** Admin-controlled token distribution with batch support and 30-day clawback window.
+
+### Functions
+
+| Function | Signature | Auth | Description |
+|----------|-----------|------|-------------|
+| `initialize` | `(admin: Address, token_id: Address)` | — | One-time setup with Nova token address. |
+| `calculate_reward` | `(base_amount: i128, rate_bps: i128) → i128` | — | Fixed-point reward calculation (rate in basis points). |
+| `distribute` | `(recipient: Address, amount: i128)` | Admin | Distributes tokens to a single recipient. |
+| `distribute_batch` | `(recipients: Vec<Address>, amounts: Vec<i128>)` | Admin | Distributes to up to 50 recipients in one call. |
+| `clawback` | `(recipient: Address)` | Admin | Reclaims tokens within 30-day window. |
+| `get_distributed` | `(recipient: Address) → i128` | — | Returns amount distributed to recipient. |
+| `get_clawback_deadline` | `(recipient: Address) → u64` | — | Returns clawback deadline timestamp. |
+| `contract_balance` | `() → i128` | — | Returns contract's Nova token balance. |
+
+### Events
+
+| Event | Topics | Data |
+|-------|--------|------|
+| Distributed | `("dist", recipient: Address)` | `(amount: i128, deadline: u64)` |
+| Clawback | `("clawback", recipient: Address)` | `amount: i128` |
+
+---
+
+## admin_roles
+
+**Crate:** `admin_roles`  
+**Purpose:** Centralized access control with two-step admin transfer and multisig configuration.
+
+### Functions
+
+| Function | Signature | Auth | Description |
+|----------|-----------|------|-------------|
+| `initialize` | `(admin: Address, signers: Vec<Address>, threshold: u32)` | — | One-time setup with admin and multisig config. |
+| `propose_admin` | `(new_admin: Address)` | Admin | Initiates two-step admin transfer. |
+| `accept_admin` | `()` | Pending Admin | Completes the admin transfer. |
+| `update_threshold` | `(threshold: u32)` | Admin | Updates multisig approval threshold. |
+| `update_signers` | `(signers: Vec<Address>)` | Admin | Replaces the multisig signer set. |
+| `mint` | `(_to: Address, _amount: i128)` | Admin | Privileged mint stub (admin-gated). |
+| `withdraw` | `(_to: Address, _amount: i128)` | Admin | Privileged withdrawal stub (admin-gated). |
+| `update_rate` | `(_rate: u32)` | Admin | Privileged rate update stub (admin-gated). |
+| `pause` | `()` | Admin | Privileged pause stub (admin-gated). |
+| `get_admin` | `() → Address` | — | Returns the active admin address. |
+| `get_pending_admin` | `() → Option<Address>` | — | Returns pending admin if transfer is in progress. |
+| `get_threshold` | `() → u32` | — | Returns multisig threshold (default: 1). |
+| `get_signers` | `() → Vec<Address>` | — | Returns configured signer set. |
+
+### Events
+
+| Event | Topics | Data |
+|-------|--------|------|
+| Admin proposed | `("adm_roles", "adm_prop")` | `(current_admin: Address, proposed: Address)` |
+| Admin transferred | `("adm_roles", "adm_xfer")` | `(old_admin: Address, new_admin: Address)` |
+
+---
+
+## Integration Examples
+
+### JavaScript / TypeScript (Stellar SDK)
+
+```typescript
+import { Contract, SorobanRpc, TransactionBuilder, Networks, BASE_FEE } from "@stellar/stellar-sdk";
+
+const server = new SorobanRpc.Server("https://soroban-testnet.stellar.org");
+
+// Read a user's Nova balance
+async function getBalance(contractId: string, userAddress: string) {
+  const contract = new Contract(contractId);
+  const tx = new TransactionBuilder(sourceAccount, {
+    fee: BASE_FEE,
+    networkPassphrase: Networks.TESTNET,
+  })
+    .addOperation(contract.call("get_balance", userAddress))
+    .setTimeout(30)
+    .build();
+
+  const result = await server.simulateTransaction(tx);
+  return result; // i128 balance
+}
+
+// Listen for distribution events
+async function watchDistributionEvents(contractId: string) {
+  const events = await server.getEvents({
+    startLedger: 1000000,
+    filters: [{
+      type: "contract",
+      contractIds: [contractId],
+      topics: [["dist"]],
+    }],
+  });
+
+  for (const event of events.events) {
+    const [amount, deadline] = event.value.value();
+    console.log(`Distributed ${amount} tokens, clawback deadline: ${deadline}`);
+  }
+}
+```
+
+### Stellar CLI
+
+```bash
+# Check pool balance
+stellar contract invoke \
+  --id <REWARD_POOL_CONTRACT_ID> \
+  --network testnet \
+  -- get_balance
+
+# Register a referral
+stellar contract invoke \
+  --id <REFERRAL_CONTRACT_ID> \
+  --source referred_wallet \
+  --network testnet \
+  -- register_referral \
+  --referrer <REFERRER_ADDRESS> \
+  --referred <REFERRED_ADDRESS>
+
+# Create a governance proposal
+stellar contract invoke \
+  --id <GOVERNANCE_CONTRACT_ID> \
+  --source proposer_wallet \
+  --network testnet \
+  -- create_proposal \
+  --proposer <PROPOSER_ADDRESS> \
+  --title "Increase reward rate" \
+  --description "Raise base reward rate from 1% to 2%"
+```

--- a/docs/contracts.md
+++ b/docs/contracts.md
@@ -1,0 +1,160 @@
+# Contract Addresses
+
+All Nova Rewards smart contracts are deployed on the Stellar network using the Soroban runtime.
+
+## Networks
+
+| Network | RPC Endpoint | Explorer |
+|---------|-------------|---------|
+| Testnet | `https://soroban-testnet.stellar.org` | [Stellar Expert (Testnet)](https://stellar.expert/explorer/testnet) |
+| Mainnet | `https://soroban-mainnet.stellar.org` | [Stellar Expert (Mainnet)](https://stellar.expert/explorer/public) |
+
+---
+
+## Contract Addresses
+
+> **Note:** Addresses below are placeholders. Replace with actual deployed contract IDs after running `stellar contract deploy`.
+
+### Testnet
+
+| Contract | Contract ID | Deployed At (Ledger) | Version |
+|----------|------------|----------------------|---------|
+| `nova-rewards` | `CXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX` | — | 1.0.0 |
+| `nova_token` | `CXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX` | — | 1.0.0 |
+| `governance` | `CXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX` | — | 1.0.0 |
+| `reward_pool` | `CXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX` | — | 1.0.0 |
+| `vesting` | `CXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX` | — | 1.0.0 |
+| `referral` | `CXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX` | — | 1.0.0 |
+| `distribution` | `CXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX` | — | 1.0.0 |
+| `admin_roles` | `CXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX` | — | 1.0.0 |
+
+### Mainnet
+
+| Contract | Contract ID | Deployed At (Ledger) | Version |
+|----------|------------|----------------------|---------|
+| `nova-rewards` | `CXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX` | — | — |
+| `nova_token` | `CXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX` | — | — |
+| `governance` | `CXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX` | — | — |
+| `reward_pool` | `CXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX` | — | — |
+| `vesting` | `CXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX` | — | — |
+| `referral` | `CXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX` | — | — |
+| `distribution` | `CXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX` | — | — |
+| `admin_roles` | `CXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX` | — | — |
+
+---
+
+## Deploying Contracts
+
+### Prerequisites
+
+```bash
+# Install Stellar CLI
+cargo install stellar-cli --features opt
+
+# Configure testnet identity
+stellar keys generate deployer --network testnet
+stellar keys fund deployer --network testnet
+```
+
+### Build
+
+```bash
+cd contracts
+cargo build --release --target wasm32-unknown-unknown
+```
+
+Or use the provided script:
+
+```bash
+./scripts/build-contracts.sh
+```
+
+### Deploy (Testnet)
+
+```bash
+# Deploy nova_token
+stellar contract deploy \
+  --wasm target/wasm32-unknown-unknown/release/nova_token.wasm \
+  --source deployer \
+  --network testnet
+
+# Deploy nova-rewards
+stellar contract deploy \
+  --wasm target/wasm32-unknown-unknown/release/nova_rewards.wasm \
+  --source deployer \
+  --network testnet
+```
+
+Repeat for each contract. Record the returned contract IDs and update the tables above.
+
+### Initialize After Deploy
+
+Each contract requires a one-time `initialize` call:
+
+```bash
+# Initialize nova_token
+stellar contract invoke \
+  --id <NOVA_TOKEN_CONTRACT_ID> \
+  --source deployer \
+  --network testnet \
+  -- initialize \
+  --admin <ADMIN_ADDRESS>
+
+# Initialize distribution (requires token address)
+stellar contract invoke \
+  --id <DISTRIBUTION_CONTRACT_ID> \
+  --source deployer \
+  --network testnet \
+  -- initialize \
+  --admin <ADMIN_ADDRESS> \
+  --token_id <NOVA_TOKEN_CONTRACT_ID>
+```
+
+---
+
+## Contract Dependencies
+
+```
+admin_roles          (standalone)
+nova_token           (standalone)
+reward_pool          (standalone)
+vesting              (standalone)
+referral             (standalone)
+governance           (standalone)
+distribution    ──►  nova_token  (calls transfer / transfer_from)
+nova-rewards    ──►  DEX router  (calls swap_exact_in via set_swap_config)
+```
+
+---
+
+## Upgrade Process
+
+Contracts support in-place WASM upgrades via the two-step `upgrade` → `migrate` pattern:
+
+```bash
+# 1. Build new WASM
+cargo build --release --target wasm32-unknown-unknown
+
+# 2. Upload new WASM and get hash
+stellar contract install \
+  --wasm target/wasm32-unknown-unknown/release/nova_rewards.wasm \
+  --source deployer \
+  --network testnet
+
+# 3. Trigger upgrade (admin only)
+stellar contract invoke \
+  --id <CONTRACT_ID> \
+  --source admin \
+  --network testnet \
+  -- upgrade \
+  --new_wasm_hash <WASM_HASH>
+
+# 4. Run migration (admin only)
+stellar contract invoke \
+  --id <CONTRACT_ID> \
+  --source admin \
+  --network testnet \
+  -- migrate
+```
+
+See [upgrade-guide.md](upgrade-guide.md) for full details.

--- a/docs/error-codes.md
+++ b/docs/error-codes.md
@@ -1,0 +1,184 @@
+# Error Code Reference
+
+All Nova Rewards Soroban contracts use `panic!` with a string message as the error mechanism.
+Soroban surfaces these as `InvokeHostFunctionTrapped` with the panic message in the diagnostic events.
+
+> **Tip:** When a transaction fails, check the `diagnosticEvents` field in the simulation or transaction result for the panic message.
+
+---
+
+## How to Read Errors
+
+```typescript
+// Stellar SDK: catch and inspect errors
+try {
+  await server.simulateTransaction(tx);
+} catch (e) {
+  // e.message contains the panic string, e.g. "insufficient balance"
+  console.error("Contract error:", e.message);
+}
+```
+
+---
+
+## Error Reference
+
+### nova-rewards
+
+| Error Message | Contract Function(s) | Description | Remediation |
+|---------------|---------------------|-------------|-------------|
+| `"already initialized"` | `initialize` | Contract has already been initialized. | Call `initialize` only once after deployment. |
+| `"contract is paused"` | All state-changing functions | The contract is in a paused state. | Wait for admin to call `resume` or `unpause`, or check `is_paused()`. |
+| `"contract must be paused"` | `restore_account`, `recover_transaction`, `recover_funds` | Recovery operations require the contract to be paused first. | Admin must call `pause` before executing recovery operations. |
+| `"duration must be > 0"` | `emergency_pause` | Emergency pause duration must be a positive number of seconds. | Pass a `duration_secs` value greater than 0. |
+| `"not initialized"` | All functions | Contract storage has no admin set. | Call `initialize` first. |
+| `"nova_amount must be positive"` | `swap_for_xlm` | Swap amount must be greater than zero. | Pass a positive `nova_amount`. |
+| `"min_xlm_out must be non-negative"` | `swap_for_xlm` | Slippage floor cannot be negative. | Pass `min_xlm_out >= 0`. |
+| `"path exceeds maximum of 5 hops"` | `swap_for_xlm` | Swap path is too long. | Reduce the swap path to at most 5 token addresses. |
+| `"insufficient Nova balance"` | `swap_for_xlm` | User does not have enough Nova points to burn. | Check `get_balance` before calling `swap_for_xlm`. |
+| `"router not configured"` | `swap_for_xlm` | DEX router address has not been set. | Admin must call `set_swap_config` before swaps are available. |
+| `"slippage: received X < min Y"` | `swap_for_xlm` | DEX returned fewer XLM than the minimum specified. | Increase `min_xlm_out` tolerance or retry when market conditions improve. |
+| `"migration already applied"` | `migrate` | The current migration version has already been run. | Do not call `migrate` twice for the same version. |
+| `"no pending wasm hash"` | `migrate` | `upgrade` was not called before `migrate`. | Call `upgrade` with the new WASM hash first. |
+| `"rate must be between 0 and 10000 basis points"` | `set_annual_rate` | Staking rate is out of the valid range. | Pass a rate between `0` and `10000` (inclusive). |
+| `"amount must be positive"` | `stake` | Stake amount must be greater than zero. | Pass a positive `amount`. |
+| `"user already has an active stake"` | `stake` | The staker already has an open stake position. | Call `unstake` to close the existing position before staking again. |
+| `"insufficient balance for staking"` | `stake` | User's balance is less than the requested stake amount. | Check `get_balance` and ensure sufficient funds before staking. |
+| `"no active stake found"` | `unstake` | The staker has no open stake position. | Only call `unstake` after a successful `stake`. |
+| `"snapshot not found"` | `restore_account` | No snapshot exists for the given user. | Call `snapshot_account` before attempting a restore. |
+| `"recovery would overdraw balance"` | `recover_transaction` | Applying the delta would result in a negative balance. | Use a smaller or positive `amount_delta`. |
+| `"insufficient balance for fund recovery"` | `recover_funds` | Source account has insufficient balance for the transfer. | Verify `get_balance(from)` before calling `recover_funds`. |
+
+---
+
+### nova_token
+
+| Error Message | Contract Function(s) | Description | Remediation |
+|---------------|---------------------|-------------|-------------|
+| `"already initialized"` | `initialize` | Token contract already initialized. | Call `initialize` only once. |
+| `"amount must be positive"` | `mint`, `burn`, `transfer`, `transfer_from`, `increase_allowance`, `decrease_allowance` | Token amount must be greater than zero. | Pass a positive `amount`. |
+| `"insufficient balance"` | `burn`, `transfer`, `transfer_from` | Account does not hold enough tokens. | Check `balance(addr)` before the operation. |
+| `"insufficient allowance"` | `transfer_from` | Spender's allowance is less than the requested amount. | Call `approve` or `increase_allowance` to grant sufficient allowance first. |
+
+---
+
+### governance
+
+| Error Message | Contract Function(s) | Description | Remediation |
+|---------------|---------------------|-------------|-------------|
+| `"already initialised"` | `initialize` | Governance contract already initialized. | Call `initialize` only once. |
+| `"proposal not found"` | `vote`, `finalise`, `execute`, `get_proposal` | No proposal exists with the given id. | Verify the proposal id using `proposal_count()`. |
+| `"already voted"` | `vote` | The voter has already cast a vote on this proposal. | Each address may only vote once per proposal. |
+| `"proposal not active"` | `vote`, `finalise` | The proposal is not in `Active` status. | Check `get_proposal(id).status` before voting or finalising. |
+| `"voting period ended"` | `vote` | The current ledger sequence exceeds the proposal's `end_ledger`. | Voting is closed; call `finalise` instead. |
+| `"voting period not ended"` | `finalise` | The voting period has not yet elapsed. | Wait until the ledger sequence exceeds `proposal.end_ledger`. |
+| `"proposal not passed"` | `execute` | The proposal status is not `Passed`. | Only passed proposals can be executed. Check `get_proposal(id).status`. |
+
+---
+
+### reward_pool
+
+| Error Message | Contract Function(s) | Description | Remediation |
+|---------------|---------------------|-------------|-------------|
+| `"already initialised"` | `initialize` | Pool already initialized. | Call `initialize` only once. |
+| `"amount must be positive"` | `deposit`, `withdraw`, `set_daily_limit` | Amount or limit must be greater than zero. | Pass a positive value. |
+| `"insufficient pool balance"` | `withdraw` | The pool holds fewer tokens than the requested withdrawal. | Check `get_balance()` before withdrawing. |
+| `"daily withdrawal limit exceeded"` | `withdraw` | The wallet's 24-hour withdrawal total would exceed the configured cap. | Wait for the 24-hour window to reset, or request a limit increase from the admin. |
+
+---
+
+### vesting
+
+| Error Message | Contract Function(s) | Description | Remediation |
+|---------------|---------------------|-------------|-------------|
+| `"already initialised"` | `initialize` | Vesting contract already initialized. | Call `initialize` only once. |
+| `"amount must be positive"` | `fund_pool` | Pool funding amount must be positive. | Pass a positive `amount`. |
+| `"total_duration must be > 0"` | `create_schedule` | Vesting duration cannot be zero. | Pass a `total_duration` greater than 0. |
+| `"total_amount must be > 0"` | `create_schedule` | Total vesting amount must be positive. | Pass a `total_amount` greater than 0. |
+| `"schedule not found"` | `release`, `get_schedule` | No schedule exists for the given beneficiary and id. | Verify the schedule id returned by `create_schedule`. |
+| `"nothing to release"` | `release` | No new tokens have vested since the last release. | Wait for more time to pass, or check the schedule's cliff and duration. |
+| `"insufficient pool balance"` | `release` | The vesting pool does not hold enough tokens. | Admin must call `fund_pool` to top up the pool. |
+
+---
+
+### referral
+
+| Error Message | Contract Function(s) | Description | Remediation |
+|---------------|---------------------|-------------|-------------|
+| `"already initialised"` | `initialize` | Referral contract already initialized. | Call `initialize` only once. |
+| `"amount must be positive"` | `fund_pool` | Pool funding amount must be positive. | Pass a positive `amount`. |
+| `"cannot refer yourself"` | `register_referral` | Referrer and referred addresses are the same. | Use two distinct addresses. |
+| `"already referred"` | `register_referral` | The referred wallet already has a registered referrer. | Each wallet can only be referred once. |
+| `"reward_amount must be positive"` | `credit_referrer` | Reward amount must be greater than zero. | Pass a positive `reward_amount`. |
+| `"no referrer found"` | `credit_referrer` | The referred wallet has no registered referrer. | Call `register_referral` before crediting. |
+| `"insufficient pool balance"` | `credit_referrer` | The reward pool does not hold enough tokens. | Admin must call `fund_pool` to top up the pool. |
+
+---
+
+### distribution
+
+| Error Message | Contract Function(s) | Description | Remediation |
+|---------------|---------------------|-------------|-------------|
+| `"already initialized"` | `initialize` | Distribution contract already initialized. | Call `initialize` only once. |
+| `"not initialized"` | All functions | Admin or token address not set. | Call `initialize` first. |
+| `"amount must be positive"` | `distribute`, `distribute_batch` | Distribution amount must be positive. | Pass a positive `amount`. |
+| `"insufficient contract balance"` | `distribute` | Contract holds fewer tokens than the requested amount. | Fund the contract with Nova tokens before distributing. |
+| `"recipients and amounts length mismatch"` | `distribute_batch` | The `recipients` and `amounts` vectors have different lengths. | Ensure both vectors have the same number of elements. |
+| `"empty batch"` | `distribute_batch` | The batch is empty. | Provide at least one recipient. |
+| `"batch exceeds maximum of 50"` | `distribute_batch` | More than 50 recipients were provided. | Split into multiple calls of ≤ 50 recipients each. |
+| `"insufficient contract balance for batch"` | `distribute_batch` | Contract cannot cover the total batch amount. | Fund the contract before calling `distribute_batch`. |
+| `"base_amount must be non-negative"` | `calculate_reward` | Base amount for reward calculation is negative. | Pass `base_amount >= 0`. |
+| `"rate_bps must be 0–10 000"` | `calculate_reward` | Rate in basis points is out of range. | Pass a `rate_bps` between `0` and `10000`. |
+| `"no clawback record for recipient"` | `clawback` | No distribution was recorded for this recipient. | Only call `clawback` after a successful `distribute`. |
+| `"clawback window has expired"` | `clawback` | More than 30 days have passed since the distribution. | Clawback is no longer possible after the window expires. |
+| `"nothing to clawback"` | `clawback` | The recorded distribution amount is zero. | The distribution may have already been clawed back. |
+
+---
+
+### admin_roles
+
+| Error Message | Contract Function(s) | Description | Remediation |
+|---------------|---------------------|-------------|-------------|
+| `"already initialised"` | `initialize` | Admin roles contract already initialized. | Call `initialize` only once. |
+| `"no pending admin"` | `accept_admin` | No admin transfer is in progress. | Current admin must call `propose_admin` first. |
+
+---
+
+## Common Patterns
+
+### Checking Before Calling
+
+```typescript
+// Always check balance before withdrawing
+const balance = await client.get_balance({ user: userAddress });
+if (balance < withdrawAmount) {
+  throw new Error("Insufficient balance");
+}
+await client.withdraw({ to: userAddress, amount: withdrawAmount });
+```
+
+### Handling Paused State
+
+```typescript
+const isPaused = await client.is_paused();
+if (isPaused) {
+  console.warn("Contract is paused. Operations are temporarily unavailable.");
+  return;
+}
+```
+
+### Retry on Slippage
+
+```typescript
+async function swapWithRetry(novaAmount: bigint, maxRetries = 3) {
+  for (let i = 0; i < maxRetries; i++) {
+    try {
+      // Reduce min_xlm_out by 1% per retry
+      const minXlm = (expectedXlm * BigInt(99 - i)) / 100n;
+      return await client.swap_for_xlm({ user, nova_amount: novaAmount, min_xlm_out: minXlm, path });
+    } catch (e) {
+      if (!e.message.includes("slippage") || i === maxRetries - 1) throw e;
+    }
+  }
+}
+```


### PR DESCRIPTION
Closes #[issue]                                                                                
                                                                                                 
  Rewrites the root README.md to serve as the definitive entry point for developers, merchants,  
  and contributors.                                                                              
                                                                                                 
  Changes:                                                                                       
                                                                                                 
  - Added all required sections: Overview, Architecture Diagram (Mermaid), Tech Stack, Quick     
  Start, Environment Setup, Contributing, License, and Documentation Index                       
  - Verified all sub-doc links against actual files in the repo                                  
  - Quick start path gets a developer running locally in under 15 minutes                        
  - Env variable table synced with novaRewards/.env.example                                      
  - Scripts, test commands, and Rust toolchain target verified against codebase                  
                                                                                                 
  Area: Documentation | Priority: P1-high | Milestone: MVP
closes #663                                        
                                        