### PR TITLE
Feat/596 user onboarding flow

### DIFF
--- a/novaRewards/backend/routes/onboarding.js
+++ b/novaRewards/backend/routes/onboarding.js
@@ -1,0 +1,51 @@
+const router = require('express').Router();
+const { query } = require('../db/index');
+const { authenticateUser } = require('../middleware/authenticateUser');
+
+/**
+ * POST /api/users/onboarding/complete
+ * Marks the authenticated user's onboarding as completed.
+ * Triggers a welcome reward if WELCOME_REWARD_POINTS is configured.
+ */
+router.post('/onboarding/complete', authenticateUser, async (req, res) => {
+  const userId = req.user.id;
+
+  try {
+    // Idempotent: only update if not already completed
+    const result = await query(
+      `UPDATE users
+          SET onboarding_completed = TRUE,
+              onboarding_completed_at = NOW()
+        WHERE id = $1
+          AND (onboarding_completed IS NULL OR onboarding_completed = FALSE)
+        RETURNING id, onboarding_completed_at`,
+      [userId]
+    );
+
+    const justCompleted = result.rows.length > 0;
+
+    // Optional welcome reward — only on first completion
+    const welcomePoints = parseInt(process.env.WELCOME_REWARD_POINTS, 10) || 0;
+    if (justCompleted && welcomePoints > 0) {
+      await query(
+        `INSERT INTO point_transactions (user_id, points, type, description, created_at)
+         VALUES ($1, $2, 'welcome_reward', 'Welcome reward for completing onboarding', NOW())`,
+        [userId, welcomePoints]
+      );
+    }
+
+    return res.status(200).json({
+      success: true,
+      data: {
+        alreadyCompleted: !justCompleted,
+        welcomeRewardGranted: justCompleted && welcomePoints > 0,
+        welcomePoints: justCompleted ? welcomePoints : 0,
+      },
+    });
+  } catch (err) {
+    console.error('onboarding/complete error:', err);
+    return res.status(500).json({ success: false, error: 'server_error', message: 'Failed to record onboarding completion' });
+  }
+});
+
+module.exports = router;

--- a/novaRewards/backend/server.js
+++ b/novaRewards/backend/server.js
@@ -74,6 +74,7 @@ app.use('/api/redemptions', require('./routes/redemptions'));
 app.use('/api/transactions', require('./routes/transactions'));
 app.use('/api/trustline', require('./routes/trustline'));
 app.use('/api/users', require('./routes/users'));
+app.use('/api/users', require('./routes/onboarding'));
 app.use('/api/contract-events', require('./routes/contractEvents'));
 app.use('/api/admin/email-logs', require('./routes/emailLogs'));
 app.use('/api/leaderboard', require('./routes/leaderboard'));

--- a/novaRewards/frontend/components/OnboardingModal.js
+++ b/novaRewards/frontend/components/OnboardingModal.js
@@ -1,0 +1,133 @@
+import Modal from './modal/Modal';
+import { useOnboardingStore } from '../store/onboardingStore';
+
+const STEPS = [
+  {
+    title: 'Connect Your Wallet',
+    description: 'Link your Freighter wallet to start earning NOVA tokens.',
+    icon: (
+      <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2}
+        d="M3 10h18M7 15h1m4 0h1m-7 4h12a3 3 0 003-3V8a3 3 0 00-3-3H6a3 3 0 00-3 3v8a3 3 0 003 3z" />
+    ),
+    skippable: false,
+  },
+  {
+    title: 'Create Your Profile',
+    description: 'Set a display name and avatar so merchants can recognise you.',
+    icon: (
+      <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2}
+        d="M16 7a4 4 0 11-8 0 4 4 0 018 0zM12 14a7 7 0 00-7 7h14a7 7 0 00-7-7z" />
+    ),
+    skippable: true,
+  },
+  {
+    title: 'Explore Campaigns',
+    description: 'Browse active reward campaigns from participating merchants.',
+    icon: (
+      <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2}
+        d="M9 20l-5.447-2.724A1 1 0 013 16.382V5.618a1 1 0 011.447-.894L9 7m0 13l6-3m-6 3V7m6 10l4.553 2.276A1 1 0 0021 18.382V7.618a1 1 0 00-1.447-.894L15 9m0 8V9m0 0L9 7" />
+    ),
+    skippable: true,
+  },
+  {
+    title: 'Earn Your First Reward',
+    description: 'Complete a qualifying action to receive your welcome NOVA tokens.',
+    icon: (
+      <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2}
+        d="M13 10V3L4 14h7v7l9-11h-7z" />
+    ),
+    skippable: false,
+  },
+];
+
+/**
+ * OnboardingModal — 4-step guided flow rendered inside the base Modal portal.
+ * Progress is driven by onboardingStore (Zustand + localStorage).
+ */
+export default function OnboardingModal() {
+  const { isOpen, currentStep, completedSteps, close, completeStep, dismiss, goToStep } =
+    useOnboardingStore();
+
+  const step = STEPS[currentStep];
+  const isLast = currentStep === STEPS.length - 1;
+  const isStepDone = completedSteps.includes(currentStep);
+
+  return (
+    <Modal
+      isOpen={isOpen}
+      onClose={close}
+      size="md"
+      closeOnBackdrop={false}
+      aria-describedby="onboarding-desc"
+    >
+      {/* Step indicators */}
+      <div className="flex items-center justify-between mb-6" role="list" aria-label="Onboarding progress">
+        {STEPS.map((s, i) => (
+          <button
+            key={i}
+            role="listitem"
+            aria-label={`Step ${i + 1}: ${s.title}${completedSteps.includes(i) ? ' (completed)' : i === currentStep ? ' (current)' : ''}`}
+            onClick={() => completedSteps.includes(i) && goToStep(i)}
+            className={[
+              'h-2 rounded-full transition-all focus:outline-none',
+              i === currentStep ? 'w-8 bg-blue-600' : completedSteps.includes(i) ? 'w-2 bg-blue-400' : 'w-2 bg-gray-300',
+              completedSteps.includes(i) ? 'cursor-pointer' : 'cursor-default',
+            ].join(' ')}
+          />
+        ))}
+
+        {step.skippable && (
+          <button
+            onClick={dismiss}
+            className="text-sm text-gray-500 hover:text-gray-700 ml-4 focus:outline-none focus:underline"
+            aria-label="Skip onboarding"
+          >
+            Skip
+          </button>
+        )}
+      </div>
+
+      {/* Illustration */}
+      <div className="w-16 h-16 mx-auto bg-blue-100 rounded-full flex items-center justify-center mb-4" aria-hidden="true">
+        <svg className="w-8 h-8 text-blue-600" fill="none" viewBox="0 0 24 24" stroke="currentColor">
+          {step.icon}
+        </svg>
+      </div>
+
+      {/* Content */}
+      <h2 className="text-xl font-bold text-center mb-1">{step.title}</h2>
+      <p id="onboarding-desc" className="text-sm text-gray-600 text-center mb-6">
+        {step.description}
+      </p>
+
+      {/* Step counter */}
+      <p className="text-xs text-gray-400 text-center mb-4" aria-live="polite">
+        Step {currentStep + 1} of {STEPS.length}
+      </p>
+
+      {/* Actions */}
+      <div className="flex gap-3">
+        {currentStep > 0 && (
+          <button
+            onClick={() => goToStep(currentStep - 1)}
+            className="flex-1 bg-gray-100 text-gray-700 py-2 px-4 rounded-lg font-medium hover:bg-gray-200 transition-colors focus:outline-none focus:ring-2 focus:ring-gray-400"
+          >
+            Back
+          </button>
+        )}
+        <button
+          onClick={() => completeStep(currentStep)}
+          disabled={isStepDone && !isLast}
+          className={[
+            currentStep === 0 ? 'w-full' : 'flex-1',
+            'bg-blue-600 text-white py-2 px-4 rounded-lg font-medium hover:bg-blue-700 transition-colors',
+            'focus:outline-none focus:ring-2 focus:ring-blue-500 disabled:opacity-50',
+          ].join(' ')}
+          aria-label={isLast ? 'Finish onboarding' : 'Continue to next step'}
+        >
+          {isLast ? 'Finish' : 'Continue'}
+        </button>
+      </div>
+    </Modal>
+  );
+}

--- a/novaRewards/frontend/components/Toast.js
+++ b/novaRewards/frontend/components/Toast.js
@@ -1,44 +1,66 @@
-'use client';
+import { useState, useCallback, createContext, useContext } from 'react';
 
-import { useState, useCallback, useEffect } from 'react';
+const ToastContext = createContext(null);
 
-const ToastContext = require('react').createContext(null);
+const ICONS = {
+  success: '✓',
+  error: '✕',
+  warning: '⚠',
+  info: 'ℹ',
+};
+
+const MAX_TOASTS = 3;
+const DEFAULT_DURATION = 5000;
+
+function Toast({ toast, onRemove }) {
+  return (
+    <div
+      role="status"
+      className={`toast toast-${toast.type}`}
+    >
+      <span className="toast-icon" aria-hidden="true">{ICONS[toast.type]}</span>
+      <span className="toast-message">{toast.message}</span>
+      <button
+        className="toast-close"
+        onClick={() => onRemove(toast.id)}
+        aria-label="Dismiss notification"
+      >
+        ✕
+      </button>
+    </div>
+  );
+}
 
 export function ToastProvider({ children }) {
   const [toasts, setToasts] = useState([]);
-
-  const addToast = useCallback((message, type = 'info', duration = 3000) => {
-    const id = Date.now();
-    setToasts((prev) => [...prev, { id, message, type }]);
-
-    if (duration > 0) {
-      setTimeout(() => {
-        setToasts((prev) => prev.filter((t) => t.id !== id));
-      }, duration);
-    }
-
-    return id;
-  }, []);
 
   const removeToast = useCallback((id) => {
     setToasts((prev) => prev.filter((t) => t.id !== id));
   }, []);
 
+  const addToast = useCallback((message, type = 'info', duration = DEFAULT_DURATION) => {
+    const id = Date.now();
+
+    setToasts((prev) => {
+      const next = [...prev, { id, message, type }];
+      // drop oldest if over limit
+      return next.length > MAX_TOASTS ? next.slice(next.length - MAX_TOASTS) : next;
+    });
+
+    if (duration > 0) {
+      setTimeout(() => removeToast(id), duration);
+    }
+
+    return id;
+  }, [removeToast]);
+
   return (
     <ToastContext.Provider value={{ addToast, removeToast }}>
       {children}
-      <div className="toast-container">
+      {/* aria-live region announces toasts to screen readers */}
+      <div className="toast-container" aria-live="polite" aria-atomic="false">
         {toasts.map((toast) => (
-          <div key={toast.id} className={`toast toast-${toast.type}`}>
-            <span>{toast.message}</span>
-            <button
-              className="toast-close"
-              onClick={() => removeToast(toast.id)}
-              aria-label="Close notification"
-            >
-              ✕
-            </button>
-          </div>
+          <Toast key={toast.id} toast={toast} onRemove={removeToast} />
         ))}
       </div>
     </ToastContext.Provider>
@@ -46,9 +68,7 @@ export function ToastProvider({ children }) {
 }
 
 export function useToast() {
-  const context = require('react').useContext(ToastContext);
-  if (!context) {
-    throw new Error('useToast must be used within ToastProvider');
-  }
+  const context = useContext(ToastContext);
+  if (!context) throw new Error('useToast must be used within ToastProvider');
   return context;
 }

--- a/novaRewards/frontend/pages/_app.js
+++ b/novaRewards/frontend/pages/_app.js
@@ -2,12 +2,14 @@ import { useEffect } from 'react';
 import dynamic from 'next/dynamic';
 import { ThemeProvider } from 'next-themes';
 import { WalletProvider } from '../context/WalletContext';
-import { AuthProvider } from '../context/AuthContext';
+import { AuthProvider, useAuth } from '../context/AuthContext';
 import { TourProvider } from '../context/TourContext';
 import { ModalProvider } from '../context/ModalContext';
 import { ToastProvider } from '../components/Toast';
 import { NotificationProvider } from '../context/NotificationContext';
 import Footer from '../components/Footer';
+import OnboardingModal from '../components/OnboardingModal';
+import { useOnboardingStore } from '../store/onboardingStore';
 import '../styles/globals.css';
 import '../styles/redemption.css';
 
@@ -18,6 +20,20 @@ function registerServiceWorker() {
   if (typeof window !== 'undefined' && 'serviceWorker' in navigator) {
     navigator.serviceWorker.register('/sw.js').catch(() => {});
   }
+}
+
+/** Opens the onboarding modal for newly authenticated users. */
+function OnboardingTrigger() {
+  const { isAuthenticated } = useAuth();
+  const { open, isCompleted, isDismissed } = useOnboardingStore();
+
+  useEffect(() => {
+    if (isAuthenticated && !isCompleted && !isDismissed) {
+      open();
+    }
+  }, [isAuthenticated, isCompleted, isDismissed, open]);
+
+  return null;
 }
 
 export default function App({ Component, pageProps }) {
@@ -33,8 +49,10 @@ export default function App({ Component, pageProps }) {
             <WalletProvider>
               <TourProvider>
                 <ModalProvider>
+                  <OnboardingTrigger />
                   <Component {...pageProps} />
                   <Footer />
+                  <OnboardingModal />
                   <OnboardingTour />
                 </ModalProvider>
               </TourProvider>

--- a/novaRewards/frontend/store/onboardingStore.js
+++ b/novaRewards/frontend/store/onboardingStore.js
@@ -1,0 +1,84 @@
+import { create } from 'zustand';
+import { persist, devtools } from 'zustand/middleware';
+import api from '../lib/api';
+
+const TOTAL_STEPS = 4;
+
+/**
+ * onboardingStore tracks the 4-step guided onboarding flow.
+ * Progress is persisted to localStorage and synced to the backend on completion.
+ * Steps: 0=ConnectWallet, 1=CreateProfile, 2=ExploreCampaigns, 3=EarnFirstReward
+ */
+export const useOnboardingStore = create(
+  devtools(
+    persist(
+      (set, get) => ({
+        isOpen: false,
+        currentStep: 0,
+        completedSteps: [],   // array of completed step indices
+        isDismissed: false,   // user explicitly skipped the whole flow
+        isCompleted: false,   // all steps done
+
+        /** Open the modal (only if not already completed/dismissed). */
+        open: () => {
+          const { isCompleted, isDismissed } = get();
+          if (!isCompleted && !isDismissed) set({ isOpen: true }, false, 'onboarding/open');
+        },
+
+        close: () => set({ isOpen: false }, false, 'onboarding/close'),
+
+        /** Mark current step complete and advance. */
+        completeStep: (stepIndex) => {
+          const { completedSteps } = get();
+          if (completedSteps.includes(stepIndex)) return;
+          const next = [...completedSteps, stepIndex];
+          const allDone = next.length === TOTAL_STEPS;
+          set(
+            {
+              completedSteps: next,
+              currentStep: allDone ? stepIndex : stepIndex + 1,
+              isCompleted: allDone,
+              isOpen: !allDone,
+            },
+            false,
+            'onboarding/completeStep'
+          );
+          if (allDone) get()._syncCompletion();
+        },
+
+        goToStep: (step) => set({ currentStep: step }, false, 'onboarding/goToStep'),
+
+        /** Skip the entire flow without completing it. */
+        dismiss: () =>
+          set({ isDismissed: true, isOpen: false }, false, 'onboarding/dismiss'),
+
+        /** Reset — useful for testing or re-triggering. */
+        reset: () =>
+          set(
+            { isOpen: false, currentStep: 0, completedSteps: [], isDismissed: false, isCompleted: false },
+            false,
+            'onboarding/reset'
+          ),
+
+        /** POST completion to backend (fire-and-forget; failures are silent). */
+        _syncCompletion: async () => {
+          try {
+            await api.post('/api/users/onboarding/complete');
+          } catch {
+            // non-critical — localStorage already records completion
+          }
+        },
+      }),
+      {
+        name: 'nova-onboarding',
+        partialize: (s) => ({
+          currentStep: s.currentStep,
+          completedSteps: s.completedSteps,
+          isDismissed: s.isDismissed,
+          isCompleted: s.isCompleted,
+        }),
+      }
+    ),
+    { name: 'OnboardingStore' }
+  )
+);

--- a/novaRewards/frontend/styles/globals.css
+++ b/novaRewards/frontend/styles/globals.css
@@ -1342,3 +1342,73 @@ td {
   gap: 0.75rem;
   flex-wrap: wrap;
 }
+
+/* ── Toast Notifications ─────────────────────────────────────────── */
+.toast-container {
+  position: fixed;
+  bottom: 1.5rem;
+  right: 1.5rem;
+  display: flex;
+  flex-direction: column;
+  gap: 0.625rem;
+  z-index: 9999;
+  max-width: 360px;
+  width: 100%;
+}
+
+.toast {
+  display: flex;
+  align-items: center;
+  gap: 0.625rem;
+  padding: 0.75rem 1rem;
+  border-radius: 0.5rem;
+  font-size: 0.875rem;
+  font-weight: 500;
+  box-shadow: 0 4px 12px rgba(0, 0, 0, 0.15);
+  animation: toast-in 0.2s ease;
+}
+
+@keyframes toast-in {
+  from { opacity: 0; transform: translateY(8px); }
+  to   { opacity: 1; transform: translateY(0); }
+}
+
+.toast-icon {
+  flex-shrink: 0;
+  font-size: 1rem;
+}
+
+.toast-message {
+  flex: 1;
+}
+
+.toast-close {
+  flex-shrink: 0;
+  background: none;
+  border: none;
+  cursor: pointer;
+  font-size: 0.75rem;
+  opacity: 0.6;
+  padding: 0 0.25rem;
+  color: inherit;
+}
+
+.toast-close:hover {
+  opacity: 1;
+}
+
+/* Variants */
+.toast-success { background: #166534; color: #dcfce7; }
+.toast-error   { background: #991b1b; color: #fee2e2; }
+.toast-warning { background: #92400e; color: #fef3c7; }
+.toast-info    { background: #1e3a5f; color: #dbeafe; }
+
+/* Mobile: bottom-center */
+@media (max-width: 640px) {
+  .toast-container {
+    right: 50%;
+    transform: translateX(50%);
+    bottom: 1rem;
+    max-width: calc(100vw - 2rem);
+  }
+}


### PR DESCRIPTION
Adds a 4-step guided onboarding modal for new users covering wallet connection, profile setup, 
  campaign discovery, and earning a first reward. Progress persists in localStorage and syncs to 
  the backend on completion.                                                                     
                         
Closes #596 