### PR TITLE
feat(stellar): Stellar Transaction Status Polling and Confirmation

### DIFF
--- a/novaRewards/frontend/components/TxStatusBadge.js
+++ b/novaRewards/frontend/components/TxStatusBadge.js
@@ -1,0 +1,41 @@
+'use client';
+
+const CONFIG = {
+  pending:    { label: 'Pending',     color: '#f59e0b', dot: true  },
+  confirming: { label: 'Confirming…', color: '#06b6d4', dot: true  },
+  confirmed:  { label: 'Confirmed',   color: '#10b981', dot: false },
+  failed:     { label: 'Failed',      color: '#ef4444', dot: false },
+  expired:    { label: 'Expired',     color: '#8b5cf6', dot: false },
+  timeout:    { label: 'Timed out',   color: '#ef4444', dot: false },
+};
+
+/**
+ * Displays real-time Stellar transaction status.
+ * pending → confirming → confirmed / failed
+ *
+ * Issue #662
+ */
+export default function TxStatusBadge({ status }) {
+  if (!status) return null;
+  const cfg = CONFIG[status] || { label: status, color: '#64748b', dot: false };
+
+  return (
+    <span
+      role="status"
+      aria-live="polite"
+      style={{
+        display: 'inline-flex', alignItems: 'center', gap: 6,
+        padding: '3px 10px', borderRadius: 9999, fontSize: 13, fontWeight: 500,
+        background: `${cfg.color}22`, color: cfg.color, border: `1px solid ${cfg.color}55`,
+      }}
+    >
+      {cfg.dot && (
+        <span aria-hidden="true" style={{
+          width: 8, height: 8, borderRadius: '50%', background: cfg.color,
+          animation: 'pulse 1.2s ease-in-out infinite',
+        }} />
+      )}
+      {cfg.label}
+    </span>
+  );
+}

--- a/novaRewards/frontend/hooks/useTxPoller.js
+++ b/novaRewards/frontend/hooks/useTxPoller.js
@@ -1,0 +1,57 @@
+import { useState, useCallback, useRef } from 'react';
+import { pollTransactionStatus, TransactionTimeout, TransactionExpired } from '../lib/txPoller';
+
+/**
+ * React hook that wraps pollTransactionStatus and exposes real-time status.
+ *
+ * Usage:
+ *   const { status, error, start } = useTxPoller();
+ *   await start(hash);
+ *
+ * status: null | 'pending' | 'confirming' | 'confirmed' | 'failed' | 'expired' | 'timeout'
+ *
+ * Issue #662
+ */
+export function useTxPoller() {
+  const [status, setStatus] = useState(null);
+  const [error, setError]   = useState(null);
+  const abortRef = useRef(false);
+
+  const start = useCallback(async (hash, { onConfirmed, onFailed } = {}) => {
+    abortRef.current = false;
+    setError(null);
+    setStatus('pending');
+
+    try {
+      const tx = await pollTransactionStatus(hash, (s) => {
+        if (!abortRef.current) setStatus(s);
+      });
+
+      if (tx.successful) {
+        onConfirmed?.(tx);
+      } else {
+        onFailed?.(tx);
+      }
+      return tx;
+    } catch (err) {
+      if (abortRef.current) return;
+      if (err instanceof TransactionTimeout) {
+        setStatus('timeout');
+      } else if (err instanceof TransactionExpired) {
+        setStatus('expired');
+      } else {
+        setStatus('failed');
+      }
+      setError(err.message);
+      throw err;
+    }
+  }, []);
+
+  const reset = useCallback(() => {
+    abortRef.current = true;
+    setStatus(null);
+    setError(null);
+  }, []);
+
+  return { status, error, start, reset };
+}

--- a/novaRewards/frontend/lib/txPoller.js
+++ b/novaRewards/frontend/lib/txPoller.js
@@ -1,0 +1,88 @@
+import { Horizon } from 'stellar-sdk';
+
+const HORIZON_URL = process.env.NEXT_PUBLIC_HORIZON_URL || 'https://horizon-testnet.stellar.org';
+const server = new Horizon.Server(HORIZON_URL, { timeout: 15000 });
+
+const POLL_INTERVAL_MS = 3_000;
+const TIMEOUT_MS       = 60_000;
+
+export class TransactionTimeout extends Error {
+  constructor(hash) {
+    super(`Transaction ${hash} timed out after ${TIMEOUT_MS / 1000}s`);
+    this.name = 'TransactionTimeout';
+    this.hash = hash;
+  }
+}
+
+export class TransactionExpired extends Error {
+  constructor(hash) {
+    super(`Transaction ${hash} sequence number too old — needs resubmission`);
+    this.name = 'TransactionExpired';
+    this.hash = hash;
+  }
+}
+
+/**
+ * Polls Horizon until a transaction is confirmed or failed.
+ *
+ * @param {string} hash - Stellar transaction hash
+ * @param {function} [onStatus] - optional callback(status) for real-time updates
+ *   status: 'pending' | 'confirming' | 'confirmed' | 'failed' | 'expired'
+ * @returns {Promise<object>} Horizon transaction record
+ * @throws {TransactionTimeout} after 60 s with no result
+ * @throws {TransactionExpired} when sequence number is too old
+ *
+ * Issue #662
+ */
+export async function pollTransactionStatus(hash, onStatus) {
+  const deadline = Date.now() + TIMEOUT_MS;
+  onStatus?.('pending');
+
+  while (Date.now() < deadline) {
+    try {
+      const tx = await server.transactions().transaction(hash).call();
+
+      if (tx.successful === true) {
+        onStatus?.('confirmed');
+        return tx;
+      }
+
+      // Horizon marks failed txs with successful=false
+      onStatus?.('failed');
+      return tx;
+    } catch (err) {
+      const status = err?.response?.status;
+
+      if (status === 404) {
+        // Not yet on-chain — keep polling
+        onStatus?.('confirming');
+        await _sleep(POLL_INTERVAL_MS);
+        continue;
+      }
+
+      // tx_bad_seq / sequence too old
+      if (_isExpiredSequence(err)) {
+        onStatus?.('expired');
+        throw new TransactionExpired(hash);
+      }
+
+      throw err;
+    }
+  }
+
+  throw new TransactionTimeout(hash);
+}
+
+function _isExpiredSequence(err) {
+  const extras = err?.response?.data?.extras;
+  if (!extras) return false;
+  const codes = extras.result_codes;
+  return (
+    codes?.transaction === 'tx_bad_seq' ||
+    (Array.isArray(codes?.operations) && codes.operations.includes('op_bad_seq'))
+  );
+}
+
+function _sleep(ms) {
+  return new Promise((resolve) => setTimeout(resolve, ms));
+}


### PR DESCRIPTION
## Summary

Implements a transaction status polling service that monitors submitted Stellar transactions until confirmed or failed, with real-time frontend status updates.

Closes #662

## Changes

- `lib/txPoller.js` — core polling service
- `hooks/useTxPoller.js` — React hook wrapping the poller
- `components/TxStatusBadge.js` — real-time status badge component

## Acceptance Criteria

- [x] `pollTransactionStatus(hash)` polls Horizon until confirmed, failed, or timeout
- [x] Timeout after 60 seconds with `TransactionTimeout` error
- [x] Expired transactions (`tx_bad_seq`) detected and flagged via `TransactionExpired` error
- [x] Frontend shows transaction status: pending → confirming → confirmed/failed
- [x] Confirmed transactions return the full tx record for cache invalidation

## Implementation Details

- Polls every 3 s, deadline at 60 s
- 404 from Horizon = not yet on-chain → keep polling
- `tx_bad_seq` in result codes → throws `TransactionExpired` (caller should resubmit)
- `useTxPoller` hook exposes `{ status, error, start, reset }`
- `TxStatusBadge` uses `aria-live="polite"` for accessibility