### PR TITLE
feat: implement mobile-first responsive layouts (#614)

### DIFF
--- a/novaRewards/frontend/components/BottomNav.js
+++ b/novaRewards/frontend/components/BottomNav.js
@@ -4,8 +4,8 @@ import Link from 'next/link';
 import { useRouter } from 'next/router';
 
 /**
- * Mobile bottom navigation bar — visible only on small screens.
- * Mirrors the sidebar nav links with touch-friendly tap targets.
+ * Mobile bottom navigation bar — visible only on screens below lg breakpoint.
+ * Touch targets meet the 44×44px minimum (WCAG 2.5.5).
  */
 const NAV_ITEMS = [
   { href: '/dashboard',   icon: '📊', label: 'Home' },
@@ -19,18 +19,33 @@ export default function BottomNav() {
   const { pathname } = useRouter();
 
   return (
-    <nav className="bottom-nav" aria-label="Mobile navigation">
-      {NAV_ITEMS.map(({ href, icon, label }) => (
-        <Link
-          key={href}
-          href={href}
-          className={`bottom-nav-item${pathname === href ? ' bottom-nav-item--active' : ''}`}
-          aria-current={pathname === href ? 'page' : undefined}
-        >
-          <span className="bottom-nav-icon" aria-hidden="true">{icon}</span>
-          <span className="bottom-nav-label">{label}</span>
-        </Link>
-      ))}
+    <nav
+      className="fixed bottom-0 left-0 right-0 z-50 flex h-16 border-t bg-white dark:bg-brand-card dark:border-brand-border lg:hidden"
+      style={{ paddingBottom: 'env(safe-area-inset-bottom, 0px)' }}
+      aria-label="Mobile navigation"
+    >
+      {NAV_ITEMS.map(({ href, icon, label }) => {
+        const active = pathname === href;
+        return (
+          <Link
+            key={href}
+            href={href}
+            aria-current={active ? 'page' : undefined}
+            className={[
+              // Touch target: flex-1 ensures full-width tap area, min-h satisfies 44px
+              'touch-target flex flex-1 flex-col items-center justify-center gap-0.5',
+              'text-xs font-medium transition-colors duration-150',
+              '-webkit-tap-highlight-color-transparent',
+              active
+                ? 'text-brand-purple'
+                : 'text-slate-500 dark:text-slate-400 hover:text-brand-purple',
+            ].join(' ')}
+          >
+            <span className="text-xl leading-none" aria-hidden="true">{icon}</span>
+            <span className="leading-none">{label}</span>
+          </Link>
+        );
+      })}
     </nav>
   );
 }

--- a/novaRewards/frontend/components/MobileCardList.js
+++ b/novaRewards/frontend/components/MobileCardList.js
@@ -1,0 +1,81 @@
+/**
+ * MobileCardList — renders tabular data as stacked cards on mobile,
+ * and falls back to a standard <table> on md+ screens.
+ *
+ * Props:
+ *   columns: [{ key: string, label: string, render?: (value, row) => ReactNode }]
+ *   data:    array of row objects
+ *   keyField?: string — field to use as React key (default: 'id')
+ *   emptyMessage?: string
+ */
+export default function MobileCardList({
+  columns = [],
+  data = [],
+  keyField = 'id',
+  emptyMessage = 'No data available.',
+}) {
+  if (!data.length) {
+    return (
+      <p className="py-8 text-center text-sm text-slate-500 dark:text-slate-400">
+        {emptyMessage}
+      </p>
+    );
+  }
+
+  return (
+    <>
+      {/* ── Mobile: card list (< md) ─────────────────────────────────────── */}
+      <ul className="space-y-3 md:hidden" role="list">
+        {data.map((row, i) => (
+          <li
+            key={row[keyField] ?? i}
+            className="rounded-xl border border-slate-200 dark:border-brand-border bg-white dark:bg-brand-card p-4 shadow-sm"
+          >
+            {columns.map(({ key, label, render }) => {
+              const value = row[key];
+              return (
+                <div key={key} className="flex items-start justify-between py-1 text-sm">
+                  <span className="font-semibold uppercase tracking-wide text-xs text-slate-400 dark:text-slate-500 w-1/3 shrink-0">
+                    {label}
+                  </span>
+                  <span className="text-right text-slate-800 dark:text-slate-200 break-all">
+                    {render ? render(value, row) : (value ?? '—')}
+                  </span>
+                </div>
+              );
+            })}
+          </li>
+        ))}
+      </ul>
+
+      {/* ── Desktop: standard table (≥ md) ──────────────────────────────── */}
+      <div className="hidden md:block overflow-x-auto rounded-xl border border-slate-200 dark:border-brand-border">
+        <table className="w-full text-sm">
+          <thead className="bg-slate-50 dark:bg-brand-card text-slate-500 dark:text-slate-400 uppercase text-xs tracking-wide">
+            <tr>
+              {columns.map(({ key, label }) => (
+                <th key={key} className="px-4 py-3 text-left font-semibold whitespace-nowrap">
+                  {label}
+                </th>
+              ))}
+            </tr>
+          </thead>
+          <tbody className="divide-y divide-slate-100 dark:divide-brand-border">
+            {data.map((row, i) => (
+              <tr
+                key={row[keyField] ?? i}
+                className="bg-white dark:bg-brand-card hover:bg-slate-50 dark:hover:bg-brand-border/30 transition-colors"
+              >
+                {columns.map(({ key, render }) => (
+                  <td key={key} className="px-4 py-3 text-slate-800 dark:text-slate-200">
+                    {render ? render(row[key], row) : (row[key] ?? '—')}
+                  </td>
+                ))}
+              </tr>
+            ))}
+          </tbody>
+        </table>
+      </div>
+    </>
+  );
+}

--- a/novaRewards/frontend/components/RedemptionHistory.js
+++ b/novaRewards/frontend/components/RedemptionHistory.js
@@ -3,16 +3,39 @@
 import { useState, useEffect } from 'react';
 import api from '../lib/api';
 import { useAuth } from '../context/AuthContext';
+import MobileCardList from './MobileCardList';
 
 const STATUS_LABEL = {
-  pending:   { text: 'Pending',   cls: 'badge-yellow' },
-  completed: { text: 'Completed', cls: 'badge-green'  },
-  failed:    { text: 'Failed',    cls: 'badge-red'    },
-  cancelled: { text: 'Cancelled', cls: 'badge-gray'   },
+  pending:   { text: 'Pending',   cls: 'text-yellow-600' },
+  completed: { text: 'Completed', cls: 'text-green-600'  },
+  failed:    { text: 'Failed',    cls: 'text-red-600'    },
+  cancelled: { text: 'Cancelled', cls: 'text-slate-400'  },
 };
+
+const COLUMNS = [
+  { key: 'reward_name',   label: 'Reward',  render: (v, r) => v || r.rewardName || '—' },
+  { key: 'points_spent',  label: 'Points',  render: (v, r) => `−${v ?? r.pointsSpent ?? r.cost ?? '?'}` },
+  {
+    key: 'status',
+    label: 'Status',
+    render: (v) => {
+      const { text, cls } = STATUS_LABEL[v] || { text: v, cls: 'text-slate-400' };
+      return <span className={`font-semibold ${cls}`}>{text}</span>;
+    },
+  },
+  { key: 'created_at', label: 'Date', render: (v) => v ? new Date(v).toLocaleDateString() : '—' },
+  {
+    key: 'tx_hash',
+    label: 'Tx',
+    render: (v) => v
+      ? <a href={`https://stellar.expert/explorer/testnet/tx/${v}`} target="_blank" rel="noopener noreferrer" className="text-blue-500 font-medium" title={v}>{v.slice(0, 8)}…</a>
+      : '—',
+  },
+];
 
 /**
  * Displays paginated redemption history for the authenticated user.
+ * Uses MobileCardList for responsive table/card rendering.
  */
 export default function RedemptionHistory() {
   const { user } = useAuth();
@@ -46,83 +69,38 @@ export default function RedemptionHistory() {
     return () => { cancelled = true; };
   }, [user?.id, page]);
 
-  if (loading) {
-    return (
-      <div className="card">
-        <h2 style={{ marginBottom: '1rem' }}>📜 Redemption History</h2>
-        <div className="loading-spinner" />
-      </div>
-    );
-  }
-
-  if (error) {
-    return (
-      <div className="card">
-        <h2 style={{ marginBottom: '1rem' }}>📜 Redemption History</h2>
-        <p className="error">{error}</p>
-      </div>
-    );
-  }
-
   return (
-    <div className="card">
-      <h2 style={{ marginBottom: '1rem' }}>📜 Redemption History</h2>
+    <div className="rounded-xl border border-slate-200 dark:border-brand-border bg-white dark:bg-brand-card p-4 md:p-6 shadow-sm">
+      <h2 className="text-base font-bold dark:text-white mb-4">📜 Redemption History</h2>
 
-      {redemptions.length === 0 ? (
-        <p style={{ color: 'var(--muted)' }}>No redemptions yet.</p>
+      {loading ? (
+        <div className="space-y-3">
+          {[...Array(3)].map((_, i) => (
+            <div key={i} className="h-16 rounded-lg bg-slate-100 dark:bg-brand-border animate-pulse" />
+          ))}
+        </div>
+      ) : error ? (
+        <p className="text-sm text-red-500">{error}</p>
       ) : (
         <>
-          <div className="redemption-history-table" role="table" aria-label="Redemption history">
-            <div className="rh-header" role="row">
-              <span role="columnheader">Reward</span>
-              <span role="columnheader">Points</span>
-              <span role="columnheader">Status</span>
-              <span role="columnheader">Date</span>
-              <span role="columnheader">Tx</span>
-            </div>
-
-            {redemptions.map((r) => {
-              const { text, cls } = STATUS_LABEL[r.status] || { text: r.status, cls: 'badge-gray' };
-              return (
-                <div key={r.id} className="rh-row" role="row">
-                  <span role="cell" className="rh-reward-name">{r.reward_name || r.rewardName || '—'}</span>
-                  <span role="cell" className="rh-points">−{r.points_spent ?? r.pointsSpent ?? r.cost ?? '?'}</span>
-                  <span role="cell">
-                    <span className={`badge ${cls}`}>{text}</span>
-                  </span>
-                  <span role="cell" className="rh-date">
-                    {r.created_at ? new Date(r.created_at).toLocaleDateString() : '—'}
-                  </span>
-                  <span role="cell">
-                    {r.tx_hash ? (
-                      <a
-                        href={`https://stellar.expert/explorer/testnet/tx/${r.tx_hash}`}
-                        target="_blank"
-                        rel="noopener noreferrer"
-                        className="tx-hash-link"
-                        title={r.tx_hash}
-                      >
-                        {r.tx_hash.slice(0, 8)}…
-                      </a>
-                    ) : '—'}
-                  </span>
-                </div>
-              );
-            })}
-          </div>
+          <MobileCardList
+            columns={COLUMNS}
+            data={redemptions}
+            emptyMessage="No redemptions yet."
+          />
 
           {totalPages > 1 && (
-            <div className="pagination">
+            <div className="flex items-center justify-center gap-3 mt-4">
               <button
-                className="btn btn-secondary"
+                className="touch-target px-4 py-2 text-sm rounded-lg border border-slate-200 dark:border-brand-border bg-white dark:bg-brand-card disabled:opacity-40"
                 onClick={() => setPage((p) => Math.max(1, p - 1))}
                 disabled={page === 1}
               >
                 ← Prev
               </button>
-              <span className="pagination-info">Page {page} of {totalPages}</span>
+              <span className="text-sm text-slate-500">Page {page} of {totalPages}</span>
               <button
-                className="btn btn-secondary"
+                className="touch-target px-4 py-2 text-sm rounded-lg border border-slate-200 dark:border-brand-border bg-white dark:bg-brand-card disabled:opacity-40"
                 onClick={() => setPage((p) => Math.min(totalPages, p + 1))}
                 disabled={page === totalPages}
               >

--- a/novaRewards/frontend/components/TransactionHistory.js
+++ b/novaRewards/frontend/components/TransactionHistory.js
@@ -4,6 +4,7 @@ import { useState, useEffect, useCallback } from 'react';
 import { useTransactions } from '../lib/useApi';
 import EmptyState from './EmptyState';
 import LoadingSkeleton from './LoadingSkeleton';
+import MobileCardList from './MobileCardList';
 
 const PAGE_SIZE = 20;
 const TRANSACTION_TYPES = ['all', 'issuance', 'redemption', 'transfer'];
@@ -223,98 +224,29 @@ export default function TransactionHistory({ userId }) {
         </div>
       </div>
 
-      {/* Transaction Table */}
+      {/* Transaction Table / Card List */}
       {isLoading ? (
         <LoadingSkeleton rows={5} />
       ) : transactions && transactions.length > 0 ? (
-        <div className="table-wrapper" style={{ overflowX: 'auto', marginBottom: '2rem' }}>
-          <table
-            style={{
-              width: '100%',
-              borderCollapse: 'collapse',
-              fontSize: '0.875rem',
-            }}
-          >
-            <thead>
-              <tr style={{ borderBottom: '2px solid #e5e7eb', backgroundColor: '#f9fafb' }}>
-                <th style={{ padding: '1rem', textAlign: 'left', fontWeight: 600 }}>Type</th>
-                <th style={{ padding: '1rem', textAlign: 'right', fontWeight: 600 }}>Amount</th>
-                <th style={{ padding: '1rem', textAlign: 'left', fontWeight: 600 }}>Campaign</th>
-                <th style={{ padding: '1rem', textAlign: 'left', fontWeight: 600 }}>Date</th>
-                <th style={{ padding: '1rem', textAlign: 'center', fontWeight: 600 }}>Status</th>
-                <th style={{ padding: '1rem', textAlign: 'center', fontWeight: 600 }}>Explorer</th>
-              </tr>
-            </thead>
-            <tbody>
-              {transactions.map((tx, idx) => (
-                <tr
-                  key={tx.id}
-                  style={{
-                    borderBottom: '1px solid #e5e7eb',
-                    backgroundColor: idx % 2 === 0 ? '#fff' : '#f9fafb',
-                  }}
-                >
-                  <td style={{ padding: '1rem' }}>
-                    <span
-                      className="badge"
-                      style={{
-                        display: 'inline-block',
-                        padding: '0.25rem 0.75rem',
-                        borderRadius: '9999px',
-                        fontSize: '0.75rem',
-                        fontWeight: 600,
-                        backgroundColor: getBadgeColor(tx.type),
-                        color: '#fff',
-                      }}
-                    >
-                      {tx.type}
-                    </span>
-                  </td>
-                  <td style={{ padding: '1rem', textAlign: 'right', fontWeight: 500 }}>
-                    {tx.amount}
-                  </td>
-                  <td style={{ padding: '1rem' }}>{tx.campaign?.name || 'N/A'}</td>
-                  <td style={{ padding: '1rem' }}>
-                    {new Date(tx.createdAt).toLocaleDateString()}
-                  </td>
-                  <td style={{ padding: '1rem', textAlign: 'center' }}>
-                    <span
-                      className="status-badge"
-                      style={{
-                        display: 'inline-block',
-                        padding: '0.25rem 0.75rem',
-                        borderRadius: '0.25rem',
-                        fontSize: '0.75rem',
-                        fontWeight: 600,
-                        backgroundColor: getStatusColor(tx.status),
-                        color: '#fff',
-                      }}
-                    >
-                      {tx.status}
-                    </span>
-                  </td>
-                  <td style={{ padding: '1rem', textAlign: 'center' }}>
-                    {tx.txHash ? (
-                      <a
-                        href={`https://stellar.expert/explorer/public/tx/${tx.txHash}`}
-                        target="_blank"
-                        rel="noopener noreferrer"
-                        style={{
-                          color: '#3b82f6',
-                          textDecoration: 'none',
-                          fontWeight: 500,
-                        }}
-                      >
-                        View
-                      </a>
-                    ) : (
-                      <span style={{ color: '#9ca3af' }}>-</span>
-                    )}
-                  </td>
-                </tr>
-              ))}
-            </tbody>
-          </table>
+        <div className="mb-8">
+          <MobileCardList
+            columns={[
+              { key: 'type',     label: 'Type',     render: (v) => <span className="font-semibold capitalize">{v}</span> },
+              { key: 'amount',   label: 'Amount',   render: (v) => <span className="font-medium">{v}</span> },
+              { key: 'campaign', label: 'Campaign', render: (v) => v?.name || 'N/A' },
+              { key: 'createdAt',label: 'Date',     render: (v) => new Date(v).toLocaleDateString() },
+              { key: 'status',   label: 'Status',   render: (v) => <span className="capitalize font-semibold">{v}</span> },
+              {
+                key: 'txHash',
+                label: 'Explorer',
+                render: (v) => v
+                  ? <a href={`https://stellar.expert/explorer/public/tx/${v}`} target="_blank" rel="noopener noreferrer" className="text-blue-500 font-medium">View</a>
+                  : '—',
+              },
+            ]}
+            data={transactions}
+            emptyMessage="No transactions found."
+          />
         </div>
       ) : (
         <EmptyState

--- a/novaRewards/frontend/components/layout/DashboardLayout.js
+++ b/novaRewards/frontend/components/layout/DashboardLayout.js
@@ -2,29 +2,35 @@
 import Header from './Header';
 import Sidebar from './Sidebar';
 import Footer from './Footer';
+import BottomNav from '../BottomNav';
 
 /**
- * DashboardLayout - A responsive layout wrapper for protected dashboard pages.
- * Includes Header, Sidebar, Main Content, and Footer.
+ * DashboardLayout — responsive layout wrapper for protected pages.
+ * - Desktop (≥lg): sidebar + header + footer
+ * - Mobile (<lg):  header + bottom tab bar; sidebar available as slide-out drawer
  */
 export default function DashboardLayout({ children }) {
   return (
     <div className="flex min-h-screen bg-gray-50 dark:bg-brand-dark transition-colors duration-200">
-      {/* Sidebar - Collapsible with desktop/mobile support */}
+      {/* Sidebar — hidden on mobile, visible on lg+ */}
       <Sidebar />
 
-      <div className="flex flex-col flex-1 min-w-0 transition-all duration-300">
-        {/* Header - Sticky with user profile and theme toggle */}
+      <div className="flex flex-col flex-1 min-w-0">
         <Header />
 
-        {/* Main Content Area - Scrollable with proper padding */}
-        <main className="flex-1 w-full max-w-[1600px] mx-auto px-4 md:px-8 py-8 animate-in fade-in slide-in-from-bottom-2 duration-500 ease-out">
+        {/* Main content — extra bottom padding on mobile to clear the bottom nav */}
+        <main className="flex-1 w-full max-w-[1600px] mx-auto px-4 md:px-6 lg:px-8 py-4 md:py-6 lg:py-8 pb-20 lg:pb-8 animate-in fade-in slide-in-from-bottom-2 duration-500 ease-out">
           {children}
         </main>
 
-        {/* Footer - Minimal and responsive */}
-        <Footer />
+        {/* Footer — hidden on mobile to save space */}
+        <div className="hidden lg:block">
+          <Footer />
+        </div>
       </div>
+
+      {/* Bottom tab bar — mobile only */}
+      <BottomNav />
     </div>
   );
 }

--- a/novaRewards/frontend/pages/dashboard.js
+++ b/novaRewards/frontend/pages/dashboard.js
@@ -82,14 +82,14 @@ function DashboardContent() {
 
   return (
     <DashboardLayout>
-      <div className="dashboard-content">
+      <div className="space-y-4 md:space-y-6">
         {/* Wallet connection section */}
-        <div className="card" style={{ marginBottom: '1.5rem' }}>
-          <div style={{ display: 'flex', justifyContent: 'space-between', alignItems: 'center', flexWrap: 'wrap', gap: '1rem' }}>
+        <div className="rounded-xl border border-slate-200 dark:border-brand-border bg-white dark:bg-brand-card p-4 md:p-6 shadow-sm">
+          <div className="flex flex-wrap items-center justify-between gap-3">
             <div>
-              <h2 style={{ marginBottom: '0.25rem' }}>Wallet</h2>
+              <h2 className="text-lg font-bold dark:text-white">Wallet</h2>
               {publicKey && (
-                <p style={{ fontFamily: 'monospace', fontSize: '0.85rem', color: 'var(--muted)' }}>
+                <p className="font-mono text-xs text-slate-500 dark:text-slate-400 mt-1 break-all">
                   {publicKey}
                 </p>
               )}
@@ -97,7 +97,7 @@ function DashboardContent() {
             <WalletConnect />
           </div>
           {walletError && (
-            <p className="error" style={{ marginTop: '0.75rem', fontSize: '0.85rem' }}>{walletError}</p>
+            <p className="mt-3 text-sm text-red-500">{walletError}</p>
           )}
         </div>
 
@@ -105,127 +105,103 @@ function DashboardContent() {
           <LoadingSkeleton />
         ) : (
           <>
-            <div className="dashboard-summary-grid">
+            {/* Summary grid — 1 col mobile, 2 col md, 3 col lg */}
+            <div className="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-3 gap-4">
               {/* Balance cards per campaign */}
               {userBalance && campaigns ? (
                 Object.entries(userBalance).map(([campaignId, amount]) => {
                   const campaign = campaigns.find(c => c.id === campaignId);
                   return (
-                    <div key={campaignId} className="card" style={{ textAlign: "center" }}>
-                      <p style={{ color: "#94a3b8", marginBottom: "0.4rem" }}>
-                        {campaign?.name || 'Unknown Campaign'} Balance
-                      </p>
-                      <p style={{ fontSize: "2rem", fontWeight: 800, color: "#7c3aed" }}>
-                        {parseFloat(amount).toFixed(2)}
-                      </p>
-                      <p style={{ color: "#94a3b8", fontSize: "0.85rem" }}>{campaign?.tokenSymbol || 'TOKEN'}</p>
-                      <div style={{ marginTop: "0.5rem", width: "100%", background: "#e5e7eb", borderRadius: "4px", height: "8px" }}>
-                        <div style={{ width: `${Math.min((amount / (campaign?.totalSupply || 1000)) * 100, 100)}%`, background: "#7c3aed", height: "100%", borderRadius: "4px" }}></div>
+                    <div key={campaignId} className="rounded-xl border border-slate-200 dark:border-brand-border bg-white dark:bg-brand-card p-4 shadow-sm text-center">
+                      <p className="text-slate-400 text-sm mb-1">{campaign?.name || 'Unknown Campaign'} Balance</p>
+                      <p className="text-3xl font-extrabold text-brand-purple">{parseFloat(amount).toFixed(2)}</p>
+                      <p className="text-slate-400 text-xs mt-1">{campaign?.tokenSymbol || 'TOKEN'}</p>
+                      <div className="mt-2 w-full bg-slate-200 dark:bg-brand-border rounded h-2">
+                        <div
+                          className="bg-brand-purple h-2 rounded"
+                          style={{ width: `${Math.min((amount / (campaign?.totalSupply || 1000)) * 100, 100)}%` }}
+                        />
                       </div>
                     </div>
                   );
                 })
               ) : (
-                <div className="card" style={{ textAlign: "center" }}>
-                  <p style={{ color: "#94a3b8", marginBottom: "0.4rem" }}>
-                    No balances yet
-                  </p>
-                  <p style={{ fontSize: "1.5rem", color: "#7c3aed" }}>
-                    Start earning rewards!
-                  </p>
+                <div className="rounded-xl border border-slate-200 dark:border-brand-border bg-white dark:bg-brand-card p-4 shadow-sm text-center">
+                  <p className="text-slate-400 text-sm mb-1">No balances yet</p>
+                  <p className="text-xl text-brand-purple">Start earning rewards!</p>
                 </div>
               )}
 
               {/* Active campaigns */}
-              <div className="card">
-                <h2 style={{ marginBottom: "1rem" }}>Active Campaigns</h2>
+              <div className="rounded-xl border border-slate-200 dark:border-brand-border bg-white dark:bg-brand-card p-4 shadow-sm">
+                <h2 className="font-bold text-base dark:text-white mb-3">Active Campaigns</h2>
                 {campaigns && campaigns.length > 0 ? (
-                  <div>
+                  <ul className="divide-y divide-slate-100 dark:divide-brand-border">
                     {campaigns.slice(0, 5).map(campaign => (
-                      <div key={campaign.id} style={{ padding: "0.5rem 0", borderBottom: "1px solid #e5e7eb" }}>
-                        <p style={{ fontWeight: 600 }}>{campaign.name}</p>
-                        <p style={{ fontSize: "0.85rem", color: "#94a3b8" }}>{campaign.description}</p>
-                      </div>
+                      <li key={campaign.id} className="py-2">
+                        <p className="font-semibold text-sm dark:text-white">{campaign.name}</p>
+                        <p className="text-xs text-slate-400">{campaign.description}</p>
+                      </li>
                     ))}
-                  </div>
+                  </ul>
                 ) : (
-                  <p style={{ color: "#94a3b8" }}>No active campaigns</p>
+                  <p className="text-slate-400 text-sm">No active campaigns</p>
                 )}
               </div>
 
               {/* Recent transactions */}
-              <div className="card">
-                <h2 style={{ marginBottom: "1rem" }}>Recent Transactions</h2>
+              <div className="rounded-xl border border-slate-200 dark:border-brand-border bg-white dark:bg-brand-card p-4 shadow-sm">
+                <h2 className="font-bold text-base dark:text-white mb-3">Recent Transactions</h2>
                 {txLoading ? (
-                  <p>Loading...</p>
+                  <p className="text-sm text-slate-400">Loading…</p>
                 ) : recentTransactions && recentTransactions.length > 0 ? (
-                  <div>
+                  <ul className="divide-y divide-slate-100 dark:divide-brand-border">
                     {recentTransactions.map((tx, i) => (
-                      <div key={tx.id || i} style={{ padding: "0.5rem 0", borderBottom: "1px solid #e5e7eb", display: "flex", justifyContent: "space-between" }}>
+                      <li key={tx.id || i} className="py-2 flex justify-between items-start gap-2">
                         <div>
-                          <p style={{ fontWeight: 600 }}>{tx.type}</p>
-                          <p style={{ fontSize: "0.85rem", color: "#94a3b8" }}>{tx.amount} {tx.campaign?.tokenSymbol || 'TOKEN'}</p>
+                          <p className="font-semibold text-sm dark:text-white">{tx.type}</p>
+                          <p className="text-xs text-slate-400">{tx.amount} {tx.campaign?.tokenSymbol || 'TOKEN'}</p>
                         </div>
-                        <div style={{ textAlign: "right" }}>
-                          <p style={{ fontSize: "0.85rem" }}>{new Date(tx.createdAt).toLocaleDateString()}</p>
-                          <span className={`badge ${tx.status === 'confirmed' ? 'success' : 'pending'}`}>{tx.status}</span>
+                        <div className="text-right shrink-0">
+                          <p className="text-xs text-slate-400">{new Date(tx.createdAt).toLocaleDateString()}</p>
+                          <span className={`text-xs font-semibold ${tx.status === 'confirmed' ? 'text-green-500' : 'text-yellow-500'}`}>{tx.status}</span>
                         </div>
-                      </div>
+                      </li>
                     ))}
-                  </div>
+                  </ul>
                 ) : (
-                  <div style={{ textAlign: "center", padding: "1rem 0" }}>
-                    <p style={{ color: "#94a3b8", marginBottom: "0.75rem" }}>
-                      No transactions yet. Start earning rewards!
-                    </p>
-                    <a href="/merchant" style={{ color: "#7c3aed", fontWeight: 600 }}>
-                      Browse merchants →
-                    </a>
+                  <div className="text-center py-4">
+                    <p className="text-slate-400 text-sm mb-2">No transactions yet.</p>
+                    <a href="/merchant" className="text-brand-purple font-semibold text-sm">Browse merchants →</a>
                   </div>
                 )}
               </div>
             </div>
 
-            <div className="card">
-              <h2 style={{ marginBottom: "1rem" }}>Trustline</h2>
-              <TrustlineButton
-                walletAddress={publicKey}
-                onSuccess={() => refreshBalance()}
-              />
+            {/* Trustline */}
+            <div className="rounded-xl border border-slate-200 dark:border-brand-border bg-white dark:bg-brand-card p-4 md:p-6 shadow-sm">
+              <h2 className="font-bold text-base dark:text-white mb-3">Trustline</h2>
+              <TrustlineButton walletAddress={publicKey} onSuccess={() => refreshBalance()} />
             </div>
 
-            {/* Referral Link — Requirement 168 */}
             <ReferralLink userId={publicKey} />
 
-
             {/* Transfer */}
-            <div className="card">
-              <h2 style={{ marginBottom: "1rem" }}>Send NOVA</h2>
-              <TransferForm
-                senderPublicKey={publicKey}
-                senderBalance={balance}
-                onSuccess={() => refreshBalance()}
-              />
+            <div className="rounded-xl border border-slate-200 dark:border-brand-border bg-white dark:bg-brand-card p-4 md:p-6 shadow-sm">
+              <h2 className="font-bold text-base dark:text-white mb-3">Send NOVA</h2>
+              <TransferForm senderPublicKey={publicKey} senderBalance={balance} onSuccess={() => refreshBalance()} />
             </div>
 
             {/* Redeem */}
-            <div className="card">
-              <h2 style={{ marginBottom: "1rem" }}>Redeem NOVA</h2>
-              <RedeemForm
-                senderPublicKey={publicKey}
-                senderBalance={balance}
-                onSuccess={() => refreshBalance()}
-              />
+            <div className="rounded-xl border border-slate-200 dark:border-brand-border bg-white dark:bg-brand-card p-4 md:p-6 shadow-sm">
+              <h2 className="font-bold text-base dark:text-white mb-3">Redeem NOVA</h2>
+              <RedeemForm senderPublicKey={publicKey} senderBalance={balance} onSuccess={() => refreshBalance()} />
             </div>
           </>
         )}
       </div>
-      
-      {/* Stellar Drop Modal */}
-      <StellarDropModal 
-        ref={dropModalRef}
-        onClaimSuccess={handleDropClaimSuccess}
-      />
+
+      <StellarDropModal ref={dropModalRef} onClaimSuccess={handleDropClaimSuccess} />
     </DashboardLayout>
   );
 }

--- a/novaRewards/frontend/pages/merchant-dashboard.js
+++ b/novaRewards/frontend/pages/merchant-dashboard.js
@@ -86,25 +86,24 @@ function MerchantDashboardContent() {
   }
 
   return (
-    <div className="container">
+    <div className="space-y-4 md:space-y-6">
       {/* Header */}
-      <div style={{ display: 'flex', flexWrap: 'wrap', alignItems: 'center', justifyContent: 'space-between', gap: '1rem', marginBottom: '1.5rem' }}>
+      <div className="flex flex-wrap items-center justify-between gap-3">
         <div>
-          <h1 style={{ fontSize: '1.6rem', fontWeight: 700, margin: 0 }}>📊 Merchant Dashboard</h1>
+          <h1 className="text-xl md:text-2xl font-bold dark:text-white">📊 Merchant Dashboard</h1>
           {lastRefreshed && (
-            <p style={{ color: 'var(--muted)', fontSize: '0.8rem', marginTop: '0.2rem' }}>
+            <p className="text-xs text-slate-400 mt-1">
               Last updated: {lastRefreshed.toLocaleTimeString()} · auto-refreshes every 60s
             </p>
           )}
         </div>
-        <div style={{ display: 'flex', alignItems: 'center', gap: '0.75rem' }}>
+        <div className="flex items-center gap-2">
           <DateRangePicker value={range} onChange={setRange} />
           <button
-            className="btn btn-secondary"
+            className="touch-target px-3 py-2 text-sm rounded-lg border border-slate-200 dark:border-brand-border bg-white dark:bg-brand-card hover:bg-slate-50 dark:hover:bg-brand-border transition-colors"
             onClick={loadAll}
             disabled={loading}
             aria-label="Refresh dashboard data"
-            style={{ padding: '0.45rem 1rem', fontSize: '0.85rem' }}
           >
             {loading ? '…' : '↻ Refresh'}
           </button>
@@ -113,9 +112,9 @@ function MerchantDashboardContent() {
 
       {/* Error */}
       {error && (
-        <div className="card" style={{ textAlign: 'center' }}>
-          <p className="error" style={{ marginBottom: '0.75rem' }}>⚠️ {error}</p>
-          <button className="btn btn-secondary" onClick={loadAll}>Try Again</button>
+        <div className="rounded-xl border border-red-200 bg-red-50 dark:bg-red-900/20 p-4 text-center">
+          <p className="text-red-600 dark:text-red-400 text-sm mb-2">⚠️ {error}</p>
+          <button className="touch-target px-4 py-2 text-sm rounded-lg bg-white dark:bg-brand-card border border-slate-200 dark:border-brand-border" onClick={loadAll}>Try Again</button>
         </div>
       )}
 
@@ -123,18 +122,18 @@ function MerchantDashboardContent() {
       <KpiCards kpis={kpis} loading={loading} />
 
       {/* Daily Issuance Chart */}
-      <div className="card">
-        <h2 style={{ fontSize: '1rem', fontWeight: 600, marginBottom: '1rem' }}>🎁 Daily Reward Issuance</h2>
+      <div className="rounded-xl border border-slate-200 dark:border-brand-border bg-white dark:bg-brand-card p-4 md:p-6 shadow-sm">
+        <h2 className="text-base font-semibold dark:text-white mb-4">🎁 Daily Reward Issuance</h2>
         {loading ? (
-          <div className="skeleton-block" style={{ height: 240, borderRadius: 8 }} />
+          <div className="h-60 rounded-lg bg-slate-100 dark:bg-brand-border animate-pulse" />
         ) : (
           <RewardsLineChart data={issuance} />
         )}
       </div>
 
       {/* Campaign List */}
-      <div className="card">
-        <h2 style={{ fontSize: '1rem', fontWeight: 600, marginBottom: '1rem' }}>🚀 Campaigns</h2>
+      <div className="rounded-xl border border-slate-200 dark:border-brand-border bg-white dark:bg-brand-card p-4 md:p-6 shadow-sm">
+        <h2 className="text-base font-semibold dark:text-white mb-4">🚀 Campaigns</h2>
         <CampaignList
           campaigns={campaigns}
           loading={loading}

--- a/novaRewards/frontend/tailwind.config.js
+++ b/novaRewards/frontend/tailwind.config.js
@@ -6,16 +6,38 @@ module.exports = {
   ],
   darkMode: 'class',
   theme: {
+    // Explicit breakpoints matching the three required design widths
+    screens: {
+      sm:  '375px',   // mobile
+      md:  '768px',   // tablet
+      lg:  '1024px',  // desktop
+      xl:  '1280px',  // wide desktop
+      '2xl': '1536px',
+    },
     extend: {
       colors: {
         brand: {
-          dark: '#0f0f1a',
-          card: '#1a1a2e',
+          dark:   '#0f0f1a',
+          card:   '#1a1a2e',
           border: '#2d2d4e',
           purple: '#7c3aed',
         },
       },
+      // Minimum 44×44px touch targets (WCAG 2.5.5)
+      minHeight: { touch: '44px' },
+      minWidth:  { touch: '44px' },
+      spacing:   { touch: '44px' },
     },
   },
-  plugins: [],
-}
+  plugins: [
+    // Touch-target utility: adds min-h-[44px] min-w-[44px] in one class
+    function ({ addUtilities }) {
+      addUtilities({
+        '.touch-target': {
+          'min-height': '44px',
+          'min-width':  '44px',
+        },
+      });
+    },
+  ],
+};


### PR DESCRIPTION
closes #614 

- Add explicit sm/md/lg/xl breakpoints to tailwind.config.js
- Add .touch-target utility (min 44x44px, WCAG 2.5.5)
- Rewrite BottomNav with Tailwind classes, hidden on lg+
- Update DashboardLayout: include BottomNav, mobile-safe pb-20, hide footer on mobile
- Create MobileCardList: card list on <md, table on >=md
- Update dashboard.js: mobile-first grid (1→2→3 cols), Tailwind card classes
- Update merchant-dashboard.js: Tailwind header/card layout
- Update TransactionHistory: replace inline-style table with MobileCardList
- Update RedemptionHistory: replace custom table with MobileCardList