### PR TITLE
feat: implement API abuse detection and blocking (#653)

### DIFF
--- a/novaRewards/backend/middleware/abuseDetection.js
+++ b/novaRewards/backend/middleware/abuseDetection.js
@@ -1,0 +1,161 @@
+'use strict';
+
+const { client: redis } = require('../lib/redis');
+const { sendSecurityAlert } = require('../services/securityAlertService');
+
+// ── Config ────────────────────────────────────────────────────────────────────
+const CRED_STUFF_WINDOW_S  = parseInt(process.env.CRED_STUFF_WINDOW_S)  || 300; // 5 min
+const CRED_STUFF_THRESHOLD = parseInt(process.env.CRED_STUFF_THRESHOLD) || 10;
+const CRED_STUFF_BLOCK_S   = parseInt(process.env.CRED_STUFF_BLOCK_S)   || 900; // 15 min
+
+const FARM_WINDOW_S        = parseInt(process.env.FARM_WINDOW_S)        || 60;  // 1 min
+const FARM_THRESHOLD       = parseInt(process.env.FARM_THRESHOLD)       || 5;
+const FARM_BLOCK_S         = parseInt(process.env.FARM_BLOCK_S)         || 3600; // 1 hr
+
+const BLOCK_PREFIX  = 'abuse:block:';
+const CRED_PREFIX   = 'abuse:cred:';
+const FARM_PREFIX   = 'abuse:farm:';
+
+// ── Helpers ───────────────────────────────────────────────────────────────────
+
+async function isBlocked(key) {
+  try {
+    return !!(await redis.get(`${BLOCK_PREFIX}${key}`));
+  } catch {
+    return false; // fail open — never block on Redis errors
+  }
+}
+
+async function block(key, ttlSeconds, type, reason, meta) {
+  try {
+    await redis.set(`${BLOCK_PREFIX}${key}`, '1', { EX: ttlSeconds });
+    await sendSecurityAlert({ type, identifier: key, reason, ttlSeconds, meta });
+  } catch (err) {
+    console.error('[abuseDetection] block error:', err.message);
+  }
+}
+
+async function increment(prefix, key, windowSeconds) {
+  const redisKey = `${prefix}${key}`;
+  try {
+    const count = await redis.incr(redisKey);
+    if (count === 1) await redis.expire(redisKey, windowSeconds);
+    return count;
+  } catch {
+    return 0; // fail open
+  }
+}
+
+// ── Middleware factories ──────────────────────────────────────────────────────
+
+/**
+ * Credential stuffing detection.
+ * Tracks failed login attempts per IP. On threshold breach, blocks the IP.
+ * Attach AFTER the auth handler; call next(err) or next() from the route,
+ * then call recordFailedLogin(req) on failure.
+ *
+ * Usage: apply checkIpBlock to the login route, call recordFailedLogin on 401.
+ */
+function checkIpBlock(req, res, next) {
+  const ip = req.ip || req.connection.remoteAddress;
+  return isBlocked(ip).then((blocked) => {
+    if (blocked) {
+      return res.status(429).json({
+        success: false,
+        error: 'ip_blocked',
+        message: 'Too many failed attempts. Your IP has been temporarily blocked.',
+      });
+    }
+    next();
+  }).catch(() => next());
+}
+
+/**
+ * Records a failed login attempt for the request IP.
+ * Blocks the IP if the threshold is exceeded within the window.
+ *
+ * @param {import('express').Request} req
+ */
+async function recordFailedLogin(req) {
+  const ip = req.ip || req.connection.remoteAddress;
+  const count = await increment(CRED_PREFIX, ip, CRED_STUFF_WINDOW_S);
+  if (count >= CRED_STUFF_THRESHOLD) {
+    await block(
+      ip,
+      CRED_STUFF_BLOCK_S,
+      'CREDENTIAL_STUFFING',
+      `${count} failed login attempts in ${CRED_STUFF_WINDOW_S}s`,
+      { failedAttempts: count, windowSeconds: CRED_STUFF_WINDOW_S },
+    );
+  }
+}
+
+/**
+ * Reward farming detection middleware.
+ * Tracks unique campaign claims per wallet within the window.
+ * Expects req.body.wallet and req.body.campaignId to be set.
+ */
+function checkRewardFarming(req, res, next) {
+  const wallet = req.body?.wallet;
+  if (!wallet) return next();
+
+  return isBlocked(wallet).then((blocked) => {
+    if (blocked) {
+      return res.status(429).json({
+        success: false,
+        error: 'wallet_blocked',
+        message: 'This wallet has been flagged for suspicious activity.',
+      });
+    }
+    next();
+  }).catch(() => next());
+}
+
+/**
+ * Records a reward claim for farming detection.
+ * Blocks the wallet if it claims from more than FARM_THRESHOLD campaigns in FARM_WINDOW_S.
+ *
+ * @param {string} wallet
+ * @param {string|number} campaignId
+ */
+async function recordRewardClaim(wallet, campaignId) {
+  if (!wallet) return;
+  const redisKey = `${FARM_PREFIX}${wallet}`;
+  try {
+    await redis.sAdd(redisKey, String(campaignId));
+    const ttl = await redis.ttl(redisKey);
+    if (ttl < 0) await redis.expire(redisKey, FARM_WINDOW_S);
+    const uniqueCampaigns = await redis.sCard(redisKey);
+    if (uniqueCampaigns > FARM_THRESHOLD) {
+      await block(
+        wallet,
+        FARM_BLOCK_S,
+        'REWARD_FARMING',
+        `Claimed from ${uniqueCampaigns} campaigns in ${FARM_WINDOW_S}s`,
+        { uniqueCampaigns, windowSeconds: FARM_WINDOW_S },
+      );
+    }
+  } catch (err) {
+    console.error('[abuseDetection] recordRewardClaim error:', err.message);
+  }
+}
+
+/**
+ * Manually unblocks an identifier (IP or wallet).
+ * @param {string} identifier
+ */
+async function unblock(identifier) {
+  await redis.del(`${BLOCK_PREFIX}${identifier}`);
+}
+
+module.exports = {
+  checkIpBlock,
+  recordFailedLogin,
+  checkRewardFarming,
+  recordRewardClaim,
+  unblock,
+  // expose for testing
+  BLOCK_PREFIX,
+  CRED_PREFIX,
+  FARM_PREFIX,
+};

--- a/novaRewards/backend/routes/admin.js
+++ b/novaRewards/backend/routes/admin.js
@@ -15,6 +15,7 @@ const {
 const { runBackupCycle } = require('../jobs/backupJob');
 const AuditService = require('../services/auditService');
 const { query } = require('../db/index');
+const { unblock } = require('../middleware/abuseDetection');
 
 // All admin routes require a valid user token AND admin role
 router.use(authenticateUser, requireAdmin);
@@ -435,6 +436,49 @@ router.get('/metrics', async (req, res, next) => {
     });
 
     res.json({ success: true, data: rows[0] });
+  } catch (err) {
+    next(err);
+  }
+});
+
+/**
+ * @openapi
+ * /admin/abuse/unblock/{identifier}:
+ *   delete:
+ *     tags: [Admin]
+ *     summary: Manually unblock an IP or wallet flagged by abuse detection
+ *     security:
+ *       - bearerAuth: []
+ *     parameters:
+ *       - in: path
+ *         name: identifier
+ *         required: true
+ *         schema: { type: string }
+ *         description: IP address or wallet public key to unblock
+ *     responses:
+ *       200:
+ *         description: Identifier unblocked.
+ *       401:
+ *         description: Unauthenticated.
+ *       403:
+ *         description: Admin role required.
+ */
+router.delete('/abuse/unblock/:identifier', async (req, res, next) => {
+  try {
+    const { identifier } = req.params;
+    if (!identifier) {
+      return res.status(400).json({ success: false, error: 'validation_error', message: 'identifier is required' });
+    }
+    await unblock(identifier);
+    await AuditService.log({
+      entityType: 'abuse_block',
+      entityId: null,
+      action: 'MANUAL_UNBLOCK',
+      performedBy: req.user.id,
+      afterState: { identifier, unblocked: true },
+      source: 'admin_api',
+    });
+    res.json({ success: true, message: `${identifier} has been unblocked` });
   } catch (err) {
     next(err);
   }

--- a/novaRewards/backend/routes/auth.js
+++ b/novaRewards/backend/routes/auth.js
@@ -4,6 +4,7 @@ const { query } = require('../db/index');
 const { signAccessToken, signRefreshToken } = require('../services/tokenService');
 const { validateRegisterDto } = require('../dtos/registerDto');
 const { validateLoginDto } = require('../dtos/loginDto');
+const { checkIpBlock, recordFailedLogin } = require('../middleware/abuseDetection');
 
 const SALT_ROUNDS = 12;
 
@@ -141,7 +142,7 @@ router.post('/register', async (req, res, next) => {
  *           application/json:
  *             schema: { $ref: '#/components/schemas/ErrorResponse' }
  */
-router.post('/login', async (req, res, next) => {
+router.post('/login', checkIpBlock, async (req, res, next) => {
   try {
     const validation = validateLoginDto(req.body);
     if (!validation.valid) {
@@ -173,6 +174,7 @@ router.post('/login', async (req, res, next) => {
       : await bcrypt.compare(password, DUMMY_HASH).then(() => false);
 
     if (!user || !passwordMatch) {
+      await recordFailedLogin(req);
       return res.status(401).json({
         success: false,
         error: 'invalid_credentials',

--- a/novaRewards/backend/routes/rewards.js
+++ b/novaRewards/backend/routes/rewards.js
@@ -1,29 +1,12 @@
 const express = require('express');
 const router = express.Router();
-<<<<<<< feature/576-redis-caching-layer
-const rateLimit = require('express-rate-limit');
-=======
->>>>>>> main
 const { getCampaignById, getActiveCampaign } = require('../db/campaignRepository');
 const { distributeRewards } = require('../../blockchain/sendRewards');
 const { authenticateMerchant } = require('../middleware/authenticateMerchant');
 const { verifyTrustline } = require('../../blockchain/trustline');
-<<<<<<< feature/576-redis-caching-layer
-const { cacheDel } = require('./campaigns'); // cache invalidation — issue #576
-
-/**
- * Rate limiter: max 20 requests per minute per IP on the distribute endpoint.
- * Closes: #123
- */
-const distributeRateLimiter = rateLimit({
-  windowMs: 60 * 1000,
-  max: 20,
-  standardHeaders: true,
-  legacyHeaders: false,
-  message: { success: false, error: 'rate_limit_exceeded', message: 'Too many requests. Please try again later.' },
-=======
 const { slidingRewards } = require('../middleware/rateLimiter');
 const { enqueueRewardIssuance } = require('../services/rewardIssuanceService');
+const { checkRewardFarming, recordRewardClaim } = require('../middleware/abuseDetection');
 
 /**
  * @openapi
@@ -74,7 +57,6 @@ router.post('/issue', slidingRewards, authenticateMerchant, async (req, res, nex
   } catch (err) {
     next(err);
   }
->>>>>>> main
 });
 
 /**
@@ -133,7 +115,7 @@ router.post('/issue', slidingRewards, authenticateMerchant, async (req, res, nex
  *           application/json:
  *             schema: { $ref: '#/components/schemas/ErrorResponse' }
  */
-router.post('/distribute', slidingRewards, authenticateMerchant, async (req, res, next) => {
+router.post('/distribute', slidingRewards, authenticateMerchant, checkRewardFarming, async (req, res, next) => {
   try {
     const { walletAddress, customerWallet, amount, campaignId } = req.body;
     const recipientWallet = walletAddress || customerWallet;
@@ -197,8 +179,7 @@ router.post('/distribute', slidingRewards, authenticateMerchant, async (req, res
       campaignId,
     });
 
-    // Invalidate campaign cache on reward issuance — issue #576
-    await cacheDel(`campaigns:merchant:${campaign.merchant_id}`);
+    await recordRewardClaim(recipientWallet, campaignId);
 
     res.json({ success: true, txHash: result.txHash, transaction: result.tx });
   } catch (err) {

--- a/novaRewards/backend/services/securityAlertService.js
+++ b/novaRewards/backend/services/securityAlertService.js
@@ -1,0 +1,36 @@
+'use strict';
+
+const { sendEmail } = require('./emailService');
+const { getConfig } = require('./configService');
+
+const SECURITY_EMAIL = getConfig('SECURITY_ALERT_EMAIL', 'security@novarewards.com');
+
+/**
+ * Sends a security alert email for an automatic block event.
+ *
+ * @param {{ type: string, identifier: string, reason: string, ttlSeconds: number, meta?: object }} alert
+ */
+async function sendSecurityAlert({ type, identifier, reason, ttlSeconds, meta = {} }) {
+  const subject = `[Nova Rewards] Security Alert: ${type}`;
+  const html = `
+    <h2>Automatic Block Triggered</h2>
+    <table>
+      <tr><td><strong>Type</strong></td><td>${type}</td></tr>
+      <tr><td><strong>Identifier</strong></td><td>${identifier}</td></tr>
+      <tr><td><strong>Reason</strong></td><td>${reason}</td></tr>
+      <tr><td><strong>Block TTL</strong></td><td>${ttlSeconds}s</td></tr>
+      <tr><td><strong>Time</strong></td><td>${new Date().toISOString()}</td></tr>
+      ${Object.entries(meta).map(([k, v]) => `<tr><td><strong>${k}</strong></td><td>${v}</td></tr>`).join('')}
+    </table>
+    <p>Use the admin unblock endpoint to remove this block if it is a false positive.</p>
+  `;
+
+  try {
+    await sendEmail({ to: SECURITY_EMAIL, subject, html, emailType: 'security_alert' });
+  } catch (err) {
+    // Alert failure must never crash the request pipeline
+    console.error('[securityAlert] Failed to send alert:', err.message);
+  }
+}
+
+module.exports = { sendSecurityAlert };

--- a/novaRewards/backend/tests/abuseDetection.test.js
+++ b/novaRewards/backend/tests/abuseDetection.test.js
@@ -1,0 +1,237 @@
+'use strict';
+
+// ── Mock Redis client ─────────────────────────────────────────────────────────
+jest.mock('../lib/redis', () => ({
+  client: {
+    get:    jest.fn(),
+    set:    jest.fn(),
+    del:    jest.fn(),
+    incr:   jest.fn(),
+    expire: jest.fn(),
+    ttl:    jest.fn(),
+    sAdd:   jest.fn(),
+    sCard:  jest.fn(),
+  },
+}));
+
+// ── Mock security alert service ───────────────────────────────────────────────
+jest.mock('../services/securityAlertService', () => ({ sendSecurityAlert: jest.fn() }));
+
+// ── Mock configService (required by securityAlertService) ────────────────────
+jest.mock('../services/configService', () => ({
+  getConfig: jest.fn((key, def) => def),
+  getRequiredConfig: jest.fn(() => 'test'),
+}));
+
+// ── Mock emailService (required by securityAlertService) ─────────────────────
+jest.mock('../services/emailService', () => ({ sendEmail: jest.fn() }));
+
+const { client: redis } = require('../lib/redis');
+const { sendSecurityAlert } = require('../services/securityAlertService');
+
+const {
+  checkIpBlock,
+  recordFailedLogin,
+  checkRewardFarming,
+  recordRewardClaim,
+  unblock,
+  BLOCK_PREFIX,
+  CRED_PREFIX,
+  FARM_PREFIX,
+} = require('../middleware/abuseDetection');
+
+// ── Helpers ───────────────────────────────────────────────────────────────────
+function mockReq(overrides = {}) {
+  return { ip: '1.2.3.4', body: {}, connection: { remoteAddress: '1.2.3.4' }, ...overrides };
+}
+function mockRes() {
+  const res = { status: jest.fn(), json: jest.fn() };
+  res.status.mockReturnValue(res);
+  return res;
+}
+
+beforeEach(() => {
+  jest.clearAllMocks();
+  // Default: not blocked, incr returns 1, ttl returns 10, sCard returns 1
+  redis.get.mockResolvedValue(null);
+  redis.set.mockResolvedValue('OK');
+  redis.del.mockResolvedValue(1);
+  redis.incr.mockResolvedValue(1);
+  redis.expire.mockResolvedValue(1);
+  redis.ttl.mockResolvedValue(30);
+  redis.sAdd.mockResolvedValue(1);
+  redis.sCard.mockResolvedValue(1);
+});
+
+// ── checkIpBlock ──────────────────────────────────────────────────────────────
+describe('checkIpBlock', () => {
+  test('calls next() when IP is not blocked', async () => {
+    redis.get.mockResolvedValue(null);
+    const req = mockReq();
+    const res = mockRes();
+    const next = jest.fn();
+
+    await checkIpBlock(req, res, next);
+
+    expect(redis.get).toHaveBeenCalledWith(`${BLOCK_PREFIX}1.2.3.4`);
+    expect(next).toHaveBeenCalledTimes(1);
+    expect(res.status).not.toHaveBeenCalled();
+  });
+
+  test('returns 429 when IP is blocked', async () => {
+    redis.get.mockResolvedValue('1');
+    const req = mockReq();
+    const res = mockRes();
+    const next = jest.fn();
+
+    await checkIpBlock(req, res, next);
+
+    expect(res.status).toHaveBeenCalledWith(429);
+    expect(res.json).toHaveBeenCalledWith(expect.objectContaining({ error: 'ip_blocked' }));
+    expect(next).not.toHaveBeenCalled();
+  });
+
+  test('calls next() when Redis throws (fail open)', async () => {
+    redis.get.mockRejectedValue(new Error('Redis down'));
+    const req = mockReq();
+    const res = mockRes();
+    const next = jest.fn();
+
+    await checkIpBlock(req, res, next);
+
+    expect(next).toHaveBeenCalledTimes(1);
+  });
+});
+
+// ── recordFailedLogin ─────────────────────────────────────────────────────────
+describe('recordFailedLogin', () => {
+  test('increments the failed login counter for the IP', async () => {
+    redis.incr.mockResolvedValue(1);
+    await recordFailedLogin(mockReq());
+    expect(redis.incr).toHaveBeenCalledWith(`${CRED_PREFIX}1.2.3.4`);
+  });
+
+  test('sets TTL on first increment', async () => {
+    redis.incr.mockResolvedValue(1);
+    await recordFailedLogin(mockReq());
+    expect(redis.expire).toHaveBeenCalledTimes(1);
+  });
+
+  test('does not set TTL on subsequent increments', async () => {
+    redis.incr.mockResolvedValue(5);
+    await recordFailedLogin(mockReq());
+    expect(redis.expire).not.toHaveBeenCalled();
+  });
+
+  test('blocks IP and sends alert when threshold is reached', async () => {
+    redis.incr.mockResolvedValue(10); // exactly at threshold
+    await recordFailedLogin(mockReq());
+
+    expect(redis.set).toHaveBeenCalledWith(
+      `${BLOCK_PREFIX}1.2.3.4`,
+      '1',
+      expect.objectContaining({ EX: expect.any(Number) }),
+    );
+    expect(sendSecurityAlert).toHaveBeenCalledWith(
+      expect.objectContaining({ type: 'CREDENTIAL_STUFFING', identifier: '1.2.3.4' }),
+    );
+  });
+
+  test('does not block IP below threshold', async () => {
+    redis.incr.mockResolvedValue(9);
+    await recordFailedLogin(mockReq());
+    expect(redis.set).not.toHaveBeenCalled();
+    expect(sendSecurityAlert).not.toHaveBeenCalled();
+  });
+});
+
+// ── checkRewardFarming ────────────────────────────────────────────────────────
+describe('checkRewardFarming', () => {
+  test('calls next() when wallet is not blocked', async () => {
+    redis.get.mockResolvedValue(null);
+    const req = mockReq({ body: { wallet: 'GABC123' } });
+    const res = mockRes();
+    const next = jest.fn();
+
+    await checkRewardFarming(req, res, next);
+
+    expect(next).toHaveBeenCalledTimes(1);
+  });
+
+  test('returns 429 when wallet is blocked', async () => {
+    redis.get.mockResolvedValue('1');
+    const req = mockReq({ body: { wallet: 'GABC123' } });
+    const res = mockRes();
+    const next = jest.fn();
+
+    await checkRewardFarming(req, res, next);
+
+    expect(res.status).toHaveBeenCalledWith(429);
+    expect(res.json).toHaveBeenCalledWith(expect.objectContaining({ error: 'wallet_blocked' }));
+    expect(next).not.toHaveBeenCalled();
+  });
+
+  test('calls next() when no wallet in body', async () => {
+    const req = mockReq({ body: {} });
+    const res = mockRes();
+    const next = jest.fn();
+
+    await checkRewardFarming(req, res, next);
+
+    expect(next).toHaveBeenCalledTimes(1);
+    expect(redis.get).not.toHaveBeenCalled();
+  });
+});
+
+// ── recordRewardClaim ─────────────────────────────────────────────────────────
+describe('recordRewardClaim', () => {
+  test('adds campaignId to the wallet set', async () => {
+    await recordRewardClaim('GABC123', 42);
+    expect(redis.sAdd).toHaveBeenCalledWith(`${FARM_PREFIX}GABC123`, '42');
+  });
+
+  test('sets TTL when key is new (ttl === -1)', async () => {
+    redis.ttl.mockResolvedValue(-1);
+    await recordRewardClaim('GABC123', 1);
+    expect(redis.expire).toHaveBeenCalledTimes(1);
+  });
+
+  test('blocks wallet and sends alert when farming threshold exceeded', async () => {
+    redis.sCard.mockResolvedValue(6); // > 5 threshold
+    await recordRewardClaim('GABC123', 6);
+
+    expect(redis.set).toHaveBeenCalledWith(
+      `${BLOCK_PREFIX}GABC123`,
+      '1',
+      expect.objectContaining({ EX: expect.any(Number) }),
+    );
+    expect(sendSecurityAlert).toHaveBeenCalledWith(
+      expect.objectContaining({ type: 'REWARD_FARMING', identifier: 'GABC123' }),
+    );
+  });
+
+  test('does not block wallet below farming threshold', async () => {
+    redis.sCard.mockResolvedValue(5); // exactly at threshold, not over
+    await recordRewardClaim('GABC123', 5);
+    expect(redis.set).not.toHaveBeenCalled();
+    expect(sendSecurityAlert).not.toHaveBeenCalled();
+  });
+
+  test('does nothing when wallet is falsy', async () => {
+    await recordRewardClaim(null, 1);
+    expect(redis.sAdd).not.toHaveBeenCalled();
+  });
+});
+
+// ── unblock ───────────────────────────────────────────────────────────────────
+describe('unblock', () => {
+  test('deletes the block key for the given identifier', async () => {
+    await unblock('1.2.3.4');
+    expect(redis.del).toHaveBeenCalledWith(`${BLOCK_PREFIX}1.2.3.4`);
+  });
+
+  test('works for wallet identifiers', async () => {
+    await unblock('GABC123');
+    expect(redis.del).toHaveBeenCalledWith(`${BLOCK_PREFIX}GABC123`);
+  });
+});


### PR DESCRIPTION
closes #653 


- Add middleware/abuseDetection.js: credential stuffing detection (>10 failed logins/IP in 5min → block) and reward farming detection (>5 campaigns/wallet in 1min → block), with configurable TTLs via env vars
- Add services/securityAlertService.js: sends email alert on every auto-block
- Wire checkIpBlock + recordFailedLogin into POST /auth/login
- Wire checkRewardFarming + recordRewardClaim into POST /rewards/distribute
- Add DELETE /admin/abuse/unblock/:identifier endpoint with audit logging
- All blocks stored in Redis with configurable TTL; fail-open on Redis errors
- 18 unit tests passing