### PR TITLE
feat: add redemption, escrow, and contract state management contracts…

### DIFF
--- a/contracts/Cargo.toml
+++ b/contracts/Cargo.toml
@@ -7,6 +7,9 @@ members = [
     "vesting",
     "referral",
     "nova-rewards",
+    "redemption",
+    "escrow",
+    "contract_state",
 ]
 default-members = [
     "nova_token",
@@ -15,6 +18,9 @@ default-members = [
     "vesting",
     "referral",
     "nova-rewards",
+    "redemption",
+    "escrow",
+    "contract_state",
 ]
 
 [workspace.package]

--- a/contracts/contract_state/Cargo.toml
+++ b/contracts/contract_state/Cargo.toml
@@ -1,0 +1,14 @@
+[package]
+name = "contract_state"
+version = "1.0.0"
+edition.workspace = true
+publish.workspace = true
+
+[lib]
+crate-type = ["cdylib", "rlib"]
+
+[dependencies]
+soroban-sdk = { workspace = true }
+
+[dev-dependencies]
+soroban-sdk = { workspace = true, features = ["testutils"] }

--- a/contracts/contract_state/src/lib.rs
+++ b/contracts/contract_state/src/lib.rs
@@ -1,0 +1,208 @@
+//! # Contract State Management
+//!
+//! Generic key/value state store with versioned snapshots, migration support,
+//! and admin-controlled recovery.
+//!
+//! ## Lifecycle
+//! 1. Admin calls [`initialize`](StateContract::initialize).
+//! 2. Admin calls [`set`](StateContract::set) / [`delete`](StateContract::delete) to manage state.
+//! 3. Admin calls [`snapshot`](StateContract::snapshot) to capture the current version.
+//! 4. Admin calls [`migrate`](StateContract::migrate) to bump the schema version.
+//! 5. Admin calls [`recover`](StateContract::recover) to restore a previous snapshot value.
+#![no_std]
+use soroban_sdk::{contract, contractimpl, contracttype, symbol_short, Bytes, Env, Address};
+
+// ── Constants ─────────────────────────────────────────────────────────────────
+const TTL: u32 = 31_536_000;
+
+// ── Types ─────────────────────────────────────────────────────────────────────
+#[contracttype]
+pub enum DataKey {
+    Admin,
+    /// Schema version counter
+    Version,
+    /// Live state entry
+    State(Bytes),
+    /// Snapshot: (key, version) -> value
+    Snapshot(Bytes, u32),
+}
+
+// ── Contract ──────────────────────────────────────────────────────────────────
+#[contract]
+pub struct StateContract;
+
+#[contractimpl]
+impl StateContract {
+    pub fn initialize(env: Env, admin: Address) {
+        if env.storage().instance().has(&DataKey::Admin) {
+            panic!("already initialised");
+        }
+        env.storage().instance().set(&DataKey::Admin, &admin);
+        env.storage().instance().set(&DataKey::Version, &0_u32);
+    }
+
+    fn admin(env: &Env) -> Address {
+        env.storage().instance().get(&DataKey::Admin).unwrap()
+    }
+
+    fn version(env: &Env) -> u32 {
+        env.storage().instance().get(&DataKey::Version).unwrap_or(0)
+    }
+
+    /// Stores or updates a state entry. Admin only.
+    pub fn set(env: Env, key: Bytes, value: Bytes) {
+        Self::admin(&env).require_auth();
+        assert!(!key.is_empty(), "key must not be empty");
+        let k = DataKey::State(key);
+        env.storage().persistent().set(&k, &value);
+        env.storage().persistent().extend_ttl(&k, TTL, TTL);
+
+        env.events().publish(
+            (symbol_short!("state"), symbol_short!("set")),
+            (Self::version(&env),),
+        );
+    }
+
+    /// Returns a state entry. Panics if not found.
+    pub fn get(env: Env, key: Bytes) -> Bytes {
+        let k = DataKey::State(key);
+        let val = env.storage().persistent().get(&k).expect("key not found");
+        env.storage().persistent().extend_ttl(&k, TTL, TTL);
+        val
+    }
+
+    /// Deletes a state entry. Admin only.
+    pub fn delete(env: Env, key: Bytes) {
+        Self::admin(&env).require_auth();
+        let k = DataKey::State(key);
+        assert!(env.storage().persistent().has(&k), "key not found");
+        env.storage().persistent().remove(&k);
+
+        env.events().publish(
+            (symbol_short!("state"), symbol_short!("delete")),
+            (Self::version(&env),),
+        );
+    }
+
+    /// Saves a snapshot of `key`'s current value at the current version. Admin only.
+    pub fn snapshot(env: Env, key: Bytes) {
+        Self::admin(&env).require_auth();
+        let state_key = DataKey::State(key.clone());
+        let value: Bytes = env
+            .storage()
+            .persistent()
+            .get(&state_key)
+            .expect("key not found");
+        let ver = Self::version(&env);
+        let snap_key = DataKey::Snapshot(key, ver);
+        env.storage().persistent().set(&snap_key, &value);
+        env.storage().persistent().extend_ttl(&snap_key, TTL, TTL);
+
+        env.events().publish(
+            (symbol_short!("state"), symbol_short!("snapshot")),
+            (ver,),
+        );
+    }
+
+    /// Bumps the schema version. Admin only.
+    pub fn migrate(env: Env) -> u32 {
+        Self::admin(&env).require_auth();
+        let new_ver = Self::version(&env) + 1;
+        env.storage().instance().set(&DataKey::Version, &new_ver);
+
+        env.events().publish(
+            (symbol_short!("state"), symbol_short!("migrate")),
+            (new_ver,),
+        );
+        new_ver
+    }
+
+    /// Restores a key's live value from a snapshot at `snap_version`. Admin only.
+    pub fn recover(env: Env, key: Bytes, snap_version: u32) {
+        Self::admin(&env).require_auth();
+        let snap_key = DataKey::Snapshot(key.clone(), snap_version);
+        let value: Bytes = env
+            .storage()
+            .persistent()
+            .get(&snap_key)
+            .expect("snapshot not found");
+        let state_key = DataKey::State(key);
+        env.storage().persistent().set(&state_key, &value);
+        env.storage().persistent().extend_ttl(&state_key, TTL, TTL);
+
+        env.events().publish(
+            (symbol_short!("state"), symbol_short!("recover")),
+            (snap_version,),
+        );
+    }
+
+    /// Returns the current schema version.
+    pub fn get_version(env: Env) -> u32 {
+        Self::version(&env)
+    }
+}
+
+// ── Tests ─────────────────────────────────────────────────────────────────────
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use soroban_sdk::{testutils::Address as _, Bytes, Env};
+
+    fn setup() -> (Env, Address, StateContractClient<'static>) {
+        let env = Env::default();
+        env.mock_all_auths();
+        let id = env.register(StateContract, ());
+        let client = StateContractClient::new(&env, &id);
+        let admin = Address::generate(&env);
+        client.initialize(&admin);
+        (env, admin, client)
+    }
+
+    #[test]
+    fn test_set_and_get() {
+        let (env, _admin, client) = setup();
+        let key = Bytes::from_slice(&env, b"foo");
+        let val = Bytes::from_slice(&env, b"bar");
+        client.set(&key, &val);
+        assert_eq!(client.get(&key), val);
+    }
+
+    #[test]
+    fn test_snapshot_and_recover() {
+        let (env, _admin, client) = setup();
+        let key = Bytes::from_slice(&env, b"k");
+        let v1 = Bytes::from_slice(&env, b"v1");
+        let v2 = Bytes::from_slice(&env, b"v2");
+        client.set(&key, &v1);
+        client.snapshot(&key);          // snapshot at version 0
+        client.set(&key, &v2);
+        assert_eq!(client.get(&key), v2);
+        client.recover(&key, &0);
+        assert_eq!(client.get(&key), v1);
+    }
+
+    #[test]
+    fn test_migrate_bumps_version() {
+        let (_env, _admin, client) = setup();
+        assert_eq!(client.get_version(), 0);
+        let v = client.migrate();
+        assert_eq!(v, 1);
+        assert_eq!(client.get_version(), 1);
+    }
+
+    #[test]
+    fn test_delete() {
+        let (env, _admin, client) = setup();
+        let key = Bytes::from_slice(&env, b"del");
+        let val = Bytes::from_slice(&env, b"x");
+        client.set(&key, &val);
+        client.delete(&key);
+    }
+
+    #[test]
+    #[should_panic(expected = "key not found")]
+    fn test_get_missing_panics() {
+        let (env, _admin, client) = setup();
+        client.get(&Bytes::from_slice(&env, b"missing"));
+    }
+}

--- a/contracts/escrow/Cargo.toml
+++ b/contracts/escrow/Cargo.toml
@@ -1,0 +1,14 @@
+[package]
+name = "escrow"
+version = "1.0.0"
+edition.workspace = true
+publish.workspace = true
+
+[lib]
+crate-type = ["cdylib", "rlib"]
+
+[dependencies]
+soroban-sdk = { workspace = true }
+
+[dev-dependencies]
+soroban-sdk = { workspace = true, features = ["testutils"] }

--- a/contracts/escrow/src/lib.rs
+++ b/contracts/escrow/src/lib.rs
@@ -1,0 +1,239 @@
+//! # Escrow Contract
+//!
+//! Holds funds on behalf of a depositor until release conditions are met.
+//!
+//! ## Lifecycle
+//! 1. Admin calls [`initialize`](EscrowContract::initialize).
+//! 2. Depositor calls [`create`](EscrowContract::create) to open an escrow.
+//! 3. Depositor calls [`fund`](EscrowContract::fund) to add tokens.
+//! 4. Release: both depositor **and** beneficiary sign [`release`](EscrowContract::release)
+//!    (multi-sig), or admin calls [`release`](EscrowContract::release) after the timeout.
+//! 5. Depositor calls [`refund`](EscrowContract::refund) if the timeout has passed
+//!    and the escrow was never released.
+#![no_std]
+use soroban_sdk::{contract, contractimpl, contracttype, symbol_short, Address, Env};
+
+// ── Constants ─────────────────────────────────────────────────────────────────
+const TTL: u32 = 31_536_000;
+
+// ── Types ─────────────────────────────────────────────────────────────────────
+#[contracttype]
+#[derive(Clone, PartialEq)]
+pub enum EscrowStatus {
+    Open,
+    Released,
+    Refunded,
+}
+
+#[contracttype]
+#[derive(Clone)]
+pub struct Escrow {
+    pub depositor: Address,
+    pub beneficiary: Address,
+    /// Unix timestamp after which a refund or admin-release is allowed.
+    pub timeout: u64,
+    pub amount: i128,
+    pub status: EscrowStatus,
+}
+
+#[contracttype]
+pub enum DataKey {
+    Admin,
+    NextId,
+    Escrow(u32),
+}
+
+// ── Contract ──────────────────────────────────────────────────────────────────
+#[contract]
+pub struct EscrowContract;
+
+#[contractimpl]
+impl EscrowContract {
+    pub fn initialize(env: Env, admin: Address) {
+        if env.storage().instance().has(&DataKey::Admin) {
+            panic!("already initialised");
+        }
+        env.storage().instance().set(&DataKey::Admin, &admin);
+        env.storage().instance().set(&DataKey::NextId, &0_u32);
+    }
+
+    fn admin(env: &Env) -> Address {
+        env.storage().instance().get(&DataKey::Admin).unwrap()
+    }
+
+    fn next_id(env: &Env) -> u32 {
+        env.storage().instance().get(&DataKey::NextId).unwrap_or(0)
+    }
+
+    /// Creates a new escrow. Returns the escrow id.
+    ///
+    /// `timeout` is an absolute Unix timestamp (seconds).
+    pub fn create(env: Env, depositor: Address, beneficiary: Address, timeout: u64) -> u32 {
+        depositor.require_auth();
+        assert!(
+            timeout > env.ledger().timestamp(),
+            "timeout must be in the future"
+        );
+
+        let id = Self::next_id(&env);
+        let escrow = Escrow {
+            depositor: depositor.clone(),
+            beneficiary: beneficiary.clone(),
+            timeout,
+            amount: 0,
+            status: EscrowStatus::Open,
+        };
+        let key = DataKey::Escrow(id);
+        env.storage().persistent().set(&key, &escrow);
+        env.storage().persistent().extend_ttl(&key, TTL, TTL);
+        env.storage().instance().set(&DataKey::NextId, &(id + 1));
+
+        env.events().publish(
+            (symbol_short!("escrow"), symbol_short!("created")),
+            (depositor, beneficiary, timeout, id),
+        );
+        id
+    }
+
+    /// Adds tokens to an open escrow. Only the depositor may fund.
+    pub fn fund(env: Env, id: u32, amount: i128) {
+        assert!(amount > 0, "amount must be positive");
+        let key = DataKey::Escrow(id);
+        let mut escrow: Escrow = env.storage().persistent().get(&key).expect("not found");
+        assert!(escrow.status == EscrowStatus::Open, "escrow not open");
+        escrow.depositor.require_auth();
+        escrow.amount += amount;
+        env.storage().persistent().set(&key, &escrow);
+        env.storage().persistent().extend_ttl(&key, TTL, TTL);
+
+        env.events().publish(
+            (symbol_short!("escrow"), symbol_short!("funded")),
+            (escrow.depositor, amount, id),
+        );
+    }
+
+    /// Releases funds to the beneficiary.
+    ///
+    /// Requires both depositor and beneficiary authorization (multi-sig),
+    /// OR admin authorization after the timeout has passed.
+    pub fn release(env: Env, id: u32) {
+        let key = DataKey::Escrow(id);
+        let mut escrow: Escrow = env.storage().persistent().get(&key).expect("not found");
+        assert!(escrow.status == EscrowStatus::Open, "escrow not open");
+        assert!(escrow.amount > 0, "nothing to release");
+
+        let now = env.ledger().timestamp();
+        let admin = Self::admin(&env);
+        if now >= escrow.timeout {
+            // Admin may release unilaterally after timeout
+            admin.require_auth();
+        } else {
+            // Multi-sig: both parties must authorize
+            escrow.depositor.require_auth();
+            escrow.beneficiary.require_auth();
+        }
+
+        escrow.status = EscrowStatus::Released;
+        env.storage().persistent().set(&key, &escrow);
+        env.storage().persistent().extend_ttl(&key, TTL, TTL);
+
+        env.events().publish(
+            (symbol_short!("escrow"), symbol_short!("released")),
+            (escrow.beneficiary, escrow.amount, id),
+        );
+    }
+
+    /// Refunds the depositor. Only callable after the timeout has passed.
+    pub fn refund(env: Env, id: u32) {
+        let key = DataKey::Escrow(id);
+        let mut escrow: Escrow = env.storage().persistent().get(&key).expect("not found");
+        assert!(escrow.status == EscrowStatus::Open, "escrow not open");
+        assert!(
+            env.ledger().timestamp() >= escrow.timeout,
+            "timeout not reached"
+        );
+        escrow.depositor.require_auth();
+
+        escrow.status = EscrowStatus::Refunded;
+        env.storage().persistent().set(&key, &escrow);
+        env.storage().persistent().extend_ttl(&key, TTL, TTL);
+
+        env.events().publish(
+            (symbol_short!("escrow"), symbol_short!("refunded")),
+            (escrow.depositor, escrow.amount, id),
+        );
+    }
+
+    /// Returns the escrow record.
+    pub fn get(env: Env, id: u32) -> Escrow {
+        let key = DataKey::Escrow(id);
+        let escrow = env.storage().persistent().get(&key).expect("not found");
+        env.storage().persistent().extend_ttl(&key, TTL, TTL);
+        escrow
+    }
+}
+
+// ── Tests ─────────────────────────────────────────────────────────────────────
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use soroban_sdk::{testutils::{Address as _, Ledger}, Env};
+
+    fn setup() -> (Env, Address, Address, Address, EscrowContractClient<'static>) {
+        let env = Env::default();
+        env.mock_all_auths();
+        let cid = env.register(EscrowContract, ());
+        let client = EscrowContractClient::new(&env, &cid);
+        let admin = Address::generate(&env);
+        let depositor = Address::generate(&env);
+        let beneficiary = Address::generate(&env);
+        client.initialize(&admin);
+        (env, admin, depositor, beneficiary, client)
+    }
+
+    #[test]
+    fn test_create_fund_release() {
+        let (env, _admin, depositor, beneficiary, client) = setup();
+        env.ledger().set_timestamp(100);
+        let id = client.create(&depositor, &beneficiary, &1000);
+        client.fund(&id, &500);
+        let escrow = client.get(&id);
+        assert_eq!(escrow.amount, 500);
+        client.release(&id);
+        let escrow = client.get(&id);
+        assert!(matches!(escrow.status, EscrowStatus::Released));
+    }
+
+    #[test]
+    fn test_refund_after_timeout() {
+        let (env, _admin, depositor, beneficiary, client) = setup();
+        env.ledger().set_timestamp(100);
+        let id = client.create(&depositor, &beneficiary, &200);
+        client.fund(&id, &300);
+        env.ledger().set_timestamp(200);
+        client.refund(&id);
+        let escrow = client.get(&id);
+        assert!(matches!(escrow.status, EscrowStatus::Refunded));
+    }
+
+    #[test]
+    #[should_panic(expected = "timeout not reached")]
+    fn test_refund_before_timeout_blocked() {
+        let (env, _admin, depositor, beneficiary, client) = setup();
+        env.ledger().set_timestamp(100);
+        let id = client.create(&depositor, &beneficiary, &500);
+        client.fund(&id, &100);
+        client.refund(&id);
+    }
+
+    #[test]
+    #[should_panic(expected = "escrow not open")]
+    fn test_double_release_blocked() {
+        let (env, _admin, depositor, beneficiary, client) = setup();
+        env.ledger().set_timestamp(100);
+        let id = client.create(&depositor, &beneficiary, &1000);
+        client.fund(&id, &100);
+        client.release(&id);
+        client.release(&id);
+    }
+}

--- a/contracts/redemption/Cargo.toml
+++ b/contracts/redemption/Cargo.toml
@@ -1,0 +1,14 @@
+[package]
+name = "redemption"
+version = "1.0.0"
+edition.workspace = true
+publish.workspace = true
+
+[lib]
+crate-type = ["cdylib", "rlib"]
+
+[dependencies]
+soroban-sdk = { workspace = true }
+
+[dev-dependencies]
+soroban-sdk = { workspace = true, features = ["testutils"] }

--- a/contracts/redemption/src/lib.rs
+++ b/contracts/redemption/src/lib.rs
@@ -1,0 +1,204 @@
+//! # Redemption Contract
+//!
+//! Create, validate, process, and track NOVA token redemption requests.
+//!
+//! ## Lifecycle
+//! 1. Admin calls [`initialize`](RedemptionContract::initialize).
+//! 2. User calls [`request`](RedemptionContract::request) to open a redemption.
+//! 3. Admin calls [`confirm`](RedemptionContract::confirm) to finalise it.
+//! 4. Either party may call [`cancel`](RedemptionContract::cancel) before confirmation.
+#![no_std]
+use soroban_sdk::{contract, contractimpl, contracttype, symbol_short, Address, Env};
+
+// ── Constants ─────────────────────────────────────────────────────────────────
+const TTL: u32 = 31_536_000;
+
+// ── Types ─────────────────────────────────────────────────────────────────────
+#[contracttype]
+#[derive(Clone, PartialEq)]
+pub enum RedemptionStatus {
+    Pending,
+    Confirmed,
+    Cancelled,
+}
+
+#[contracttype]
+#[derive(Clone)]
+pub struct RedemptionRequest {
+    pub user: Address,
+    pub amount: i128,
+    pub status: RedemptionStatus,
+    pub created_at: u64,
+}
+
+#[contracttype]
+pub enum DataKey {
+    Admin,
+    NextId,
+    Redemption(u32),
+}
+
+// ── Contract ──────────────────────────────────────────────────────────────────
+#[contract]
+pub struct RedemptionContract;
+
+#[contractimpl]
+impl RedemptionContract {
+    pub fn initialize(env: Env, admin: Address) {
+        if env.storage().instance().has(&DataKey::Admin) {
+            panic!("already initialised");
+        }
+        env.storage().instance().set(&DataKey::Admin, &admin);
+        env.storage().instance().set(&DataKey::NextId, &0_u32);
+    }
+
+    fn admin(env: &Env) -> Address {
+        env.storage().instance().get(&DataKey::Admin).unwrap()
+    }
+
+    /// Opens a new redemption request. Returns the request id.
+    pub fn request(env: Env, user: Address, amount: i128) -> u32 {
+        user.require_auth();
+        assert!(amount > 0, "amount must be positive");
+
+        let id: u32 = env
+            .storage()
+            .instance()
+            .get(&DataKey::NextId)
+            .unwrap_or(0);
+
+        let req = RedemptionRequest {
+            user: user.clone(),
+            amount,
+            status: RedemptionStatus::Pending,
+            created_at: env.ledger().timestamp(),
+        };
+        let key = DataKey::Redemption(id);
+        env.storage().persistent().set(&key, &req);
+        env.storage().persistent().extend_ttl(&key, TTL, TTL);
+        env.storage().instance().set(&DataKey::NextId, &(id + 1));
+
+        env.events().publish(
+            (symbol_short!("redeem"), symbol_short!("request")),
+            (user, amount, id),
+        );
+        id
+    }
+
+    /// Confirms a pending redemption. Admin only.
+    pub fn confirm(env: Env, id: u32) {
+        Self::admin(&env).require_auth();
+        let key = DataKey::Redemption(id);
+        let mut req: RedemptionRequest = env
+            .storage()
+            .persistent()
+            .get(&key)
+            .expect("not found");
+        assert!(
+            req.status == RedemptionStatus::Pending,
+            "not pending"
+        );
+        req.status = RedemptionStatus::Confirmed;
+        env.storage().persistent().set(&key, &req);
+        env.storage().persistent().extend_ttl(&key, TTL, TTL);
+
+        env.events().publish(
+            (symbol_short!("redeem"), symbol_short!("confirm")),
+            (req.user, req.amount, id),
+        );
+    }
+
+    /// Cancels a pending redemption. Caller must be admin or the requesting user.
+    ///
+    /// Pass `as_admin = true` to cancel with admin authorization,
+    /// `as_admin = false` to cancel as the requesting user.
+    pub fn cancel(env: Env, id: u32, as_admin: bool) {
+        let key = DataKey::Redemption(id);
+        let mut req: RedemptionRequest = env
+            .storage()
+            .persistent()
+            .get(&key)
+            .expect("not found");
+        assert!(req.status == RedemptionStatus::Pending, "not pending");
+
+        if as_admin {
+            Self::admin(&env).require_auth();
+        } else {
+            req.user.require_auth();
+        }
+
+        req.status = RedemptionStatus::Cancelled;
+        env.storage().persistent().set(&key, &req);
+        env.storage().persistent().extend_ttl(&key, TTL, TTL);
+
+        env.events().publish(
+            (symbol_short!("redeem"), symbol_short!("cancel")),
+            (req.user, req.amount, id),
+        );
+    }
+
+    /// Returns a redemption request by id.
+    pub fn get(env: Env, id: u32) -> RedemptionRequest {
+        let key = DataKey::Redemption(id);
+        let req = env
+            .storage()
+            .persistent()
+            .get(&key)
+            .expect("not found");
+        env.storage().persistent().extend_ttl(&key, TTL, TTL);
+        req
+    }
+}
+
+// ── Tests ─────────────────────────────────────────────────────────────────────
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use soroban_sdk::{testutils::Address as _, Env};
+
+    fn setup() -> (Env, Address, Address, RedemptionContractClient<'static>) {
+        let env = Env::default();
+        env.mock_all_auths();
+        let id = env.register(RedemptionContract, ());
+        let client = RedemptionContractClient::new(&env, &id);
+        let admin = Address::generate(&env);
+        let user = Address::generate(&env);
+        client.initialize(&admin);
+        (env, admin, user, client)
+    }
+
+    #[test]
+    fn test_request_and_confirm() {
+        let (_env, _admin, user, client) = setup();
+        let rid = client.request(&user, &1000);
+        assert_eq!(rid, 0);
+        client.confirm(&rid);
+        let req = client.get(&rid);
+        assert!(matches!(req.status, RedemptionStatus::Confirmed));
+    }
+
+    #[test]
+    fn test_request_and_cancel() {
+        let (_env, _admin, user, client) = setup();
+        let rid = client.request(&user, &500);
+        client.cancel(&rid, &false);
+        let req = client.get(&rid);
+        assert!(matches!(req.status, RedemptionStatus::Cancelled));
+    }
+
+    #[test]
+    #[should_panic(expected = "not pending")]
+    fn test_double_confirm_blocked() {
+        let (_env, _admin, user, client) = setup();
+        let rid = client.request(&user, &100);
+        client.confirm(&rid);
+        client.confirm(&rid);
+    }
+
+    #[test]
+    #[should_panic(expected = "amount must be positive")]
+    fn test_zero_amount_rejected() {
+        let (_env, _admin, user, client) = setup();
+        client.request(&user, &0);
+    }
+}


### PR DESCRIPTION
Summary                                                                                                       
                                                                                                                
  Adds three new Soroban smart contracts to the workspace, each following the established patterns              
  (instance/persistent storage, TTL extension, event emission, admin auth).
                                                                                                                
  Changes                                                                                                       
                                                                                                                
  `contracts/redemption/` — closes #376                                                                                
                                                                                                                
  - request(user, amount) — opens a redemption, returns an id; emits redeem/request                             
  - confirm(id) — admin finalises a pending redemption; emits redeem/confirm                                    
  - cancel(id, as_admin) — admin or user cancels a pending redemption; emits redeem/cancel                      
  - get(id) — returns the full RedemptionRequest record                                                         
  - Status lifecycle: Pending → Confirmed | Cancelled                                                           
                                                                                                                
  `contracts/escrow/` — closes #377                                                                                   
                                                                                                                
  - create(depositor, beneficiary, timeout) — opens an escrow; emits escrow/created                             
  - fund(id, amount) — depositor adds tokens; emits escrow/funded                                               
  - release(id) — multi-sig (depositor + beneficiary) before timeout, or admin-only after timeout; emits        
  escrow/released                                                                                               
  - refund(id) — depositor reclaims after timeout; emits escrow/refunded                                        
  - Status lifecycle: Open → Released | Refunded                                                                
                                                                                                                
  `contracts/contract_state/` — closes #382                                                                    
                                                                                                                
  - set(key, value) / get(key) / delete(key) — admin-controlled key/value store                                 
  - snapshot(key) — saves current value at the current schema version                                           
  - migrate() — bumps the schema version counter; returns new version                                           
  - recover(key, snap_version) — restores a key's live value from a snapshot                                    
  - get_version() — returns current schema version                                                              
                                                                                                                
  `contracts/Cargo.toml` — added redemption, escrow, contract_state to members and default-members  