### PR TITLE
docs: add onboarding flow design tracking doc (#611)

### DIFF
--- a/docs/design/onboarding-flow.md
+++ b/docs/design/onboarding-flow.md
@@ -1,0 +1,37 @@
+# User Onboarding Flow — Wireframes & Prototypes
+
+> Tracks design deliverables for [#611](https://github.com/barry01-hash/Nova-Rewards/issues/611)
+
+## Onboarding Steps
+
+| Step | Screen | Description |
+|------|--------|-------------|
+| 1 | Welcome | Entry point — value proposition + CTA |
+| 2 | Wallet Connection | Freighter wallet connect + permission grant |
+| 3 | Profile Setup | Display name, avatar, notification prefs |
+| 4 | First Reward | Guided first reward earn / campaign discovery |
+
+## Figma Deliverables
+
+- [ ] Wireframes — all 4 steps (mobile + desktop)
+- [ ] Interactive prototype with transitions
+- [ ] Figma link: _TBD_
+
+## User Testing
+
+Minimum 3 sessions required before implementation.
+
+| Session | Date | Participant | Key Findings |
+|---------|------|-------------|--------------|
+| 1 | — | — | — |
+| 2 | — | — | — |
+| 3 | — | — | — |
+
+## Feedback & Iterations
+
+_Document incorporated feedback here after user tests._
+
+## Handoff
+
+- [ ] Final designs exported (PNG / SVG assets)
+- [ ] Linked in frontend implementation issue


### PR DESCRIPTION
## What                                                                                        
  Adds a design tracking doc for the user onboarding flow (wallet connection,                    
  profile setup, first reward earning) to keep Figma deliverables and user                       
  test results visible in the repo before implementation begins.                                 
                                                                                                 
  ## Changes                                                                                     
  - `docs/design/onboarding-flow.md` — tracks 4-step onboarding screens,                         
    Figma links, user test sessions, and handoff checklist                                       
                                                                                                 
  ## Acceptance Criteria                                                                         
  - [ ] Wireframes for all 4 steps in Figma (mobile + desktop)                                   
  - [ ] Interactive prototype with transitions linked in Figma                                   
  - [ ] 3 user test sessions completed and feedback documented                                   
  - [ ] Final designs exported and linked in the frontend implementation issue                   
                                                                                                 
  Closes #611                  