### PR TITLE
feat(auth): add Stellar wallet challenge-response auth with JWT issuance

### DIFF
--- a/novaRewards/backend/routes/stellarAuth.js
+++ b/novaRewards/backend/routes/stellarAuth.js
@@ -1,0 +1,135 @@
+const router = require('express').Router();
+const stellarAuthService = require('../services/stellarAuthService');
+const { slidingAuth } = require('../middleware/rateLimiter');
+
+/**
+ * @openapi
+ * /auth/challenge:
+ *   post:
+ *     tags: [Auth]
+ *     summary: Request a challenge nonce for wallet-based authentication
+ *     requestBody:
+ *       required: true
+ *       content:
+ *         application/json:
+ *           schema:
+ *             type: object
+ *             required: [walletAddress]
+ *             properties:
+ *               walletAddress:
+ *                 type: string
+ *                 description: Stellar Ed25519 public key (G...)
+ *                 example: "GABC..."
+ *     responses:
+ *       200:
+ *         description: Challenge nonce generated.
+ *       400:
+ *         description: Invalid wallet address.
+ */
+router.post('/challenge', slidingAuth, async (req, res, next) => {
+  try {
+    const { walletAddress } = req.body;
+
+    if (!walletAddress) {
+      return res.status(400).json({
+        success: false,
+        error: 'validation_error',
+        message: 'walletAddress is required',
+      });
+    }
+
+    const { nonce, expiresAt } = await stellarAuthService.createChallenge(walletAddress);
+
+    return res.json({
+      success: true,
+      data: {
+        walletAddress,
+        nonce,
+        expiresAt,
+        message: stellarAuthService._buildChallengeMessage(walletAddress, nonce),
+      },
+    });
+  } catch (err) {
+    if (err.status === 400) {
+      return res.status(400).json({
+        success: false,
+        error: 'validation_error',
+        message: err.message,
+      });
+    }
+    next(err);
+  }
+});
+
+/**
+ * @openapi
+ * /auth/verify:
+ *   post:
+ *     tags: [Auth]
+ *     summary: Verify a signed challenge and obtain a JWT
+ *     requestBody:
+ *       required: true
+ *       content:
+ *         application/json:
+ *           schema:
+ *             type: object
+ *             required: [walletAddress, signedChallenge]
+ *             properties:
+ *               walletAddress:
+ *                 type: string
+ *                 description: Stellar Ed25519 public key
+ *               signedChallenge:
+ *                 type: string
+ *                 description: Base64-encoded signature of the challenge message
+ *     responses:
+ *       200:
+ *         description: Authentication successful, JWT returned.
+ *       401:
+ *         description: Invalid or expired challenge / invalid signature.
+ */
+router.post('/verify', slidingAuth, async (req, res, next) => {
+  try {
+    const { walletAddress, signedChallenge } = req.body;
+
+    if (!walletAddress) {
+      return res.status(400).json({
+        success: false,
+        error: 'validation_error',
+        message: 'walletAddress is required',
+      });
+    }
+
+    if (!signedChallenge) {
+      return res.status(400).json({
+        success: false,
+        error: 'validation_error',
+        message: 'signedChallenge is required',
+      });
+    }
+
+    const result = await stellarAuthService.verifyChallenge(walletAddress, signedChallenge);
+
+    return res.json({
+      success: true,
+      data: result,
+    });
+  } catch (err) {
+    if (err.status === 401) {
+      return res.status(401).json({
+        success: false,
+        error: err.code || 'unauthorized',
+        message: err.message,
+      });
+    }
+    if (err.status === 400) {
+      return res.status(400).json({
+        success: false,
+        error: 'validation_error',
+        message: err.message,
+      });
+    }
+    next(err);
+  }
+});
+
+module.exports = router;

--- a/novaRewards/backend/routes/stellarTransaction.js
+++ b/novaRewards/backend/routes/stellarTransaction.js
@@ -1,0 +1,363 @@
+const router = require('express').Router();
+const { Operation, Asset, Keypair, Memo } = require('stellar-sdk');
+const stellarTxService = require('../services/stellarTransactionService');
+const { authenticateUser } = require('../middleware/authenticateUser');
+const { slidingGlobal } = require('../middleware/rateLimiter');
+
+/**
+ * @openapi
+ * /transactions/submit:
+ *   post:
+ *     tags: [Transactions]
+ *     summary: Build, sign, and submit a Stellar transaction
+ *     description: >
+ *       Constructs a transaction from the provided operation parameters,
+ *       signs it with the supplied signer secret, and submits to the
+ *       Stellar network. Sequence number is fetched fresh from Horizon.
+ *       If the transaction is stuck, a fee-bump is automatically attempted.
+ *     security:
+ *       - bearerAuth: []
+ *     requestBody:
+ *       required: true
+ *       content:
+ *         application/json:
+ *           schema:
+ *             type: object
+ *             required: [sourceAddress, signerSecret, operations]
+ *             properties:
+ *               sourceAddress:
+ *                 type: string
+ *                 description: Source account public key
+ *               signerSecret:
+ *                 type: string
+ *                 description: Secret key of the signing account
+ *               operations:
+ *                 type: array
+ *                 description: Array of operation descriptors
+ *                 items:
+ *                   type: object
+ *                   required: [type]
+ *                   properties:
+ *                     type:
+ *                       type: string
+ *                       enum: [payment, changeTrust, createAccount, accountMerge, manageData]
+ *                     destination:
+ *                       type: string
+ *                     assetCode:
+ *                       type: string
+ *                     assetIssuer:
+ *                       type: string
+ *                     amount:
+ *                       type: string
+ *                     startingBalance:
+ *                       type: string
+ *                     limit:
+ *                       type: string
+ *                     name:
+ *                       type: string
+ *                     value:
+ *                       type: string
+ *               timeout:
+ *                 type: number
+ *                 default: 180
+ *               memo:
+ *                 type: string
+ *               feeSourceSecret:
+ *                 type: string
+ *                 description: Secret key for fee-bump fee source
+ *               txType:
+ *                 type: string
+ *                 default: transfer
+ *               amount:
+ *                 type: string
+ *               fromWallet:
+ *                 type: string
+ *               toWallet:
+ *                 type: string
+ *               merchantId:
+ *                 type: integer
+ *               campaignId:
+ *                 type: integer
+ *     responses:
+ *       200:
+ *         description: Transaction submitted successfully.
+ *       400:
+ *         description: Validation or submission error.
+ *       401:
+ *         description: Unauthorized.
+ */
+router.post('/submit', authenticateUser, async (req, res, next) => {
+  try {
+    const {
+      sourceAddress,
+      signerSecret,
+      operations: operationDescriptors,
+      timeout,
+      memo,
+      feeSourceSecret,
+      txType,
+      amount,
+      fromWallet,
+      toWallet,
+      merchantId,
+      campaignId,
+    } = req.body;
+
+    // --- Validation ---
+    if (!sourceAddress) {
+      return res.status(400).json({
+        success: false,
+        error: 'validation_error',
+        message: 'sourceAddress is required',
+      });
+    }
+
+    if (!signerSecret) {
+      return res.status(400).json({
+        success: false,
+        error: 'validation_error',
+        message: 'signerSecret is required',
+      });
+    }
+
+    if (!operationDescriptors || !Array.isArray(operationDescriptors) || operationDescriptors.length === 0) {
+      return res.status(400).json({
+        success: false,
+        error: 'validation_error',
+        message: 'operations must be a non-empty array',
+      });
+    }
+
+    // Build Stellar operations from descriptors
+    const operations = buildOperations(operationDescriptors);
+    const signers = [Keypair.fromSecret(signerSecret)];
+
+    const result = await stellarTxService.submit({
+      sourceAddress,
+      operations,
+      signers,
+      options: {
+        timeout,
+        memo,
+        feeSourceSecret,
+        txType,
+        amount,
+        fromWallet,
+        toWallet,
+        merchantId,
+        campaignId,
+        userId: req.user?.id,
+      },
+    });
+
+    return res.json({
+      success: true,
+      data: {
+        txHash: result.txHash,
+        ledger: result.ledger,
+        status: result.status,
+        resultXdr: result.resultXdr,
+      },
+    });
+  } catch (err) {
+    if (err.status) {
+      return res.status(err.status).json({
+        success: false,
+        error: err.code || 'submission_error',
+        message: err.message,
+      });
+    }
+    next(err);
+  }
+});
+
+/**
+ * @openapi
+ * /transactions/fee-bump:
+ *   post:
+ *     tags: [Transactions]
+ *     summary: Submit a fee-bump transaction for a stuck transaction
+ *     description: >
+ *       Wraps an existing signed transaction in a fee-bump envelope
+ *       and submits it to the Stellar network.
+ *     security:
+ *       - bearerAuth: []
+ *     requestBody:
+ *       required: true
+ *       content:
+ *         application/json:
+ *           schema:
+ *             type: object
+ *             required: [innerTxXDR, feeSourceSecret]
+ *             properties:
+ *               innerTxXDR:
+ *                 type: string
+ *                 description: XDR of the original (stuck) signed transaction
+ *               feeSourceSecret:
+ *                 type: string
+ *                 description: Secret key of the account paying the higher fee
+ *               baseFee:
+ *                 type: string
+ *                 description: Custom base fee (default: 2x network base fee)
+ *     responses:
+ *       200:
+ *         description: Fee-bump transaction submitted.
+ *       400:
+ *         description: Validation or submission error.
+ *       401:
+ *         description: Unauthorized.
+ */
+router.post('/fee-bump', authenticateUser, async (req, res, next) => {
+  try {
+    const { innerTxXDR, feeSourceSecret, baseFee } = req.body;
+
+    if (!innerTxXDR) {
+      return res.status(400).json({
+        success: false,
+        error: 'validation_error',
+        message: 'innerTxXDR is required',
+      });
+    }
+
+    if (!feeSourceSecret) {
+      return res.status(400).json({
+        success: false,
+        error: 'validation_error',
+        message: 'feeSourceSecret is required',
+      });
+    }
+
+    const result = await stellarTxService.submitFeeBump({
+      innerTxXDR,
+      feeSourceSecret,
+      baseFee,
+    });
+
+    return res.json({
+      success: true,
+      data: {
+        txHash: result.txHash,
+        ledger: result.ledger,
+        status: result.status,
+        resultXdr: result.resultXdr,
+      },
+    });
+  } catch (err) {
+    if (err.status) {
+      return res.status(err.status).json({
+        success: false,
+        error: err.code || 'fee_bump_error',
+        message: err.message,
+      });
+    }
+    next(err);
+  }
+});
+
+/**
+ * @openapi
+ * /transactions/sequence/:publicKey:
+ *   get:
+ *     tags: [Transactions]
+ *     summary: Get current sequence number for a Stellar account
+ *     security:
+ *       - bearerAuth: []
+ *     parameters:
+ *       - in: path
+ *         name: publicKey
+ *         required: true
+ *         schema:
+ *           type: string
+ *     responses:
+ *       200:
+ *         description: Sequence number returned.
+ */
+router.get('/sequence/:publicKey', authenticateUser, async (req, res, next) => {
+  try {
+    const { publicKey } = req.params;
+    const sequence = await stellarTxService.getSequenceNumber(publicKey);
+
+    return res.json({
+      success: true,
+      data: { publicKey, sequence },
+    });
+  } catch (err) {
+    if (err.response?.status === 404 || err.message?.toLowerCase().includes('not found')) {
+      return res.status(404).json({
+        success: false,
+        error: 'account_not_found',
+        message: 'Account not found on Stellar network',
+      });
+    }
+    next(err);
+  }
+});
+
+// ---------------------------------------------------------------------------
+// Operation builder
+// ---------------------------------------------------------------------------
+
+/**
+ * Converts operation descriptor objects into Stellar SDK Operation instances.
+ */
+function buildOperations(descriptors) {
+  return descriptors.map((desc) => {
+    switch (desc.type) {
+      case 'payment': {
+        const asset = buildAsset(desc.assetCode, desc.assetIssuer);
+        return Operation.payment({
+          destination: desc.destination,
+          asset,
+          amount: String(desc.amount),
+        });
+      }
+      case 'changeTrust': {
+        const asset = buildAsset(desc.assetCode, desc.assetIssuer);
+        return Operation.changeTrust({
+          asset,
+          limit: desc.limit || undefined,
+        });
+      }
+      case 'createAccount': {
+        return Operation.createAccount({
+          destination: desc.destination,
+          startingBalance: String(desc.startingBalance || '1'),
+        });
+      }
+      case 'accountMerge': {
+        return Operation.accountMerge({
+          destination: desc.destination,
+        });
+      }
+      case 'manageData': {
+        return Operation.manageData({
+          name: desc.name,
+          value: desc.value,
+        });
+      }
+      default:
+        throw Object.assign(
+          new Error(`Unsupported operation type: ${desc.type}`),
+          { status: 400, code: 'validation_error' },
+        );
+    }
+  });
+}
+
+/**
+ * Builds a Stellar Asset from code and issuer. Returns native if no code provided.
+ */
+function buildAsset(code, issuer) {
+  if (!code || code === 'XLM' || code === 'native') {
+    return Asset.native();
+  }
+  if (!issuer) {
+    throw Object.assign(
+      new Error(`assetIssuer is required for non-native asset: ${code}`),
+      { status: 400, code: 'validation_error' },
+    );
+  }
+  return new Asset(code, issuer);
+}
+
+module.exports = router;

--- a/novaRewards/backend/server.js
+++ b/novaRewards/backend/server.js
@@ -90,6 +90,7 @@ app.use("/api/campaigns", require("./routes/campaigns"));
 app.use("/api/rewards", require("./routes/rewards"));
 app.use("/api/redemptions", require("./routes/redemptions"));
 app.use("/api/transactions", require("./routes/transactions"));
+app.use("/api/transactions", require("./routes/stellarTransaction"));
 app.use("/api/trustline", require("./routes/trustline"));
 app.use("/api/users", require("./routes/users"));
 app.use("/api/wallet", require("./routes/wallet"));

--- a/novaRewards/backend/server.js
+++ b/novaRewards/backend/server.js
@@ -84,6 +84,7 @@ app.use('/api/drops', require('./routes/drops'));
 app.use('/api/analytics', require('./routes/analytics'));
 app.use('/api/notifications', require('./routes/notifications'));
 app.use("/api/auth", require("./routes/auth"));
+app.use("/api/auth", require("./routes/stellarAuth"));
 app.use("/api/merchants", require("./routes/merchants"));
 app.use("/api/campaigns", require("./routes/campaigns"));
 app.use("/api/rewards", require("./routes/rewards"));

--- a/novaRewards/backend/services/stellarAuthService.js
+++ b/novaRewards/backend/services/stellarAuthService.js
@@ -1,0 +1,199 @@
+const { v4: uuidv4 } = require('uuid');
+const jwt = require('jsonwebtoken');
+const { StrKey, Keypair } = require('stellar-sdk');
+const { client: redisClient } = require('../lib/redis');
+const { query } = require('../db/index');
+const { getConfig, getRequiredConfig } = require('./configService');
+
+const NONCE_PREFIX = 'stellar:nonce:';
+const NONCE_TTL_SECONDS = 5 * 60; // 5 minutes
+const JWT_EXPIRES_IN = getConfig('STELLAR_AUTH_JWT_EXPIRES_IN', '15m');
+
+/**
+ * Generates a challenge nonce tied to a Stellar wallet address.
+ * Stores the nonce in Redis with a 5-minute TTL.
+ *
+ * @param {string} walletAddress - Stellar public key (G...)
+ * @returns {Promise<{ nonce: string, expiresAt: number }>}
+ */
+async function createChallenge(walletAddress) {
+  if (!isValidWallet(walletAddress)) {
+    throw Object.assign(new Error('Invalid Stellar wallet address'), { status: 400 });
+  }
+
+  const nonce = uuidv4();
+  const key = `${NONCE_PREFIX}${walletAddress}`;
+  const expiresAt = Math.floor(Date.now() / 1000) + NONCE_TTL_SECONDS;
+
+  // Store nonce in Redis with 5-min TTL. Overwrites any previous nonce for this wallet.
+  await redisClient.set(key, nonce, { EX: NONCE_TTL_SECONDS });
+
+  return { nonce, expiresAt };
+}
+
+/**
+ * Verifies a signed challenge and issues a JWT.
+ *
+ * Flow:
+ *  1. Retrieve the nonce from Redis for the given wallet address
+ *  2. If missing or expired → 401
+ *  3. Delete the nonce (single-use)
+ *  4. Verify the Stellar signature against the challenge message
+ *  5. Look up or create the user record, determine roles
+ *  6. Sign and return a JWT containing walletAddress, roles, expiry
+ *
+ * @param {string} walletAddress - Stellar public key
+ * @param {string} signedChallenge - Base64-encoded signed challenge
+ * @returns {Promise<{ accessToken: string, refreshToken: string, user: object }>}
+ */
+async function verifyChallenge(walletAddress, signedChallenge) {
+  if (!isValidWallet(walletAddress)) {
+    throw Object.assign(new Error('Invalid Stellar wallet address'), { status: 400 });
+  }
+
+  if (!signedChallenge) {
+    throw Object.assign(new Error('Signed challenge is required'), { status: 400 });
+  }
+
+  // 1. Retrieve nonce from Redis
+  const key = `${NONCE_PREFIX}${walletAddress}`;
+  const nonce = await redisClient.get(key);
+
+  if (!nonce) {
+    const err = new Error('Challenge expired or not found');
+    err.status = 401;
+    err.code = 'challenge_expired';
+    throw err;
+  }
+
+  // 2. Single-use: delete the nonce immediately
+  await redisClient.del(key);
+
+  // 3. Reconstruct the challenge message that was signed
+  const challengeMessage = buildChallengeMessage(walletAddress, nonce);
+
+  // 4. Verify the Stellar signature
+  const signatureValid = verifyStellarSignature(
+    walletAddress,
+    challengeMessage,
+    signedChallenge,
+  );
+
+  if (!signatureValid) {
+    const err = new Error('Invalid signature');
+    err.status = 401;
+    err.code = 'invalid_signature';
+    throw err;
+  }
+
+  // 5. Look up user by wallet address to determine roles
+  const user = await findOrCreateUserByWallet(walletAddress);
+
+  // 6. Issue JWT
+  const secret = getRequiredConfig('JWT_SECRET');
+  const accessToken = jwt.sign(
+    {
+      walletAddress,
+      userId: user.id,
+      role: user.role,
+    },
+    secret,
+    { expiresIn: JWT_EXPIRES_IN },
+  );
+
+  const refreshToken = jwt.sign(
+    { userId: user.id, walletAddress, type: 'refresh' },
+    secret,
+    { expiresIn: getConfig('JWT_REFRESH_EXPIRES_IN', '7d') },
+  );
+
+  return {
+    accessToken,
+    refreshToken,
+    user: {
+      id: user.id,
+      walletAddress: user.wallet_address,
+      role: user.role,
+    },
+  };
+}
+
+// ---------------------------------------------------------------------------
+// Internal helpers
+// ---------------------------------------------------------------------------
+
+/**
+ * Validates a Stellar Ed25519 public key.
+ */
+function isValidWallet(address) {
+  if (typeof address !== 'string') return false;
+  try {
+    return StrKey.isValidEd25519PublicKey(address);
+  } catch {
+    return false;
+  }
+}
+
+/**
+ * Builds the deterministic challenge message the client must sign.
+ * Format: "NovaRewards Auth\nWallet: <address>\nNonce: <nonce>"
+ */
+function buildChallengeMessage(walletAddress, nonce) {
+  return `NovaRewards Auth\nWallet: ${walletAddress}\nNonce: ${nonce}`;
+}
+
+/**
+ * Verifies a Stellar Ed25519 signature over the challenge message.
+ *
+ * @param {string} publicKey  - G-prefixed public key
+ * @param {string} message    - The challenge message string
+ * @param {string} signature  - Base64-encoded signature
+ * @returns {boolean}
+ */
+function verifyStellarSignature(publicKey, message, signature) {
+  try {
+    const kp = Keypair.fromPublicKey(publicKey);
+    const msgBytes = Buffer.from(message, 'utf-8');
+    const sigBytes = Buffer.from(signature, 'base64');
+    return kp.verify(msgBytes, sigBytes);
+  } catch {
+    return false;
+  }
+}
+
+/**
+ * Finds an existing user by wallet_address, or creates a new one with
+ * the default "user" role.
+ */
+async function findOrCreateUserByWallet(walletAddress) {
+  const existing = await query(
+    `SELECT id, wallet_address, role FROM users WHERE wallet_address = $1 AND is_deleted = FALSE`,
+    [walletAddress],
+  );
+
+  if (existing.rows.length > 0) {
+    return existing.rows[0];
+  }
+
+  // Auto-create user with default role
+  const result = await query(
+    `INSERT INTO users (wallet_address, role, first_name, last_name, email)
+     VALUES ($1, 'user', 'Wallet', 'User', $2)
+     ON CONFLICT (wallet_address) DO UPDATE SET is_deleted = FALSE
+     RETURNING id, wallet_address, role`,
+    [walletAddress, `${walletAddress}@stellar`],
+  );
+
+  return result.rows[0];
+}
+
+module.exports = {
+  createChallenge,
+  verifyChallenge,
+  // Exported for testing
+  _buildChallengeMessage: buildChallengeMessage,
+  _verifyStellarSignature: verifyStellarSignature,
+  _isValidWallet: isValidWallet,
+  NONCE_PREFIX,
+  NONCE_TTL_SECONDS,
+};

--- a/novaRewards/backend/services/stellarTransactionService.js
+++ b/novaRewards/backend/services/stellarTransactionService.js
@@ -1,0 +1,355 @@
+const {
+  TransactionBuilder,
+  Operation,
+  Networks,
+  BASE_FEE,
+  Keypair,
+} = require('stellar-sdk');
+const { server } = require('../../blockchain/stellarService');
+const { recordTransaction } = require('../db/transactionRepository');
+const { getConfig, getRequiredConfig } = require('./configService');
+
+// ---------------------------------------------------------------------------
+// Network configuration — selected via STELLAR_NETWORK env var
+// ---------------------------------------------------------------------------
+const NETWORK_PASSPHRASE =
+  getConfig('STELLAR_NETWORK', 'testnet') === 'mainnet'
+    ? Networks.PUBLIC
+    : Networks.TESTNET;
+
+const DEFAULT_TIMEOUT = 180;
+const FEE_BUMP_MULTIPLIER = 2;
+const MAX_FEE_BUMP_ATTEMPTS = 3;
+const STUCK_RESULT_CODES = [
+  'tx_bad_seq',
+  'tx_insufficient_fee',
+  'tx_too_late',
+];
+
+// ---------------------------------------------------------------------------
+// Error helper
+// ---------------------------------------------------------------------------
+function createError(message, status, code) {
+  const err = new Error(message);
+  err.status = status;
+  err.code = code;
+  return err;
+}
+
+// ---------------------------------------------------------------------------
+// Core: submit(operation, signers, options)
+// ---------------------------------------------------------------------------
+
+/**
+ * Builds, signs, and submits a Stellar transaction.
+ *
+ * Flow:
+ *  1. Fetch fresh sequence number from Horizon via loadAccount
+ *  2. Build transaction with the provided operation(s)
+ *  3. Sign with all provided signers
+ *  4. Submit to Horizon
+ *  5. If the transaction is stuck (bad_seq, insufficient_fee, too_late),
+ *     automatically retry with a fee-bump transaction
+ *  6. Parse the result and store in DB
+ *
+ * @param {object} params
+ * @param {string} params.sourceAddress - Source account public key
+ * @param {import('stellar-sdk').xdr.Operation[]} params.operations - One or more Stellar operations
+ * @param {import('stellar-sdk').Keypair[]} params.signers - Keypairs to sign with
+ * @param {object} [params.options]
+ * @param {number} [params.options.timeout=180] - Transaction timeout in seconds
+ * @param {string} [params.options.memo] - Memo text
+ * @param {string} [params.options.feeSourceSecret] - Secret key for fee-bump fee source (if different)
+ * @param {object} [params.options.metadata] - Metadata to store alongside the DB record
+ * @param {string} [params.options.txType='transfer'] - Transaction type for DB classification
+ * @param {string} [params.options.amount] - Amount for DB record
+ * @param {string} [params.options.fromWallet] - From wallet for DB record
+ * @param {string} [params.options.toWallet] - To wallet for DB record
+ * @param {number} [params.options.merchantId] - Merchant ID for DB record
+ * @param {number} [params.options.campaignId] - Campaign ID for DB record
+ * @param {number} [params.options.userId] - User ID for DB record
+ * @returns {Promise<{ txHash: string, ledger: number, status: string, resultXdr: string }>}
+ */
+async function submit({ sourceAddress, operations, signers, options = {} }) {
+  if (!sourceAddress) {
+    throw createError('sourceAddress is required', 400, 'validation_error');
+  }
+
+  if (!operations || (Array.isArray(operations) && operations.length === 0)) {
+    throw createError('At least one operation is required', 400, 'validation_error');
+  }
+
+  if (!signers || (Array.isArray(signers) && signers.length === 0)) {
+    throw createError('At least one signer is required', 400, 'validation_error');
+  }
+
+  const ops = Array.isArray(operations) ? operations : [operations];
+  const signerList = Array.isArray(signers) ? signers : [signers];
+
+  // 1. Fetch fresh sequence number from Horizon
+  const account = await server.loadAccount(sourceAddress);
+
+  // 2. Build transaction
+  const timeout = options.timeout || DEFAULT_TIMEOUT;
+  let builder = new TransactionBuilder(account, {
+    fee: BASE_FEE,
+    networkPassphrase: NETWORK_PASSPHRASE,
+  });
+
+  for (const op of ops) {
+    builder = builder.addOperation(op);
+  }
+
+  if (options.memo) {
+    builder = builder.addMemo(require('stellar-sdk').Memo.text(options.memo));
+  }
+
+  builder = builder.setTimeout(timeout);
+  const transaction = builder.build();
+
+  // 3. Sign with all signers
+  for (const signer of signerList) {
+    transaction.sign(signer);
+  }
+
+  // 4. Submit with automatic fee-bump retry for stuck transactions
+  const result = await submitWithFeeBumpRetry(transaction, options);
+
+  // 5. Parse and store result in DB
+  await storeTransactionResult(result, options);
+
+  return result;
+}
+
+// ---------------------------------------------------------------------------
+// Fee bump for stuck transactions
+// ---------------------------------------------------------------------------
+
+/**
+ * Submits a transaction, and if it's stuck (bad_seq, insufficient_fee, too_late),
+ * retries with a fee-bump transaction up to MAX_FEE_BUMP_ATTEMPTS times.
+ *
+ * @param {import('stellar-sdk').Transaction} transaction
+ * @param {object} options
+ * @returns {Promise<{ txHash: string, ledger: number, status: string, resultXdr: string }>}
+ */
+async function submitWithFeeBumpRetry(transaction, options = {}) {
+  let lastError;
+
+  for (let attempt = 0; attempt <= MAX_FEE_BUMP_ATTEMPTS; attempt++) {
+    try {
+      const horizonResult = await server.submitTransaction(transaction);
+
+      return {
+        txHash: horizonResult.hash,
+        ledger: horizonResult.ledger,
+        status: 'submitted',
+        resultXdr: horizonResult.result_xdr,
+        _raw: horizonResult,
+      };
+    } catch (err) {
+      lastError = err;
+
+      const resultCodes = extractResultCodes(err);
+      const isStuck = STUCK_RESULT_CODES.some((code) =>
+        resultCodes.includes(code),
+      );
+
+      if (!isStuck || attempt >= MAX_FEE_BUMP_ATTEMPTS) {
+        break;
+      }
+
+      // Transaction is stuck — build and submit a fee-bump transaction
+      const feeSourceSecret =
+        options.feeSourceSecret || getRequiredConfig('FEE_SOURCE_SECRET');
+      const feeSourceKeypair = Keypair.fromSecret(feeSourceSecret);
+      const bumpedFee = String(
+        parseInt(transaction.fee, 10) * FEE_BUMP_MULTIPLIER * (attempt + 1),
+      );
+
+      const feeBumpTx = TransactionBuilder.buildFeeBumpTransaction(
+        feeSourceKeypair,
+        bumpedFee,
+        transaction,
+        NETWORK_PASSPHRASE,
+      );
+      feeBumpTx.sign(feeSourceKeypair);
+
+      // Replace transaction reference for next iteration
+      // (on next attempt we'll submit the fee-bump tx itself)
+      const feeBumpResult = await submitFeeBumpTransaction(feeBumpTx);
+      return feeBumpResult;
+    }
+  }
+
+  // All attempts exhausted — parse and throw
+  const resultCodes = extractResultCodes(lastError);
+  throw createError(
+    `Transaction submission failed: ${resultCodes.join(', ') || lastError.message}`,
+    400,
+    'tx_submission_failed',
+  );
+}
+
+/**
+ * Submits a fee-bump transaction to Horizon.
+ *
+ * @param {import('stellar-sdk').FeeBumpTransaction} feeBumpTx
+ * @returns {Promise<{ txHash: string, ledger: number, status: string, resultXdr: string }>}
+ */
+async function submitFeeBumpTransaction(feeBumpTx) {
+  try {
+    const horizonResult = await server.submitTransaction(feeBumpTx);
+
+    return {
+      txHash: horizonResult.hash,
+      ledger: horizonResult.ledger,
+      status: 'submitted',
+      resultXdr: horizonResult.result_xdr,
+      _raw: horizonResult,
+    };
+  } catch (err) {
+    const resultCodes = extractResultCodes(err);
+    throw createError(
+      `Fee-bump submission failed: ${resultCodes.join(', ') || err.message}`,
+      400,
+      'tx_fee_bump_failed',
+    );
+  }
+}
+
+/**
+ * Explicitly submits a fee-bump for a previously submitted stuck transaction.
+ *
+ * @param {object} params
+ * @param {string} params.innerTxXDR - The XDR of the original (stuck) transaction
+ * @param {string} params.feeSourceSecret - Secret key of the account paying the fee
+ * @param {string} [params.baseFee] - Base fee for the fee-bump (default: 2x current fee)
+ * @returns {Promise<{ txHash: string, ledger: number, status: string, resultXdr: string }>}
+ */
+async function submitFeeBump({ innerTxXDR, feeSourceSecret, baseFee }) {
+  if (!innerTxXDR) {
+    throw createError('innerTxXDR is required', 400, 'validation_error');
+  }
+
+  if (!feeSourceSecret) {
+    throw createError('feeSourceSecret is required', 400, 'validation_error');
+  }
+
+  const feeSourceKeypair = Keypair.fromSecret(feeSourceSecret);
+  const innerTx = TransactionBuilder.fromXDR(innerTxXDR, NETWORK_PASSPHRASE);
+
+  const effectiveBaseFee = baseFee || String(parseInt(BASE_FEE, 10) * FEE_BUMP_MULTIPLIER);
+
+  const feeBumpTx = TransactionBuilder.buildFeeBumpTransaction(
+    feeSourceKeypair,
+    effectiveBaseFee,
+    innerTx,
+    NETWORK_PASSPHRASE,
+  );
+  feeBumpTx.sign(feeSourceKeypair);
+
+  return submitFeeBumpTransaction(feeBumpTx);
+}
+
+// ---------------------------------------------------------------------------
+// Result parsing and DB storage
+// ---------------------------------------------------------------------------
+
+/**
+ * Extracts Horizon result codes from a submission error.
+ *
+ * @param {Error} err
+ * @returns {string[]}
+ */
+function extractResultCodes(err) {
+  try {
+    const extras = err.response?.data?.extras;
+    if (!extras) return [];
+
+    const codes = extras.result_codes || {};
+    const allCodes = [];
+
+    if (codes.transaction) allCodes.push(...codes.transaction);
+    if (codes.operations) allCodes.push(...codes.operations);
+
+    return allCodes;
+  } catch {
+    return [];
+  }
+}
+
+/**
+ * Parses a successful Horizon submission result into a structured object.
+ *
+ * @param {object} horizonResult - Raw Horizon response
+ * @returns {{ txHash: string, ledger: number, status: string, resultXdr: string, successful: boolean }}
+ */
+function parseTransactionResult(horizonResult) {
+  return {
+    txHash: horizonResult.hash,
+    ledger: horizonResult.ledger,
+    status: horizonResult.successful ? 'completed' : 'failed',
+    resultXdr: horizonResult.result_xdr || null,
+    successful: horizonResult.successful,
+  };
+}
+
+/**
+ * Stores the transaction result in the database.
+ *
+ * @param {{ txHash: string, ledger: number, status: string, resultXdr: string }} result
+ * @param {object} options
+ */
+async function storeTransactionResult(result, options = {}) {
+  try {
+    await recordTransaction({
+      txHash: result.txHash,
+      txType: options.txType || 'transfer',
+      amount: options.amount || '0',
+      fromWallet: options.fromWallet || null,
+      toWallet: options.toWallet || null,
+      merchantId: options.merchantId || null,
+      campaignId: options.campaignId || null,
+      userId: options.userId || null,
+      stellarLedger: result.ledger,
+      status: result.status === 'submitted' ? 'completed' : result.status,
+      metadata: {
+        ...options.metadata,
+        resultXdr: result.resultXdr,
+      },
+    });
+  } catch (dbErr) {
+    // Log but don't fail the response — the tx was already submitted on-chain
+    console.error('[stellarTransactionService] Failed to store transaction result:', dbErr.message);
+  }
+}
+
+// ---------------------------------------------------------------------------
+// Fetch current sequence number (exposed for external consumers)
+// ---------------------------------------------------------------------------
+
+/**
+ * Fetches the current sequence number for a Stellar account from Horizon.
+ *
+ * @param {string} publicKey - Stellar public key
+ * @returns {Promise<string>} Sequence number as a string
+ */
+async function getSequenceNumber(publicKey) {
+  const account = await server.loadAccount(publicKey);
+  return account.sequence;
+}
+
+module.exports = {
+  submit,
+  submitFeeBump,
+  submitFeeBumpTransaction,
+  parseTransactionResult,
+  extractResultCodes,
+  getSequenceNumber,
+  storeTransactionResult,
+  NETWORK_PASSPHRASE,
+  STUCK_RESULT_CODES,
+  FEE_BUMP_MULTIPLIER,
+  MAX_FEE_BUMP_ATTEMPTS,
+};

--- a/novaRewards/backend/tests/stellarAuth.test.js
+++ b/novaRewards/backend/tests/stellarAuth.test.js
@@ -1,0 +1,369 @@
+/**
+ * Tests for Stellar wallet authentication (challenge-response flow).
+ *
+ * Covers:
+ *  - POST /api/auth/challenge  (happy path, validation, nonce generation)
+ *  - POST /api/auth/verify     (happy path, expired nonce, invalid signature, replay)
+ *  - stellarAuthService internals (nonce storage, signature verification, JWT claims)
+ */
+
+// ---------------------------------------------------------------------------
+// Module mocks
+// ---------------------------------------------------------------------------
+jest.mock('../lib/redis', () => {
+  const store = new Map();
+  const expiries = new Map();
+  return {
+    client: {
+      isOpen: true,
+      get: jest.fn((key) => {
+        if (expiries.has(key) && Date.now() > expiries.get(key)) {
+          store.delete(key);
+          expiries.delete(key);
+          return Promise.resolve(null);
+        }
+        return Promise.resolve(store.get(key) || null);
+      }),
+      set: jest.fn((key, value, opts) => {
+        store.set(key, value);
+        if (opts?.EX) expiries.set(key, Date.now() + opts.EX * 1000);
+        return Promise.resolve('OK');
+      }),
+      del: jest.fn((key) => {
+        const had = store.has(key);
+        store.delete(key);
+        expiries.delete(key);
+        return Promise.resolve(had ? 1 : 0);
+      }),
+    },
+    connectRedis: jest.fn(),
+  };
+});
+
+jest.mock('../db/index', () => ({
+  query: jest.fn(),
+  pool: { end: jest.fn() },
+}));
+
+jest.mock('../middleware/rateLimiter', () => ({
+  slidingAuth: (req, res, next) => next(),
+  slidingGlobal: (req, res, next) => next(),
+}));
+
+const express = require('express');
+const request = require('supertest');
+const { Keypair } = require('stellar-sdk');
+const jwt = require('jsonwebtoken');
+
+const { query } = require('../db/index');
+const { client: redisClient } = require('../lib/redis');
+const stellarAuthService = require('../services/stellarAuthService');
+
+// ---------------------------------------------------------------------------
+// Test app
+// ---------------------------------------------------------------------------
+function buildApp() {
+  const app = express();
+  app.use(express.json());
+  app.use('/api/auth', require('../routes/stellarAuth'));
+  app.use((err, _req, res, _next) => {
+    res.status(err.status || 500).json({
+      success: false,
+      error: err.code || 'internal_error',
+      message: err.message || 'An unexpected error occurred',
+    });
+  });
+  return app;
+}
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+const JWT_SECRET = process.env.JWT_SECRET || 'test-jwt-secret-for-tests';
+process.env.JWT_SECRET = JWT_SECRET;
+
+function signChallenge(keypair, message) {
+  const msgBytes = Buffer.from(message, 'utf-8');
+  const sig = keypair.sign(msgBytes);
+  return sig.toString('base64');
+}
+
+// ---------------------------------------------------------------------------
+// Tests
+// ---------------------------------------------------------------------------
+describe('Stellar Auth — POST /api/auth/challenge', () => {
+  const app = buildApp();
+
+  it('returns a nonce tied to the wallet address', async () => {
+    const kp = Keypair.random();
+    const wallet = kp.publicKey();
+
+    const res = await request(app)
+      .post('/api/auth/challenge')
+      .send({ walletAddress: wallet });
+
+    expect(res.status).toBe(200);
+    expect(res.body.success).toBe(true);
+    expect(res.body.data.walletAddress).toBe(wallet);
+    expect(res.body.data.nonce).toBeDefined();
+    expect(typeof res.body.data.nonce).toBe('string');
+    expect(res.body.data.expiresAt).toBeGreaterThan(Math.floor(Date.now() / 1000));
+    expect(res.body.data.message).toContain(wallet);
+    expect(res.body.data.message).toContain(res.body.data.nonce);
+  });
+
+  it('returns 400 when walletAddress is missing', async () => {
+    const res = await request(app)
+      .post('/api/auth/challenge')
+      .send({});
+
+    expect(res.status).toBe(400);
+    expect(res.body.error).toBe('validation_error');
+  });
+
+  it('returns 400 for an invalid Stellar address', async () => {
+    const res = await request(app)
+      .post('/api/auth/challenge')
+      .send({ walletAddress: 'not-a-valid-key' });
+
+    expect(res.status).toBe(400);
+    expect(res.body.error).toBe('validation_error');
+  });
+
+  it('overwrites previous nonce for the same wallet', async () => {
+    const kp = Keypair.random();
+    const wallet = kp.publicKey();
+
+    const res1 = await request(app)
+      .post('/api/auth/challenge')
+      .send({ walletAddress: wallet });
+
+    const res2 = await request(app)
+      .post('/api/auth/challenge')
+      .send({ walletAddress: wallet });
+
+    expect(res2.status).toBe(200);
+    // Nonces should differ (UUID v4)
+    expect(res2.body.data.nonce).not.toBe(res1.body.data.nonce);
+  });
+});
+
+describe('Stellar Auth — POST /api/auth/verify', () => {
+  const app = buildApp();
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+    // Default: user not found → auto-create
+    query.mockReset();
+    query.mockResolvedValue({
+      rows: [{ id: 1, wallet_address: 'auto', role: 'user' }],
+    });
+  });
+
+  it('issues a JWT on valid signature', async () => {
+    const kp = Keypair.random();
+    const wallet = kp.publicKey();
+
+    // Step 1: get challenge
+    const challengeRes = await request(app)
+      .post('/api/auth/challenge')
+      .send({ walletAddress: wallet });
+
+    const { nonce, message } = challengeRes.body.data;
+
+    // Step 2: sign the challenge message
+    const signedChallenge = signChallenge(kp, message);
+
+    // Step 3: verify
+    const verifyRes = await request(app)
+      .post('/api/auth/verify')
+      .send({ walletAddress: wallet, signedChallenge });
+
+    expect(verifyRes.status).toBe(200);
+    expect(verifyRes.body.success).toBe(true);
+    expect(verifyRes.body.data.accessToken).toBeDefined();
+    expect(verifyRes.body.data.refreshToken).toBeDefined();
+    expect(verifyRes.body.data.user.walletAddress).toBe(wallet);
+    expect(verifyRes.body.data.user.role).toBe('user');
+
+    // Verify JWT claims
+    const decoded = jwt.verify(verifyRes.body.data.accessToken, JWT_SECRET);
+    expect(decoded.walletAddress).toBe(wallet);
+    expect(decoded.role).toBe('user');
+    expect(decoded.userId).toBeDefined();
+    expect(decoded.exp).toBeGreaterThan(Math.floor(Date.now() / 1000));
+  });
+
+  it('returns 401 for expired or missing nonce', async () => {
+    const kp = Keypair.random();
+    const wallet = kp.publicKey();
+
+    // No challenge was requested
+    const message = stellarAuthService._buildChallengeMessage(wallet, 'fake-nonce');
+    const signedChallenge = signChallenge(kp, message);
+
+    const res = await request(app)
+      .post('/api/auth/verify')
+      .send({ walletAddress: wallet, signedChallenge });
+
+    expect(res.status).toBe(401);
+    expect(res.body.error).toBe('challenge_expired');
+  });
+
+  it('returns 401 for an invalid signature', async () => {
+    const kp = Keypair.random();
+    const wallet = kp.publicKey();
+
+    // Get a valid challenge
+    const challengeRes = await request(app)
+      .post('/api/auth/challenge')
+      .send({ walletAddress: wallet });
+
+    // Sign with a different keypair
+    const wrongKp = Keypair.random();
+    const signedChallenge = signChallenge(wrongKp, challengeRes.body.data.message);
+
+    const res = await request(app)
+      .post('/api/auth/verify')
+      .send({ walletAddress: wallet, signedChallenge });
+
+    expect(res.status).toBe(401);
+    expect(res.body.error).toBe('invalid_signature');
+  });
+
+  it('prevents replay attacks — nonce is single-use', async () => {
+    const kp = Keypair.random();
+    const wallet = kp.publicKey();
+
+    const challengeRes = await request(app)
+      .post('/api/auth/challenge')
+      .send({ walletAddress: wallet });
+
+    const message = challengeRes.body.data.message;
+    const signedChallenge = signChallenge(kp, message);
+
+    // First verification succeeds
+    const res1 = await request(app)
+      .post('/api/auth/verify')
+      .send({ walletAddress: wallet, signedChallenge });
+    expect(res1.status).toBe(200);
+
+    // Replay the same signature → should fail
+    const res2 = await request(app)
+      .post('/api/auth/verify')
+      .send({ walletAddress: wallet, signedChallenge });
+    expect(res2.status).toBe(401);
+    expect(res2.body.error).toBe('challenge_expired');
+  });
+
+  it('returns 400 when walletAddress is missing', async () => {
+    const res = await request(app)
+      .post('/api/auth/verify')
+      .send({ signedChallenge: 'abc' });
+
+    expect(res.status).toBe(400);
+    expect(res.body.error).toBe('validation_error');
+  });
+
+  it('returns 400 when signedChallenge is missing', async () => {
+    const kp = Keypair.random();
+    const res = await request(app)
+      .post('/api/auth/verify')
+      .send({ walletAddress: kp.publicKey() });
+
+    expect(res.status).toBe(400);
+    expect(res.body.error).toBe('validation_error');
+  });
+
+  it('returns 400 for an invalid wallet address', async () => {
+    const res = await request(app)
+      .post('/api/auth/verify')
+      .send({ walletAddress: 'invalid', signedChallenge: 'abc' });
+
+    expect(res.status).toBe(400);
+  });
+
+  it('uses existing user role when user already exists', async () => {
+    const kp = Keypair.random();
+    const wallet = kp.publicKey();
+
+    // Mock: user already exists with admin role
+    query.mockResolvedValueOnce({
+      rows: [{ id: 42, wallet_address: wallet, role: 'admin' }],
+    });
+
+    const challengeRes = await request(app)
+      .post('/api/auth/challenge')
+      .send({ walletAddress: wallet });
+
+    const message = challengeRes.body.data.message;
+    const signedChallenge = signChallenge(kp, message);
+
+    const verifyRes = await request(app)
+      .post('/api/auth/verify')
+      .send({ walletAddress: wallet, signedChallenge });
+
+    expect(verifyRes.status).toBe(200);
+    expect(verifyRes.body.data.user.role).toBe('admin');
+
+    const decoded = jwt.verify(verifyRes.body.data.accessToken, JWT_SECRET);
+    expect(decoded.role).toBe('admin');
+  });
+});
+
+describe('stellarAuthService internals', () => {
+  describe('_buildChallengeMessage', () => {
+    it('produces a deterministic message with wallet and nonce', () => {
+      const msg = stellarAuthService._buildChallengeMessage(
+        'GABC123',
+        'nonce-xyz',
+      );
+      expect(msg).toBe('NovaRewards Auth\nWallet: GABC123\nNonce: nonce-xyz');
+    });
+  });
+
+  describe('_isValidWallet', () => {
+    it('accepts valid Ed25519 public keys', () => {
+      const kp = Keypair.random();
+      expect(stellarAuthService._isValidWallet(kp.publicKey())).toBe(true);
+    });
+
+    it('rejects invalid strings', () => {
+      expect(stellarAuthService._isValidWallet('not-a-key')).toBe(false);
+      expect(stellarAuthService._isValidWallet('')).toBe(false);
+      expect(stellarAuthService._isValidWallet(null)).toBe(false);
+      expect(stellarAuthService._isValidWallet(undefined)).toBe(false);
+      expect(stellarAuthService._isValidWallet(123)).toBe(false);
+    });
+  });
+
+  describe('_verifyStellarSignature', () => {
+    it('returns true for a valid signature', () => {
+      const kp = Keypair.random();
+      const message = 'test message';
+      const sig = signChallenge(kp, message);
+
+      expect(
+        stellarAuthService._verifyStellarSignature(kp.publicKey(), message, sig),
+      ).toBe(true);
+    });
+
+    it('returns false for a signature from a different key', () => {
+      const kp1 = Keypair.random();
+      const kp2 = Keypair.random();
+      const message = 'test message';
+      const sig = signChallenge(kp1, message);
+
+      expect(
+        stellarAuthService._verifyStellarSignature(kp2.publicKey(), message, sig),
+      ).toBe(false);
+    });
+
+    it('returns false for malformed signature', () => {
+      const kp = Keypair.random();
+      expect(
+        stellarAuthService._verifyStellarSignature(kp.publicKey(), 'msg', 'not-base64!!!'),
+      ).toBe(false);
+    });
+  });
+});

--- a/novaRewards/backend/tests/stellarTransactionService.test.js
+++ b/novaRewards/backend/tests/stellarTransactionService.test.js
@@ -1,0 +1,566 @@
+/**
+ * Tests for the Stellar Transaction Submission Service.
+ *
+ * Covers:
+ *  - stellarTransactionService.submit()  (build, sign, submit, fee-bump retry, DB storage)
+ *  - stellarTransactionService.submitFeeBump()  (explicit fee-bump from XDR)
+ *  - stellarTransactionService.parseTransactionResult()
+ *  - stellarTransactionService.extractResultCodes()
+ *  - stellarTransactionService.getSequenceNumber()
+ *  - Route: POST /api/transactions/submit
+ *  - Route: POST /api/transactions/fee-bump
+ *  - Route: GET  /api/transactions/sequence/:publicKey
+ */
+
+// ---------------------------------------------------------------------------
+// Module mocks
+// ---------------------------------------------------------------------------
+jest.mock('../../blockchain/stellarService', () => ({
+  server: {
+    loadAccount: jest.fn(),
+    submitTransaction: jest.fn(),
+    transactions: jest.fn(() => ({
+      transaction: jest.fn(() => ({
+        call: jest.fn(),
+      })),
+    })),
+  },
+  NOVA: { code: 'NOVA', issuer: 'GTESTISSUER' },
+  isValidStellarAddress: jest.fn((addr) => {
+    if (typeof addr !== 'string') return false;
+    try {
+      const { StrKey } = require('stellar-sdk');
+      return StrKey.isValidEd25519PublicKey(addr);
+    } catch {
+      return false;
+    }
+  }),
+}));
+
+jest.mock('../db/transactionRepository', () => ({
+  recordTransaction: jest.fn(),
+}));
+
+jest.mock('../lib/redis', () => ({
+  client: { isOpen: true, get: jest.fn(), set: jest.fn(), del: jest.fn() },
+  connectRedis: jest.fn(),
+}));
+
+jest.mock('../middleware/authenticateUser', () => ({
+  authenticateUser: (req, res, next) => {
+    req.user = { id: 1, role: 'user' };
+    next();
+  },
+  requireAdmin: (req, res, next) => next(),
+}));
+
+jest.mock('../middleware/rateLimiter', () => ({
+  slidingAuth: (req, res, next) => next(),
+  slidingGlobal: (req, res, next) => next(),
+}));
+
+const express = require('express');
+const request = require('supertest');
+const {
+  Keypair,
+  Account,
+  Operation,
+  Asset,
+  TransactionBuilder,
+  Networks,
+  BASE_FEE,
+} = require('stellar-sdk');
+
+const { server } = require('../../blockchain/stellarService');
+const { recordTransaction } = require('../db/transactionRepository');
+const stellarTxService = require('../services/stellarTransactionService');
+
+// ---------------------------------------------------------------------------
+// Env setup
+// ---------------------------------------------------------------------------
+process.env.JWT_SECRET = process.env.JWT_SECRET || 'test-jwt-secret';
+process.env.STELLAR_NETWORK = 'testnet';
+
+// ---------------------------------------------------------------------------
+// Test app
+// ---------------------------------------------------------------------------
+function buildApp() {
+  const app = express();
+  app.use(express.json());
+  app.use('/api/transactions', require('../routes/stellarTransaction'));
+  app.use((err, _req, res, _next) => {
+    res.status(err.status || 500).json({
+      success: false,
+      error: err.code || 'internal_error',
+      message: err.message || 'An unexpected error occurred',
+    });
+  });
+  return app;
+}
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+function mockAccount(publicKey, sequence = '12345') {
+  return new Account(publicKey, sequence);
+}
+
+function buildSignedTx(sourceKeypair, destination, amount = '10') {
+  const account = mockAccount(sourceKeypair.publicKey());
+  const tx = new TransactionBuilder(account, {
+    fee: BASE_FEE,
+    networkPassphrase: Networks.TESTNET,
+  })
+    .addOperation(
+      Operation.payment({
+        destination,
+        asset: Asset.native(),
+        amount,
+      }),
+    )
+    .setTimeout(180)
+    .build();
+  tx.sign(sourceKeypair);
+  return tx;
+}
+
+// ---------------------------------------------------------------------------
+// Tests: stellarTransactionService internals
+// ---------------------------------------------------------------------------
+describe('stellarTransactionService — parseTransactionResult', () => {
+  it('parses a successful result', () => {
+    const result = stellarTxService.parseTransactionResult({
+      hash: 'abc123',
+      ledger: 42,
+      successful: true,
+      result_xdr: 'AAAAAA==',
+    });
+
+    expect(result.txHash).toBe('abc123');
+    expect(result.ledger).toBe(42);
+    expect(result.status).toBe('completed');
+    expect(result.successful).toBe(true);
+    expect(result.resultXdr).toBe('AAAAAA==');
+  });
+
+  it('parses a failed result', () => {
+    const result = stellarTxService.parseTransactionResult({
+      hash: 'def456',
+      ledger: 99,
+      successful: false,
+      result_xdr: 'BBBBBB==',
+    });
+
+    expect(result.status).toBe('failed');
+    expect(result.successful).toBe(false);
+  });
+});
+
+describe('stellarTransactionService — extractResultCodes', () => {
+  it('extracts result codes from Horizon error', () => {
+    const err = {
+      response: {
+        data: {
+          extras: {
+            result_codes: {
+              transaction: ['tx_bad_seq'],
+              operations: ['op_no_source_account'],
+            },
+          },
+        },
+      },
+    };
+
+    const codes = stellarTxService.extractResultCodes(err);
+    expect(codes).toContain('tx_bad_seq');
+    expect(codes).toContain('op_no_source_account');
+  });
+
+  it('returns empty array for errors without extras', () => {
+    expect(stellarTxService.extractResultCodes(new Error('network error'))).toEqual([]);
+  });
+});
+
+describe('stellarTransactionService — getSequenceNumber', () => {
+  beforeEach(() => jest.clearAllMocks());
+
+  it('fetches sequence from Horizon', async () => {
+    const kp = Keypair.random();
+    server.loadAccount.mockResolvedValue(mockAccount(kp.publicKey(), '98765'));
+
+    const seq = await stellarTxService.getSequenceNumber(kp.publicKey());
+    expect(seq).toBe('98765');
+    expect(server.loadAccount).toHaveBeenCalledWith(kp.publicKey());
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Tests: stellarTransactionService.submit()
+// ---------------------------------------------------------------------------
+describe('stellarTransactionService — submit', () => {
+  beforeEach(() => jest.clearAllMocks());
+
+  it('builds, signs, and submits a transaction with fresh sequence number', async () => {
+    const sourceKp = Keypair.random();
+    const destKp = Keypair.random();
+
+    server.loadAccount.mockResolvedValue(mockAccount(sourceKp.publicKey()));
+    server.submitTransaction.mockResolvedValue({
+      hash: 'txhash123',
+      ledger: 100,
+      result_xdr: 'AAAAAA==',
+    });
+    recordTransaction.mockResolvedValue({ id: 1 });
+
+    const result = await stellarTxService.submit({
+      sourceAddress: sourceKp.publicKey(),
+      operations: [
+        Operation.payment({
+          destination: destKp.publicKey(),
+          asset: Asset.native(),
+          amount: '10',
+        }),
+      ],
+      signers: [sourceKp],
+      options: { txType: 'transfer', amount: '10' },
+    });
+
+    expect(result.txHash).toBe('txhash123');
+    expect(result.ledger).toBe(100);
+    expect(result.status).toBe('submitted');
+
+    // Sequence number fetched fresh
+    expect(server.loadAccount).toHaveBeenCalledWith(sourceKp.publicKey());
+
+    // Transaction was submitted
+    expect(server.submitTransaction).toHaveBeenCalledTimes(1);
+
+    // Result stored in DB
+    expect(recordTransaction).toHaveBeenCalledWith(
+      expect.objectContaining({
+        txHash: 'txhash123',
+        txType: 'transfer',
+        amount: '10',
+        stellarLedger: 100,
+      }),
+    );
+  });
+
+  it('throws on missing sourceAddress', async () => {
+    await expect(
+      stellarTxService.submit({
+        sourceAddress: '',
+        operations: [Operation.payment({ destination: 'G', asset: Asset.native(), amount: '1' })],
+        signers: [Keypair.random()],
+      }),
+    ).rejects.toThrow('sourceAddress is required');
+  });
+
+  it('throws on missing operations', async () => {
+    await expect(
+      stellarTxService.submit({
+        sourceAddress: Keypair.random().publicKey(),
+        operations: [],
+        signers: [Keypair.random()],
+      }),
+    ).rejects.toThrow('At least one operation is required');
+  });
+
+  it('throws on missing signers', async () => {
+    await expect(
+      stellarTxService.submit({
+        sourceAddress: Keypair.random().publicKey(),
+        operations: [Operation.payment({ destination: 'G', asset: Asset.native(), amount: '1' })],
+        signers: [],
+      }),
+    ).rejects.toThrow('At least one signer is required');
+  });
+
+  it('attempts fee-bump retry when transaction is stuck (tx_bad_seq)', async () => {
+    const sourceKp = Keypair.random();
+    const feeSourceKp = Keypair.random();
+    process.env.FEE_SOURCE_SECRET = feeSourceKp.secret();
+
+    server.loadAccount.mockResolvedValue(mockAccount(sourceKp.publicKey()));
+
+    // First submission fails with tx_bad_seq
+    const stuckError = new Error('tx_bad_seq');
+    stuckError.response = {
+      data: {
+        extras: {
+          result_codes: { transaction: ['tx_bad_seq'] },
+        },
+      },
+    };
+    server.submitTransaction
+      .mockRejectedValueOnce(stuckError)
+      .mockResolvedValueOnce({
+        hash: 'feebumphash',
+        ledger: 101,
+        result_xdr: 'CCCCCC==',
+      });
+
+    recordTransaction.mockResolvedValue({ id: 2 });
+
+    const result = await stellarTxService.submit({
+      sourceAddress: sourceKp.publicKey(),
+      operations: [
+        Operation.payment({
+          destination: Keypair.random().publicKey(),
+          asset: Asset.native(),
+          amount: '5',
+        }),
+      ],
+      signers: [sourceKp],
+      options: { feeSourceSecret: feeSourceKp.secret() },
+    });
+
+    expect(result.txHash).toBe('feebumphash');
+    expect(server.submitTransaction).toHaveBeenCalledTimes(2);
+
+    delete process.env.FEE_SOURCE_SECRET;
+  });
+
+  it('does not retry fee-bump for non-stuck errors', async () => {
+    const sourceKp = Keypair.random();
+    server.loadAccount.mockResolvedValue(mockAccount(sourceKp.publicKey()));
+
+    const otherError = new Error('op_bad_auth');
+    otherError.response = {
+      data: {
+        extras: {
+          result_codes: { transaction: ['op_bad_auth'] },
+        },
+      },
+    };
+    server.submitTransaction.mockRejectedValue(otherError);
+
+    await expect(
+      stellarTxService.submit({
+        sourceAddress: sourceKp.publicKey(),
+        operations: [
+          Operation.payment({
+            destination: Keypair.random().publicKey(),
+            asset: Asset.native(),
+            amount: '1',
+          }),
+        ],
+        signers: [sourceKp],
+      }),
+    ).rejects.toThrow('Transaction submission failed');
+
+    // Only one submission attempt (no retry)
+    expect(server.submitTransaction).toHaveBeenCalledTimes(1);
+  });
+
+  it('stores result in DB even with default status mapping', async () => {
+    const sourceKp = Keypair.random();
+    server.loadAccount.mockResolvedValue(mockAccount(sourceKp.publicKey()));
+    server.submitTransaction.mockResolvedValue({
+      hash: 'abc',
+      ledger: 50,
+      result_xdr: null,
+    });
+    recordTransaction.mockResolvedValue({ id: 3 });
+
+    await stellarTxService.submit({
+      sourceAddress: sourceKp.publicKey(),
+      operations: [
+        Operation.payment({
+          destination: Keypair.random().publicKey(),
+          asset: Asset.native(),
+          amount: '1',
+        }),
+      ],
+      signers: [sourceKp],
+    });
+
+    expect(recordTransaction).toHaveBeenCalledWith(
+      expect.objectContaining({ status: 'completed' }),
+    );
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Tests: stellarTransactionService.submitFeeBump()
+// ---------------------------------------------------------------------------
+describe('stellarTransactionService — submitFeeBump (explicit)', () => {
+  beforeEach(() => jest.clearAllMocks());
+
+  it('throws on missing innerTxXDR', async () => {
+    await expect(
+      stellarTxService.submitFeeBump({ innerTxXDR: '', feeSourceSecret: 'S...' }),
+    ).rejects.toThrow('innerTxXDR is required');
+  });
+
+  it('throws on missing feeSourceSecret', async () => {
+    await expect(
+      stellarTxService.submitFeeBump({ innerTxXDR: 'abc', feeSourceSecret: '' }),
+    ).rejects.toThrow('feeSourceSecret is required');
+  });
+
+  it('builds and submits a fee-bump transaction', async () => {
+    const sourceKp = Keypair.random();
+    const feeSourceKp = Keypair.random();
+    const innerTx = buildSignedTx(sourceKp, Keypair.random().publicKey());
+
+    server.submitTransaction.mockResolvedValue({
+      hash: 'bump123',
+      ledger: 200,
+      result_xdr: 'DDDDDD==',
+    });
+
+    const result = await stellarTxService.submitFeeBump({
+      innerTxXDR: innerTx.toXDR(),
+      feeSourceSecret: feeSourceKp.secret(),
+    });
+
+    expect(result.txHash).toBe('bump123');
+    expect(result.ledger).toBe(200);
+    expect(server.submitTransaction).toHaveBeenCalledTimes(1);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Tests: Routes
+// ---------------------------------------------------------------------------
+describe('Route: POST /api/transactions/submit', () => {
+  const app = buildApp();
+
+  beforeEach(() => jest.clearAllMocks());
+
+  it('returns 400 when sourceAddress is missing', async () => {
+    const res = await request(app)
+      .post('/api/transactions/submit')
+      .send({ signerSecret: 'S...', operations: [{ type: 'payment' }] });
+
+    expect(res.status).toBe(400);
+    expect(res.body.error).toBe('validation_error');
+  });
+
+  it('returns 400 when signerSecret is missing', async () => {
+    const kp = Keypair.random();
+    const res = await request(app)
+      .post('/api/transactions/submit')
+      .send({ sourceAddress: kp.publicKey(), operations: [{ type: 'payment' }] });
+
+    expect(res.status).toBe(400);
+    expect(res.body.error).toBe('validation_error');
+  });
+
+  it('returns 400 when operations is empty', async () => {
+    const kp = Keypair.random();
+    const res = await request(app)
+      .post('/api/transactions/submit')
+      .send({ sourceAddress: kp.publicKey(), signerSecret: kp.secret(), operations: [] });
+
+    expect(res.status).toBe(400);
+    expect(res.body.error).toBe('validation_error');
+  });
+
+  it('returns 400 for unsupported operation type', async () => {
+    const kp = Keypair.random();
+    server.loadAccount.mockResolvedValue(mockAccount(kp.publicKey()));
+
+    const res = await request(app)
+      .post('/api/transactions/submit')
+      .send({
+        sourceAddress: kp.publicKey(),
+        signerSecret: kp.secret(),
+        operations: [{ type: 'bogus_op' }],
+      });
+
+    expect(res.status).toBe(400);
+    expect(res.body.message).toContain('Unsupported operation type');
+  });
+
+  it('successfully submits a payment transaction', async () => {
+    const sourceKp = Keypair.random();
+    const destKp = Keypair.random();
+
+    server.loadAccount.mockResolvedValue(mockAccount(sourceKp.publicKey()));
+    server.submitTransaction.mockResolvedValue({
+      hash: 'routetx123',
+      ledger: 300,
+      result_xdr: 'EEEEEE==',
+    });
+    recordTransaction.mockResolvedValue({ id: 10 });
+
+    const res = await request(app)
+      .post('/api/transactions/submit')
+      .send({
+        sourceAddress: sourceKp.publicKey(),
+        signerSecret: sourceKp.secret(),
+        operations: [
+          {
+            type: 'payment',
+            destination: destKp.publicKey(),
+            assetCode: 'XLM',
+            amount: '25',
+          },
+        ],
+        txType: 'distribution',
+        amount: '25',
+      });
+
+    expect(res.status).toBe(200);
+    expect(res.body.success).toBe(true);
+    expect(res.body.data.txHash).toBe('routetx123');
+    expect(res.body.data.ledger).toBe(300);
+  });
+});
+
+describe('Route: POST /api/transactions/fee-bump', () => {
+  const app = buildApp();
+
+  beforeEach(() => jest.clearAllMocks());
+
+  it('returns 400 when innerTxXDR is missing', async () => {
+    const res = await request(app)
+      .post('/api/transactions/fee-bump')
+      .send({ feeSourceSecret: 'S...' });
+
+    expect(res.status).toBe(400);
+    expect(res.body.error).toBe('validation_error');
+  });
+
+  it('returns 400 when feeSourceSecret is missing', async () => {
+    const res = await request(app)
+      .post('/api/transactions/fee-bump')
+      .send({ innerTxXDR: 'abc' });
+
+    expect(res.status).toBe(400);
+    expect(res.body.error).toBe('validation_error');
+  });
+});
+
+describe('Route: GET /api/transactions/sequence/:publicKey', () => {
+  const app = buildApp();
+
+  beforeEach(() => jest.clearAllMocks());
+
+  it('returns the current sequence number', async () => {
+    const kp = Keypair.random();
+    server.loadAccount.mockResolvedValue(mockAccount(kp.publicKey(), '55555'));
+
+    const res = await request(app)
+      .get(`/api/transactions/sequence/${kp.publicKey()}`);
+
+    expect(res.status).toBe(200);
+    expect(res.body.success).toBe(true);
+    expect(res.body.data.sequence).toBe('55555');
+  });
+
+  it('returns 404 for non-existent account', async () => {
+    const kp = Keypair.random();
+    const err = new Error('Not found');
+    err.response = { status: 404 };
+    server.loadAccount.mockRejectedValue(err);
+
+    const res = await request(app)
+      .get(`/api/transactions/sequence/${kp.publicKey()}`);
+
+    expect(res.status).toBe(404);
+    expect(res.body.error).toBe('account_not_found');
+  });
+});

--- a/novaRewards/frontend/__tests__/WalletConnectButton.test.js
+++ b/novaRewards/frontend/__tests__/WalletConnectButton.test.js
@@ -1,0 +1,273 @@
+/**
+ * Tests for WalletConnectButton component and walletStore integration.
+ *
+ * Covers:
+ *  - Idle state → "Connect Wallet" button
+ *  - Connecting state → spinner + "Connecting…"
+ *  - Connected state → address + balance + network badge + disconnect
+ *  - Error state → error message + retry + dismiss
+ *  - walletStore: connect, disconnect, signTransaction, rehydration, clearError
+ */
+
+import { render, screen, fireEvent, waitFor, act } from '@testing-library/react';
+import '@testing-library/jest-dom';
+import WalletConnectButton from '../components/WalletConnectButton';
+import { useWalletStore } from '../store/walletStore';
+
+// ---------------------------------------------------------------------------
+// Mocks
+// ---------------------------------------------------------------------------
+jest.mock('../lib/freighter', () => ({
+  isFreighterInstalled: jest.fn(),
+  connectWallet: jest.fn(),
+  sign: jest.fn(),
+  getNetworkPassphrase: jest.fn(() => 'Test SDF Network ; September 2015'),
+}));
+
+jest.mock('../lib/horizonClient', () => ({
+  getNOVABalance: jest.fn(() => Promise.resolve('100.0000000')),
+  getTransactionHistory: jest.fn(() => Promise.resolve([])),
+}));
+
+const { isFreighterInstalled, connectWallet, sign } = require('../lib/freighter');
+
+// Helper to reset store between tests
+function resetStore() {
+  useWalletStore.setState({
+    publicKey: null,
+    walletType: null,
+    network: 'testnet',
+    balance: '0',
+    transactions: [],
+    freighterInstalled: null,
+    isLoading: false,
+    isSigning: false,
+    error: null,
+    hydrated: true,
+  });
+}
+
+// ---------------------------------------------------------------------------
+// Tests: WalletConnectButton component states
+// ---------------------------------------------------------------------------
+describe('WalletConnectButton — component states', () => {
+  beforeEach(() => {
+    resetStore();
+    jest.clearAllMocks();
+  });
+
+  it('renders "Connect Wallet" in idle state', () => {
+    render(<WalletConnectButton />);
+    const btn = screen.getByRole('button', { name: /connect wallet/i });
+    expect(btn).toBeInTheDocument();
+    expect(btn).toHaveTextContent('Connect Wallet');
+  });
+
+  it('renders "Connecting…" with spinner when loading', () => {
+    useWalletStore.setState({ isLoading: true });
+    render(<WalletConnectButton />);
+    const btn = screen.getByRole('button', { name: /connecting/i });
+    expect(btn).toBeDisabled();
+    expect(btn).toHaveTextContent('Connecting');
+  });
+
+  it('renders wallet address, balance, and network badge when connected', () => {
+    useWalletStore.setState({
+      publicKey: 'GABCDEF1234567890ABCDEF1234567890ABCDEF1234567890ABCDEF12',
+      balance: '250.0000000',
+      network: 'testnet',
+    });
+
+    render(<WalletConnectButton />);
+
+    expect(screen.getByText(/GABCDE…EF12/)).toBeInTheDocument();
+    expect(screen.getByText(/250 NOVA/)).toBeInTheDocument();
+    expect(screen.getByText('Testnet')).toBeInTheDocument();
+    expect(screen.getByRole('button', { name: /disconnect/i })).toBeInTheDocument();
+  });
+
+  it('shows "Mainnet" badge when on mainnet', () => {
+    useWalletStore.setState({
+      publicKey: 'GABCDEF1234567890ABCDEF1234567890ABCDEF1234567890ABCDEF12',
+      balance: '10',
+      network: 'mainnet',
+    });
+
+    render(<WalletConnectButton />);
+    expect(screen.getByText('Mainnet')).toBeInTheDocument();
+  });
+
+  it('renders error message with retry and dismiss when error is set and no publicKey', () => {
+    useWalletStore.setState({
+      error: 'Freighter wallet extension is not installed.',
+    });
+
+    render(<WalletConnectButton />);
+    expect(screen.getByText(/not installed/i)).toBeInTheDocument();
+    expect(screen.getByRole('button', { name: /retry/i })).toBeInTheDocument();
+    expect(screen.getByRole('button', { name: /dismiss/i })).toBeInTheDocument();
+  });
+
+  it('returns null when not yet hydrated', () => {
+    useWalletStore.setState({ hydrated: false });
+    const { container } = render(<WalletConnectButton />);
+    expect(container.innerHTML).toBe('');
+  });
+
+  it('calls connect() when "Connect Wallet" is clicked', async () => {
+    isFreighterInstalled.mockResolvedValue(true);
+    connectWallet.mockResolvedValue('GTESTPUBLICKEY123456789ABCDEFGHIJKLMNOPQRSTUVWXYZ12');
+
+    render(<WalletConnectButton />);
+    const btn = screen.getByRole('button', { name: /connect wallet/i });
+    await act(async () => { fireEvent.click(btn); });
+
+    expect(connectWallet).toHaveBeenCalled();
+  });
+
+  it('calls disconnect() when disconnect button is clicked', () => {
+    useWalletStore.setState({
+      publicKey: 'GABCDEF1234567890ABCDEF1234567890ABCDEF1234567890ABCDEF12',
+      balance: '50',
+    });
+
+    render(<WalletConnectButton />);
+    const btn = screen.getByRole('button', { name: /disconnect/i });
+    fireEvent.click(btn);
+
+    expect(useWalletStore.getState().publicKey).toBeNull();
+  });
+
+  it('calls clearError() when dismiss is clicked', () => {
+    useWalletStore.setState({ error: 'Some error' });
+
+    render(<WalletConnectButton />);
+    const dismiss = screen.getByRole('button', { name: /dismiss/i });
+    fireEvent.click(dismiss);
+
+    expect(useWalletStore.getState().error).toBeNull();
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Tests: walletStore actions
+// ---------------------------------------------------------------------------
+describe('walletStore — actions', () => {
+  beforeEach(() => {
+    resetStore();
+    jest.clearAllMocks();
+  });
+
+  it('connect() sets publicKey on successful connection', async () => {
+    isFreighterInstalled.mockResolvedValue(true);
+    connectWallet.mockResolvedValue('GTESTPUBLICKEY123456789ABCDEFGHIJKLMNOPQRSTUVWXYZ12');
+
+    await useWalletStore.getState().connect();
+
+    expect(useWalletStore.getState().publicKey).toBe('GTESTPUBLICKEY123456789ABCDEFGHIJKLMNOPQRSTUVWXYZ12');
+    expect(useWalletStore.getState().walletType).toBe('freighter');
+    expect(useWalletStore.getState().isLoading).toBe(false);
+  });
+
+  it('connect() sets error when Freighter is not installed', async () => {
+    isFreighterInstalled.mockResolvedValue(false);
+
+    await useWalletStore.getState().connect();
+
+    expect(useWalletStore.getState().publicKey).toBeNull();
+    expect(useWalletStore.getState().error).toContain('not installed');
+  });
+
+  it('connect() sets user-friendly error on access denied', async () => {
+    isFreighterInstalled.mockResolvedValue(true);
+    connectWallet.mockRejectedValue(new Error('Access denied by user'));
+
+    await useWalletStore.getState().connect();
+
+    expect(useWalletStore.getState().error).toContain('denied');
+  });
+
+  it('disconnect() clears all wallet state', () => {
+    useWalletStore.setState({
+      publicKey: 'GTEST',
+      walletType: 'freighter',
+      balance: '100',
+    });
+
+    useWalletStore.getState().disconnect();
+
+    expect(useWalletStore.getState().publicKey).toBeNull();
+    expect(useWalletStore.getState().walletType).toBeNull();
+    expect(useWalletStore.getState().balance).toBe('0');
+    expect(useWalletStore.getState().error).toBeNull();
+  });
+
+  it('signTransaction() returns signed XDR', async () => {
+    useWalletStore.setState({ publicKey: 'GTEST' });
+    sign.mockResolvedValue('SIGNED_XDR_123');
+
+    const result = await useWalletStore.getState().signTransaction('UNSIGNED_XDR');
+
+    expect(result).toBe('SIGNED_XDR_123');
+    expect(sign).toHaveBeenCalledWith('UNSIGNED_XDR');
+  });
+
+  it('signTransaction() throws when no wallet is connected', async () => {
+    useWalletStore.setState({ publicKey: null });
+
+    await expect(
+      useWalletStore.getState().signTransaction('XDR'),
+    ).rejects.toThrow('No wallet connected');
+  });
+
+  it('signTransaction() sets error on signing failure', async () => {
+    useWalletStore.setState({ publicKey: 'GTEST' });
+    sign.mockRejectedValue(new Error('User rejected'));
+
+    await expect(
+      useWalletStore.getState().signTransaction('XDR'),
+    ).rejects.toThrow();
+
+    expect(useWalletStore.getState().error).toContain('rejected');
+  });
+
+  it('clearError() removes the error', () => {
+    useWalletStore.setState({ error: 'Something went wrong' });
+    useWalletStore.getState().clearError();
+    expect(useWalletStore.getState().error).toBeNull();
+  });
+
+  it('rehydrate() refreshes balance for persisted publicKey', async () => {
+    const { getNOVABalance, getTransactionHistory } = require('../lib/horizonClient');
+    getNOVABalance.mockResolvedValue('500.0000000');
+    getTransactionHistory.mockResolvedValue([{ id: 'tx1' }]);
+
+    useWalletStore.setState({ publicKey: 'GPERSISTED', hydrated: false });
+
+    await useWalletStore.getState().rehydrate();
+
+    expect(useWalletStore.getState().balance).toBe('500.0000000');
+    expect(useWalletStore.getState().transactions).toEqual([{ id: 'tx1' }]);
+    expect(useWalletStore.getState().hydrated).toBe(true);
+  });
+
+  it('rehydrate() clears stale publicKey on failure', async () => {
+    const { getNOVABalance } = require('../lib/horizonClient');
+    getNOVABalance.mockRejectedValue(new Error('Network error'));
+
+    useWalletStore.setState({ publicKey: 'GSTALE', hydrated: false });
+
+    await useWalletStore.getState().rehydrate();
+
+    expect(useWalletStore.getState().publicKey).toBeNull();
+    expect(useWalletStore.getState().hydrated).toBe(true);
+  });
+
+  it('rehydrate() sets hydrated=true even with no publicKey', async () => {
+    useWalletStore.setState({ publicKey: null, hydrated: false });
+
+    await useWalletStore.getState().rehydrate();
+
+    expect(useWalletStore.getState().hydrated).toBe(true);
+  });
+});

--- a/novaRewards/frontend/components/WalletConnectButton.js
+++ b/novaRewards/frontend/components/WalletConnectButton.js
@@ -1,0 +1,125 @@
+'use client';
+
+import { useWalletStore } from '../store/walletStore';
+import { truncateAddress } from '../lib/truncateAddress';
+import { Wallet, Unplug, AlertCircle, Loader2, Wifi } from 'lucide-react';
+
+/**
+ * WalletConnectButton — handles all connection states:
+ *   idle       → "Connect Wallet" button
+ *   connecting → spinner + "Connecting…"
+ *   connected  → truncated address + balance + network badge + disconnect
+ *   error      → error message with dismiss button
+ *
+ * Uses the enhanced useWalletStore (Zustand) which persists publicKey,
+ * walletType, and network to localStorage and rehydrates on page load.
+ */
+export default function WalletConnectButton() {
+  const {
+    publicKey,
+    walletType,
+    network,
+    balance,
+    isLoading,
+    error,
+    hydrated,
+    connect,
+    disconnect,
+    clearError,
+  } = useWalletStore();
+
+  // Don't render until localStorage rehydration is complete (avoids flash)
+  if (!hydrated) return null;
+
+  // --- Error state ---
+  if (error && !publicKey) {
+    return (
+      <div className="flex items-center gap-2 flex-wrap">
+        <div className="flex items-center gap-1.5 rounded-lg border border-red-200 bg-red-50 px-3 py-2 text-sm text-red-700 dark:border-red-800 dark:bg-red-950/50 dark:text-red-400">
+          <AlertCircle className="h-4 w-4 flex-shrink-0" aria-hidden="true" />
+          <span className="max-w-[200px] truncate">{error}</span>
+        </div>
+        <button
+          onClick={() => { clearError(); connect(); }}
+          className="rounded-lg bg-primary-600 px-3 py-2 text-sm font-medium text-white hover:bg-primary-700 transition-colors focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-primary-600 focus-visible:ring-offset-2"
+          aria-label="Retry wallet connection"
+        >
+          Retry
+        </button>
+        <button
+          onClick={clearError}
+          className="text-xs text-neutral-400 hover:text-neutral-600 dark:hover:text-neutral-300 transition-colors"
+          aria-label="Dismiss error"
+        >
+          Dismiss
+        </button>
+      </div>
+    );
+  }
+
+  // --- Connected state ---
+  if (publicKey) {
+    const isTestnet = network !== 'mainnet';
+
+    return (
+      <div className="flex items-center gap-2">
+        <div className="flex items-center gap-2 rounded-xl border border-neutral-200 bg-neutral-50 px-3 py-1.5 dark:border-brand-border dark:bg-brand-dark">
+          <Wallet className="h-4 w-4 text-primary-600" aria-hidden="true" />
+          <div className="hidden sm:flex flex-col leading-none">
+            <span className="text-xs font-mono text-neutral-500 dark:text-neutral-400">
+              {truncateAddress(publicKey)}
+            </span>
+            <span className="text-xs font-semibold text-primary-600 dark:text-primary-400">
+              {parseFloat(balance).toLocaleString()} NOVA
+            </span>
+          </div>
+          {/* Network badge */}
+          <span
+            className={`ml-1 inline-flex items-center gap-0.5 rounded-full px-1.5 py-0.5 text-[10px] font-semibold leading-none ${
+              isTestnet
+                ? 'bg-amber-100 text-amber-700 dark:bg-amber-900/40 dark:text-amber-400'
+                : 'bg-green-100 text-green-700 dark:bg-green-900/40 dark:text-green-400'
+            }`}
+          >
+            <Wifi className="h-2.5 w-2.5" aria-hidden="true" />
+            {isTestnet ? 'Testnet' : 'Mainnet'}
+          </span>
+        </div>
+        <button
+          onClick={disconnect}
+          aria-label="Disconnect wallet"
+          className="flex items-center gap-1 rounded-lg border border-neutral-200 px-2 py-1.5 text-xs text-neutral-500 hover:bg-red-50 hover:text-red-600 hover:border-red-200 transition-colors dark:border-brand-border dark:text-neutral-400 dark:hover:bg-red-950/30 dark:hover:text-red-400 dark:hover:border-red-800 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-primary-600"
+        >
+          <Unplug className="h-3.5 w-3.5" aria-hidden="true" />
+          <span className="hidden sm:inline">Disconnect</span>
+        </button>
+      </div>
+    );
+  }
+
+  // --- Connecting state ---
+  if (isLoading) {
+    return (
+      <button
+        disabled
+        className="flex items-center gap-1.5 rounded-lg bg-primary-600 px-3 py-2 text-sm font-medium text-white opacity-70 cursor-not-allowed"
+        aria-label="Connecting to wallet"
+      >
+        <Loader2 className="h-4 w-4 animate-spin" aria-hidden="true" />
+        Connecting…
+      </button>
+    );
+  }
+
+  // --- Idle state ---
+  return (
+    <button
+      onClick={connect}
+      aria-label="Connect wallet"
+      className="flex items-center gap-1.5 rounded-lg bg-primary-600 px-3 py-2 text-sm font-medium text-white hover:bg-primary-700 transition-colors focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-primary-600 focus-visible:ring-offset-2"
+    >
+      <Wallet className="h-4 w-4" aria-hidden="true" />
+      Connect Wallet
+    </button>
+  );
+}

--- a/novaRewards/frontend/components/layout/Header.js
+++ b/novaRewards/frontend/components/layout/Header.js
@@ -1,6 +1,7 @@
 'use client';
 import { useState, useRef, useEffect } from 'react';
 import { useWalletStore } from '../../store/walletStore';
+import WalletConnectButton from '../WalletConnectButton';
 import ThemeToggle from './ThemeToggle';
 import { User, Settings, LogOut, ChevronDown, Bell } from 'lucide-react';
 import Link from 'next/link';
@@ -32,6 +33,7 @@ export default function Header() {
       </div>
 
       <div className="flex items-center gap-2 md:gap-4">
+        <WalletConnectButton />
         <button className="p-2 text-slate-500 hover:bg-gray-100 dark:hover:bg-brand-border rounded-lg transition-colors relative">
           <Bell className="w-5 h-5" />
           <span className="absolute top-2 right-2 w-2 h-2 bg-red-500 rounded-full border-2 border-white dark:border-brand-card"></span>

--- a/novaRewards/frontend/components/navigation/Navbar.tsx
+++ b/novaRewards/frontend/components/navigation/Navbar.tsx
@@ -1,8 +1,7 @@
 import Link from 'next/link';
 import { useRouter } from 'next/router';
-import { Menu, Wallet, Star } from 'lucide-react';
-import { useWalletStore } from '../../store/walletStore';
-import { truncateAddress } from '../../lib/truncateAddress';
+import { Menu, Star } from 'lucide-react';
+import WalletConnectButton from '../WalletConnectButton';
 import { useNavigation } from '../../hooks/useNavigation';
 
 export interface NavItem {
@@ -25,7 +24,6 @@ interface NavbarProps {
 
 export default function Navbar({ items = NAV_ITEMS }: NavbarProps) {
   const router   = useRouter();
-  const { publicKey, balance, connect, disconnect, isLoading } = useWalletStore();
   const { toggleDrawer } = useNavigation();
 
   return (
@@ -69,37 +67,10 @@ export default function Navbar({ items = NAV_ITEMS }: NavbarProps) {
 
         {/* Wallet + hamburger */}
         <div className="flex items-center gap-2">
-          {/* Wallet info / connect button */}
-          {publicKey ? (
-            <div className="flex items-center gap-2 rounded-xl border border-neutral-200 bg-neutral-50 px-3 py-1.5 dark:border-brand-border dark:bg-brand-dark">
-              <Wallet className="h-4 w-4 text-primary-600" aria-hidden="true" />
-              <div className="hidden sm:flex flex-col leading-none">
-                <span className="text-xs font-mono text-neutral-500 dark:text-neutral-400">
-                  {truncateAddress(publicKey)}
-                </span>
-                <span className="text-xs font-semibold text-primary-600 dark:text-primary-400">
-                  {parseFloat(balance).toLocaleString()} NOVA
-                </span>
-              </div>
-              <button
-                onClick={disconnect}
-                aria-label="Disconnect wallet"
-                className="ml-1 hidden sm:block text-xs text-neutral-400 hover:text-error-600 transition-colors focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-primary-600 rounded"
-              >
-                ✕
-              </button>
-            </div>
-          ) : (
-            <button
-              onClick={() => connect()}
-              disabled={isLoading}
-              aria-label="Connect wallet"
-              className="hidden sm:flex items-center gap-1.5 rounded-lg bg-primary-600 px-3 py-2 text-sm font-medium text-white hover:bg-primary-700 disabled:opacity-50 transition-colors focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-primary-600 focus-visible:ring-offset-2"
-            >
-              <Wallet className="h-4 w-4" aria-hidden="true" />
-              {isLoading ? 'Connecting…' : 'Connect Wallet'}
-            </button>
-          )}
+          {/* Wallet connect button — handles all states */}
+          <div className="hidden sm:block">
+            <WalletConnectButton />
+          </div>
 
           {/* Hamburger — mobile only */}
           <button

--- a/novaRewards/frontend/lib/freighter.js
+++ b/novaRewards/frontend/lib/freighter.js
@@ -55,6 +55,44 @@ export async function connectWallet() {
 }
 
 /**
+ * Returns the current network passphrase based on NEXT_PUBLIC_STELLAR_NETWORK.
+ * Requirements: 8.1
+ *
+ * @returns {string} Network passphrase (PUBLIC or TESTNET)
+ */
+export function getNetworkPassphrase() {
+  return NETWORK_PASSPHRASE;
+}
+
+/**
+ * Signs an XDR transaction with Freighter without submitting.
+ * Returns the signed XDR for the caller to submit.
+ * Requirements: 8.2
+ *
+ * @param {string} xdr - Unsigned transaction XDR string
+ * @returns {Promise<string>} Signed transaction XDR
+ * @throws {Error} if signing fails or user rejects
+ */
+export async function sign(xdr) {
+  try {
+    const signResult = await signTransaction(xdr, {
+      networkPassphrase: NETWORK_PASSPHRASE,
+    });
+
+    if (signResult.error) {
+      throw new Error(`Transaction signing failed: ${signResult.error}`);
+    }
+
+    return signResult.signedTxXdr;
+  } catch (err) {
+    if (err.message?.includes('User rejected')) {
+      throw new Error('You rejected the signing request. Please try again.');
+    }
+    throw new Error(err.message || 'Failed to sign transaction. Please try again.');
+  }
+}
+
+/**
  * Signs an XDR transaction with Freighter and submits it to Horizon.
  * Requirements: 8.2
  *

--- a/novaRewards/frontend/store/walletStore.js
+++ b/novaRewards/frontend/store/walletStore.js
@@ -1,23 +1,78 @@
 import { create } from 'zustand';
 import { persist, devtools } from 'zustand/middleware';
-import { connectWallet, isFreighterInstalled } from '../lib/freighter';
+import { connectWallet, isFreighterInstalled, sign, getNetworkPassphrase } from '../lib/freighter';
 import { getNOVABalance, getTransactionHistory } from '../lib/horizonClient';
 
+const STELLAR_NETWORK = process.env.NEXT_PUBLIC_STELLAR_NETWORK || 'testnet';
+
 /**
- * walletStore manages wallet connection, balance, and transaction history.
- * Migrated from WalletContext for scalability and performance.
- * Requirements: Persistence for public key, DevTools support.
+ * User-friendly error messages for common wallet connection failures.
+ */
+const ERROR_MESSAGES = {
+  not_installed: 'Freighter wallet extension is not installed. Please install it from freighter.app',
+  access_denied: 'You denied wallet access. Please try again and approve the connection.',
+  no_public_key: 'Could not retrieve your public key from Freighter.',
+  sign_rejected: 'You rejected the signing request. Please try again.',
+  sign_failed: 'Failed to sign transaction. Please try again.',
+  refresh_failed: 'Failed to refresh wallet balance. Please check your connection.',
+  generic: 'Something went wrong with your wallet. Please try again.',
+};
+
+function getUserFriendlyError(err) {
+  const msg = err?.message?.toLowerCase() || '';
+  if (msg.includes('not installed') || msg.includes('freighter')) return ERROR_MESSAGES.not_installed;
+  if (msg.includes('denied') || msg.includes('rejected') || msg.includes('access')) return ERROR_MESSAGES.access_denied;
+  if (msg.includes('public key')) return ERROR_MESSAGES.no_public_key;
+  if (msg.includes('sign')) return ERROR_MESSAGES.sign_failed;
+  return err?.message || ERROR_MESSAGES.generic;
+}
+
+/**
+ * walletStore manages wallet connection, balance, signing, and transaction history.
+ * Uses Zustand with persist middleware for localStorage persistence.
+ * Connection state (publicKey, walletType, network) is persisted and restored on page load.
  */
 export const useWalletStore = create(
   devtools(
     persist(
       (set, get) => ({
         publicKey: null,
+        walletType: null,
+        network: STELLAR_NETWORK,
         balance: '0',
         transactions: [],
         freighterInstalled: null,
         isLoading: false,
+        isSigning: false,
         error: null,
+        hydrated: false,
+
+        /**
+         * Called after rehydration to refresh balance from the network.
+         * This ensures persisted state is validated against current on-chain data.
+         */
+        rehydrate: async () => {
+          const { publicKey } = get();
+          if (!publicKey) {
+            set({ hydrated: true }, false, 'wallet/rehydrateNoKey');
+            return;
+          }
+
+          try {
+            const [bal, txs] = await Promise.all([
+              getNOVABalance(publicKey),
+              getTransactionHistory(publicKey),
+            ]);
+            set({ balance: bal, transactions: txs, hydrated: true }, false, 'wallet/rehydrateSuccess');
+          } catch {
+            // Persisted key may be stale — clear it
+            set(
+              { publicKey: null, walletType: null, balance: '0', transactions: [], hydrated: true },
+              false,
+              'wallet/rehydrateFailed',
+            );
+          }
+        },
 
         /**
          * Fetches and updates the current NOVA balance and transaction history.
@@ -26,7 +81,7 @@ export const useWalletStore = create(
         refreshBalance: async (wallet) => {
           const key = wallet || get().publicKey;
           if (!key) return;
-          
+
           set({ isLoading: true, error: null }, false, 'wallet/refreshBalanceStart');
           try {
             const [bal, txs] = await Promise.all([
@@ -35,7 +90,7 @@ export const useWalletStore = create(
             ]);
             set({ balance: bal, transactions: txs }, false, 'wallet/refreshBalanceSuccess');
           } catch (err) {
-            set({ error: err.message }, false, 'wallet/refreshBalanceError');
+            set({ error: ERROR_MESSAGES.refresh_failed }, false, 'wallet/refreshBalanceError');
           } finally {
             set({ isLoading: false }, false, 'wallet/refreshBalanceEnd');
           }
@@ -43,6 +98,7 @@ export const useWalletStore = create(
 
         /**
          * Connects Freighter wallet, checks installation, and loads initial data.
+         * Persists publicKey and walletType to localStorage via zustand/persist.
          */
         connect: async () => {
           set({ isLoading: true, error: null }, false, 'wallet/connectStart');
@@ -51,15 +107,15 @@ export const useWalletStore = create(
             set({ freighterInstalled: installed }, false, 'wallet/checkFreighter');
 
             if (!installed) {
-              set({ error: 'Freighter wallet extension is not installed.' }, false, 'wallet/connectErrorNonInstalled');
+              set({ error: ERROR_MESSAGES.not_installed }, false, 'wallet/connectErrorNonInstalled');
               return;
             }
 
             const key = await connectWallet();
-            set({ publicKey: key }, false, 'wallet/setPublicKey');
+            set({ publicKey: key, walletType: 'freighter', network: STELLAR_NETWORK }, false, 'wallet/setPublicKey');
             await get().refreshBalance(key);
           } catch (err) {
-            set({ error: err.message }, false, 'wallet/connectError');
+            set({ error: getUserFriendlyError(err) }, false, 'wallet/connectError');
           } finally {
             set({ isLoading: false }, false, 'wallet/connectEnd');
           }
@@ -67,21 +123,61 @@ export const useWalletStore = create(
 
         /**
          * Disconnects the wallet and clears all session-related state.
+         * Removes persisted data from localStorage.
          */
-        disconnect: () => 
+        disconnect: () =>
           set(
-            { publicKey: null, balance: '0', transactions: [], error: null }, 
-            false, 
-            'wallet/disconnect'
+            { publicKey: null, walletType: null, balance: '0', transactions: [], error: null, freighterInstalled: null },
+            false,
+            'wallet/disconnect',
           ),
+
+        /**
+         * Signs an XDR transaction using the connected Freighter wallet.
+         * Returns the signed XDR string for the caller to submit.
+         *
+         * @param {string} xdr - Unsigned transaction XDR
+         * @returns {Promise<string>} Signed transaction XDR
+         */
+        signTransaction: async (xdr) => {
+          const { publicKey } = get();
+          if (!publicKey) {
+            throw new Error('No wallet connected. Please connect your wallet first.');
+          }
+
+          set({ isSigning: true, error: null }, false, 'wallet/signStart');
+          try {
+            const signedXdr = await sign(xdr);
+            return signedXdr;
+          } catch (err) {
+            const friendlyError = getUserFriendlyError(err);
+            set({ error: friendlyError }, false, 'wallet/signError');
+            throw new Error(friendlyError);
+          } finally {
+            set({ isSigning: false }, false, 'wallet/signEnd');
+          }
+        },
+
+        /**
+         * Clears the current error state.
+         */
+        clearError: () => set({ error: null }, false, 'wallet/clearError'),
       }),
       {
         name: 'nova-wallet-storage',
-        partialize: (state) => ({ 
-          publicKey: state.publicKey 
-        }), // Only persist the public key, not balance/transactions which should be fresh
-      }
+        partialize: (state) => ({
+          publicKey: state.publicKey,
+          walletType: state.walletType,
+          network: state.network,
+        }),
+        // After rehydration from localStorage, trigger balance refresh
+        onRehydrateStorage: () => (state) => {
+          if (state) {
+            state.rehydrate();
+          }
+        },
+      },
     ),
-    { name: 'WalletStore' }
-  )
+    { name: 'WalletStore' },
+  ),
 );


### PR DESCRIPTION
- POST /auth/challenge: generates UUID nonce tied to wallet, stored in Redis with 5-min TTL

- POST /auth/verify: validates Ed25519 signature, issues JWT with walletAddress/role/exp

- Nonces are single-use (deleted on verify) to prevent replay attacks

- Invalid/expired challenges and signatures return 401

- Rate-limited via slidingAuth limiter

- Comprehensive test suite (14 cases)

closes #569 