### PR TITLE
feat(devops): configure environment-specific infrastructure (staging vs production) #628

### DIFF
--- a/novaRewards/.env.prod.example
+++ b/novaRewards/.env.prod.example
@@ -1,0 +1,73 @@
+# .env.prod — Production environment variables
+# Copy to novaRewards/.env.prod and fill in real values.
+# Never commit the real .env.prod file.
+# In production, prefer injecting secrets via AWS Secrets Manager / Vault.
+
+# ── Stellar ──────────────────────────────────────────────────────────────────
+STELLAR_NETWORK=mainnet
+HORIZON_URL=https://horizon.stellar.org
+ISSUER_PUBLIC=G...
+ISSUER_SECRET=S...
+DISTRIBUTION_PUBLIC=G...
+DISTRIBUTION_SECRET=S...
+
+# ── PostgreSQL ────────────────────────────────────────────────────────────────
+POSTGRES_USER=nova
+POSTGRES_PASSWORD=change-me-strong-prod-password
+POSTGRES_DB=nova_rewards
+DATABASE_URL=postgresql://nova:change-me-strong-prod-password@postgres:5432/nova_rewards
+# Use a dedicated migration user with limited privileges
+DATABASE_MIGRATE_URL=postgresql://nova_migrate:change-me-migrate-password@postgres:5432/nova_rewards
+
+# ── Redis ─────────────────────────────────────────────────────────────────────
+REDIS_PASSWORD=change-me-strong-redis-password
+REDIS_URL=redis://:change-me-strong-redis-password@redis:6379
+REDIS_MODE=single
+REDIS_MAXMEMORY=512mb
+
+# ── Backend ───────────────────────────────────────────────────────────────────
+PORT=3001
+NODE_ENV=production
+ALLOWED_ORIGIN=https://app.novarewards.app
+JWT_SECRET=change-me-long-random-prod-jwt-secret
+JWT_EXPIRES_IN=15m
+JWT_REFRESH_EXPIRES_IN=7d
+FIELD_ENCRYPTION_KEY=replace-with-64-char-hex-string
+
+# ── Rate Limiting ─────────────────────────────────────────────────────────────
+RATE_LIMIT_WHITELIST=127.0.0.1,::1
+RL_GLOBAL_MAX=100
+RL_AUTH_MAX=5
+RL_USER_MAX=200
+RL_SEARCH_MAX=30
+RL_WEBHOOK_MAX=60
+RL_REWARDS_MAX=20
+RL_ADMIN_MAX=120
+
+# ── Frontend ──────────────────────────────────────────────────────────────────
+NEXT_PUBLIC_API_URL=https://api.novarewards.app
+NEXT_PUBLIC_HORIZON_URL=https://horizon.stellar.org
+NEXT_PUBLIC_STELLAR_NETWORK=mainnet
+NEXT_PUBLIC_ISSUER_PUBLIC=G...
+
+# ── Email ─────────────────────────────────────────────────────────────────────
+SMTP_HOST=
+SMTP_PORT=
+SMTP_USER=
+SMTP_PASSWORD=
+EMAIL_FROM=noreply@novarewards.app
+SENDGRID_API_KEY=change-me
+
+# ── Backups ───────────────────────────────────────────────────────────────────
+BACKUP_RETAIN_DAYS=30
+BACKUP_S3_BUCKET=nova-rewards-prod-backups
+AWS_REGION=us-east-1
+AWS_ACCESS_KEY_ID=change-me
+AWS_SECRET_ACCESS_KEY=change-me
+
+# ── Misc ──────────────────────────────────────────────────────────────────────
+DAILY_BONUS_POINTS=10
+REFERRAL_BONUS_POINTS=100
+WEBHOOK_TIMEOUT_MS=10000
+WEBHOOK_RETRY_INTERVAL_MS=60000
+WEBHOOK_MAX_ATTEMPTS=5

--- a/novaRewards/.env.staging.example
+++ b/novaRewards/.env.staging.example
@@ -1,0 +1,71 @@
+# .env.staging — Staging environment variables
+# Copy to novaRewards/.env.staging and fill in real values.
+# Never commit the real .env.staging file.
+
+# ── Stellar ──────────────────────────────────────────────────────────────────
+STELLAR_NETWORK=testnet
+HORIZON_URL=https://horizon-testnet.stellar.org
+ISSUER_PUBLIC=G...
+ISSUER_SECRET=S...
+DISTRIBUTION_PUBLIC=G...
+DISTRIBUTION_SECRET=S...
+
+# ── PostgreSQL ────────────────────────────────────────────────────────────────
+POSTGRES_USER=nova_staging
+POSTGRES_PASSWORD=change-me-staging
+POSTGRES_DB=nova_rewards_staging
+DATABASE_URL=postgresql://nova_staging:change-me-staging@postgres:5432/nova_rewards_staging
+DATABASE_MIGRATE_URL=postgresql://nova_staging:change-me-staging@postgres:5432/nova_rewards_staging
+
+# ── Redis ─────────────────────────────────────────────────────────────────────
+REDIS_PASSWORD=
+REDIS_URL=redis://redis:6379
+REDIS_MODE=single
+REDIS_MAXMEMORY=128mb
+
+# ── Backend ───────────────────────────────────────────────────────────────────
+PORT=3001
+NODE_ENV=staging
+ALLOWED_ORIGIN=https://staging.novarewards.app
+JWT_SECRET=change-me-staging-jwt-secret
+JWT_EXPIRES_IN=15m
+JWT_REFRESH_EXPIRES_IN=7d
+FIELD_ENCRYPTION_KEY=replace-with-64-char-hex-string
+
+# ── Rate Limiting ─────────────────────────────────────────────────────────────
+RATE_LIMIT_WHITELIST=127.0.0.1,::1
+RL_GLOBAL_MAX=100
+RL_AUTH_MAX=5
+RL_USER_MAX=200
+RL_SEARCH_MAX=30
+RL_WEBHOOK_MAX=60
+RL_REWARDS_MAX=20
+RL_ADMIN_MAX=120
+
+# ── Frontend ──────────────────────────────────────────────────────────────────
+NEXT_PUBLIC_API_URL=https://staging-api.novarewards.app
+NEXT_PUBLIC_HORIZON_URL=https://horizon-testnet.stellar.org
+NEXT_PUBLIC_STELLAR_NETWORK=testnet
+NEXT_PUBLIC_ISSUER_PUBLIC=G...
+
+# ── Email ─────────────────────────────────────────────────────────────────────
+SMTP_HOST=smtp.example.com
+SMTP_PORT=587
+SMTP_USER=staging@novarewards.app
+SMTP_PASSWORD=change-me
+EMAIL_FROM=staging@novarewards.app
+SENDGRID_API_KEY=
+
+# ── Backups ───────────────────────────────────────────────────────────────────
+BACKUP_RETAIN_DAYS=7
+BACKUP_S3_BUCKET=nova-rewards-staging-backups
+AWS_REGION=us-east-1
+AWS_ACCESS_KEY_ID=change-me
+AWS_SECRET_ACCESS_KEY=change-me
+
+# ── Misc ──────────────────────────────────────────────────────────────────────
+DAILY_BONUS_POINTS=10
+REFERRAL_BONUS_POINTS=100
+WEBHOOK_TIMEOUT_MS=10000
+WEBHOOK_RETRY_INTERVAL_MS=60000
+WEBHOOK_MAX_ATTEMPTS=5

--- a/novaRewards/.gitignore
+++ b/novaRewards/.gitignore
@@ -2,6 +2,8 @@
 .env
 .env.local
 .env.*.local
+.env.staging
+.env.prod
 
 # Dependencies
 node_modules/

--- a/novaRewards/docker-compose.prod.yml
+++ b/novaRewards/docker-compose.prod.yml
@@ -1,0 +1,202 @@
+# docker-compose.prod.yml — Production environment
+# Usage: docker compose -f docker-compose.prod.yml up --build
+# Requires: novaRewards/.env.prod
+# NOTE: Never run with --build in production without a tested image tag.
+
+services:
+  postgres:
+    build:
+      context: ./postgres
+      dockerfile: Dockerfile
+    restart: always
+    env_file: .env.prod
+    environment:
+      POSTGRES_DB: ${POSTGRES_DB:-nova_rewards}
+      POSTGRES_USER: ${POSTGRES_USER:-nova}
+      POSTGRES_PASSWORD: ${POSTGRES_PASSWORD:?POSTGRES_PASSWORD is required}
+    volumes:
+      - postgres_data:/var/lib/postgresql/data
+      - ./database:/docker-entrypoint-initdb.d:ro
+      - ./backups/wal:/var/lib/postgresql/wal-archive
+    command:
+      - postgres
+      - -c
+      - max_connections=200
+      - -c
+      - shared_buffers=1GB
+      - -c
+      - effective_cache_size=3GB
+      - -c
+      - work_mem=16MB
+      - -c
+      - maintenance_work_mem=256MB
+      - -c
+      - wal_level=replica
+      - -c
+      - archive_mode=on
+      - -c
+      - archive_timeout=60s
+      - -c
+      - max_wal_senders=5
+      - -c
+      - archive_command=/usr/local/bin/archive-wal.sh %p %f
+      - -c
+      - log_statement=ddl
+      - -c
+      - log_min_duration_statement=1000
+    healthcheck:
+      test: ["CMD-SHELL", "pg_isready -U ${POSTGRES_USER:-nova} -d ${POSTGRES_DB:-nova_rewards}"]
+      interval: 10s
+      timeout: 5s
+      retries: 10
+    deploy:
+      resources:
+        limits:
+          cpus: "2.0"
+          memory: 4G
+
+  migrate:
+    build:
+      context: ./backend
+      dockerfile: Dockerfile
+    command: ["node", "/migrations/migrate.js"]
+    env_file: .env.prod
+    environment:
+      DATABASE_URL: ${DATABASE_MIGRATE_URL:?DATABASE_MIGRATE_URL is required for production migrations}
+      NODE_ENV: production
+    volumes:
+      - ./database:/migrations:ro
+    depends_on:
+      postgres:
+        condition: service_healthy
+    restart: on-failure
+
+  redis:
+    image: redis:7-alpine
+    restart: always
+    command: >
+      redis-server
+      --appendonly yes
+      --appendfsync everysec
+      --save 900 1
+      --save 300 10
+      --save 60 10000
+      --maxmemory 512mb
+      --maxmemory-policy allkeys-lru
+      --requirepass ${REDIS_PASSWORD:?REDIS_PASSWORD is required}
+    volumes:
+      - redis_data:/data
+    healthcheck:
+      test: ["CMD", "redis-cli", "-a", "${REDIS_PASSWORD}", "ping"]
+      interval: 10s
+      timeout: 3s
+      retries: 5
+    deploy:
+      resources:
+        limits:
+          cpus: "0.5"
+          memory: 640M
+
+  pg-backup:
+    image: postgres:16-alpine
+    restart: always
+    env_file: .env.prod
+    environment:
+      DATABASE_URL: postgresql://${POSTGRES_USER:-nova}:${POSTGRES_PASSWORD}@postgres:5432/${POSTGRES_DB:-nova_rewards}
+      BACKUP_RETAIN_DAYS: ${BACKUP_RETAIN_DAYS:-30}
+      BACKUP_S3_BUCKET: ${BACKUP_S3_BUCKET:?BACKUP_S3_BUCKET is required}
+      AWS_REGION: ${AWS_REGION:-us-east-1}
+      AWS_ACCESS_KEY_ID: ${AWS_ACCESS_KEY_ID:?AWS_ACCESS_KEY_ID is required}
+      AWS_SECRET_ACCESS_KEY: ${AWS_SECRET_ACCESS_KEY:?AWS_SECRET_ACCESS_KEY is required}
+    volumes:
+      - ./scripts/pg-backup.sh:/usr/local/bin/pg-backup.sh:ro
+      - pg_backups:/backups
+    depends_on:
+      postgres:
+        condition: service_healthy
+    command: >
+      sh -c "
+        apk add --no-cache aws-cli &&
+        chmod +x /usr/local/bin/pg-backup.sh &&
+        echo '0 */6 * * * /usr/local/bin/pg-backup.sh >> /var/log/pg-backup.log 2>&1' | crontab - &&
+        /usr/local/bin/pg-backup.sh &&
+        crond -f -l 8
+      "
+    deploy:
+      resources:
+        limits:
+          cpus: "0.25"
+          memory: 128M
+
+  backend:
+    build:
+      context: ./backend
+      dockerfile: Dockerfile
+    restart: always
+    env_file: .env.prod
+    environment:
+      PORT: 3001
+      NODE_ENV: production
+      DATABASE_URL: postgresql://${POSTGRES_USER:-nova}:${POSTGRES_PASSWORD}@postgres:5432/${POSTGRES_DB:-nova_rewards}
+      REDIS_URL: redis://:${REDIS_PASSWORD}@redis:6379
+      REDIS_MODE: single
+      ALLOWED_ORIGIN: ${ALLOWED_ORIGIN:?ALLOWED_ORIGIN is required}
+      # Connection pool — sized for production load
+      DB_POOL_MIN: 5
+      DB_POOL_MAX: 50
+    ports:
+      - "3001:3001"
+    depends_on:
+      postgres:
+        condition: service_healthy
+      redis:
+        condition: service_healthy
+      migrate:
+        condition: service_completed_successfully
+    deploy:
+      replicas: 2
+      resources:
+        limits:
+          cpus: "1.0"
+          memory: 1G
+
+  frontend:
+    build:
+      context: ./frontend
+      dockerfile: Dockerfile
+    restart: always
+    env_file: .env.prod
+    environment:
+      NODE_ENV: production
+      NEXT_PUBLIC_API_URL: ${NEXT_PUBLIC_API_URL:?NEXT_PUBLIC_API_URL is required}
+    ports:
+      - "3000:3000"
+    depends_on:
+      backend:
+        condition: service_started
+    deploy:
+      replicas: 2
+      resources:
+        limits:
+          cpus: "1.0"
+          memory: 1G
+
+  gateway:
+    image: nginx:1.25-alpine
+    restart: always
+    ports:
+      - "8080:80"
+    volumes:
+      - ../deployment/nginx/nginx.conf:/etc/nginx/nginx.conf:ro
+    depends_on:
+      - backend
+    deploy:
+      resources:
+        limits:
+          cpus: "0.5"
+          memory: 128M
+
+volumes:
+  postgres_data:
+  redis_data:
+  pg_backups:

--- a/novaRewards/docker-compose.staging.yml
+++ b/novaRewards/docker-compose.staging.yml
@@ -1,0 +1,158 @@
+# docker-compose.staging.yml — Staging environment
+# Usage: docker compose -f docker-compose.staging.yml up --build
+# Requires: novaRewards/.env.staging
+
+services:
+  postgres:
+    build:
+      context: ./postgres
+      dockerfile: Dockerfile
+    restart: unless-stopped
+    env_file: .env.staging
+    environment:
+      POSTGRES_DB: ${POSTGRES_DB:-nova_rewards_staging}
+      POSTGRES_USER: ${POSTGRES_USER:-nova_staging}
+      POSTGRES_PASSWORD: ${POSTGRES_PASSWORD:?POSTGRES_PASSWORD is required}
+    volumes:
+      - postgres_data:/var/lib/postgresql/data
+      - ./database:/docker-entrypoint-initdb.d:ro
+    command:
+      - postgres
+      - -c
+      - max_connections=50
+      - -c
+      - shared_buffers=256MB
+      - -c
+      - wal_level=replica
+      - -c
+      - archive_mode=on
+      - -c
+      - archive_timeout=60s
+      - -c
+      - max_wal_senders=3
+      - -c
+      - archive_command=/usr/local/bin/archive-wal.sh %p %f
+      - -c
+      - log_statement=ddl
+      - -c
+      - log_min_duration_statement=500
+    healthcheck:
+      test: ["CMD-SHELL", "pg_isready -U ${POSTGRES_USER:-nova_staging} -d ${POSTGRES_DB:-nova_rewards_staging}"]
+      interval: 10s
+      timeout: 5s
+      retries: 10
+    deploy:
+      resources:
+        limits:
+          cpus: "0.5"
+          memory: 512M
+
+  migrate:
+    build:
+      context: ./backend
+      dockerfile: Dockerfile
+    command: ["node", "/migrations/migrate.js"]
+    env_file: .env.staging
+    environment:
+      DATABASE_URL: postgresql://${POSTGRES_USER:-nova_staging}:${POSTGRES_PASSWORD}@postgres:5432/${POSTGRES_DB:-nova_rewards_staging}
+      NODE_ENV: staging
+    volumes:
+      - ./database:/migrations:ro
+    depends_on:
+      postgres:
+        condition: service_healthy
+    restart: on-failure
+
+  redis:
+    image: redis:7-alpine
+    restart: unless-stopped
+    command: >
+      redis-server
+      --appendonly yes
+      --appendfsync everysec
+      --save 900 1
+      --save 300 10
+      --maxmemory 128mb
+      --maxmemory-policy allkeys-lru
+    volumes:
+      - redis_data:/data
+    healthcheck:
+      test: ["CMD", "redis-cli", "ping"]
+      interval: 10s
+      timeout: 3s
+      retries: 5
+    deploy:
+      resources:
+        limits:
+          cpus: "0.25"
+          memory: 192M
+
+  backend:
+    build:
+      context: ./backend
+      dockerfile: Dockerfile
+    restart: unless-stopped
+    env_file: .env.staging
+    environment:
+      PORT: 3001
+      NODE_ENV: staging
+      DATABASE_URL: postgresql://${POSTGRES_USER:-nova_staging}:${POSTGRES_PASSWORD}@postgres:5432/${POSTGRES_DB:-nova_rewards_staging}
+      REDIS_URL: redis://redis:6379
+      REDIS_MODE: single
+      ALLOWED_ORIGIN: ${ALLOWED_ORIGIN:?ALLOWED_ORIGIN is required}
+      # Connection pool — conservative for staging
+      DB_POOL_MIN: 2
+      DB_POOL_MAX: 10
+    ports:
+      - "3001:3001"
+    depends_on:
+      postgres:
+        condition: service_healthy
+      redis:
+        condition: service_healthy
+      migrate:
+        condition: service_completed_successfully
+    deploy:
+      resources:
+        limits:
+          cpus: "0.5"
+          memory: 512M
+
+  frontend:
+    build:
+      context: ./frontend
+      dockerfile: Dockerfile
+    restart: unless-stopped
+    env_file: .env.staging
+    environment:
+      NODE_ENV: staging
+      NEXT_PUBLIC_API_URL: ${NEXT_PUBLIC_API_URL:?NEXT_PUBLIC_API_URL is required}
+    ports:
+      - "3000:3000"
+    depends_on:
+      backend:
+        condition: service_started
+    deploy:
+      resources:
+        limits:
+          cpus: "0.5"
+          memory: 512M
+
+  gateway:
+    image: nginx:1.25-alpine
+    restart: unless-stopped
+    ports:
+      - "8080:80"
+    volumes:
+      - ../deployment/nginx/nginx.conf:/etc/nginx/nginx.conf:ro
+    depends_on:
+      - backend
+    deploy:
+      resources:
+        limits:
+          cpus: "0.25"
+          memory: 64M
+
+volumes:
+  postgres_data:
+  redis_data:

--- a/scripts/diff-env-configs.sh
+++ b/scripts/diff-env-configs.sh
@@ -1,0 +1,132 @@
+#!/usr/bin/env bash
+# scripts/diff-env-configs.sh
+# Detects unexpected differences between staging and production environment configs.
+# Usage: ./scripts/diff-env-configs.sh [--strict]
+#
+# Exit codes:
+#   0 — no unexpected differences
+#   1 — unexpected differences found
+#   2 — usage error
+
+set -euo pipefail
+
+STAGING_EXAMPLE="novaRewards/.env.staging.example"
+PROD_EXAMPLE="novaRewards/.env.prod.example"
+STRICT=${1:-}
+
+# Keys that are EXPECTED to differ between environments
+EXPECTED_DIFFS=(
+  "STELLAR_NETWORK"
+  "HORIZON_URL"
+  "POSTGRES_USER"
+  "POSTGRES_PASSWORD"
+  "POSTGRES_DB"
+  "DATABASE_URL"
+  "DATABASE_MIGRATE_URL"
+  "REDIS_PASSWORD"
+  "REDIS_URL"
+  "REDIS_MAXMEMORY"
+  "NODE_ENV"
+  "ALLOWED_ORIGIN"
+  "JWT_SECRET"
+  "FIELD_ENCRYPTION_KEY"
+  "NEXT_PUBLIC_API_URL"
+  "NEXT_PUBLIC_HORIZON_URL"
+  "NEXT_PUBLIC_STELLAR_NETWORK"
+  "SMTP_HOST"
+  "SMTP_PORT"
+  "SMTP_USER"
+  "SMTP_PASSWORD"
+  "EMAIL_FROM"
+  "SENDGRID_API_KEY"
+  "BACKUP_RETAIN_DAYS"
+  "BACKUP_S3_BUCKET"
+  "AWS_ACCESS_KEY_ID"
+  "AWS_SECRET_ACCESS_KEY"
+  "ISSUER_PUBLIC"
+  "ISSUER_SECRET"
+  "DISTRIBUTION_PUBLIC"
+  "DISTRIBUTION_SECRET"
+  "NEXT_PUBLIC_ISSUER_PUBLIC"
+)
+
+if [[ ! -f "$STAGING_EXAMPLE" ]]; then
+  echo "ERROR: $STAGING_EXAMPLE not found" >&2
+  exit 2
+fi
+
+if [[ ! -f "$PROD_EXAMPLE" ]]; then
+  echo "ERROR: $PROD_EXAMPLE not found" >&2
+  exit 2
+fi
+
+# Extract variable names (lines starting with a letter, not comments)
+extract_keys() {
+  grep -E '^[A-Z_]+=?' "$1" | sed 's/=.*//' | sort
+}
+
+staging_keys=$(extract_keys "$STAGING_EXAMPLE")
+prod_keys=$(extract_keys "$PROD_EXAMPLE")
+
+echo "=== Nova Rewards — Environment Config Diff ==="
+echo "Staging : $STAGING_EXAMPLE"
+echo "Prod    : $PROD_EXAMPLE"
+echo ""
+
+# ── 1. Keys present in staging but missing from prod ─────────────────────────
+missing_in_prod=$(comm -23 <(echo "$staging_keys") <(echo "$prod_keys"))
+if [[ -n "$missing_in_prod" ]]; then
+  echo "⚠  Keys in staging but MISSING in prod:"
+  echo "$missing_in_prod" | sed 's/^/   - /'
+  echo ""
+fi
+
+# ── 2. Keys present in prod but missing from staging ─────────────────────────
+missing_in_staging=$(comm -13 <(echo "$staging_keys") <(echo "$prod_keys"))
+if [[ -n "$missing_in_staging" ]]; then
+  echo "⚠  Keys in prod but MISSING in staging:"
+  echo "$missing_in_staging" | sed 's/^/   - /'
+  echo ""
+fi
+
+# ── 3. Keys present in both — check for unexpected identical values ───────────
+unexpected_same=()
+while IFS= read -r key; do
+  staging_val=$(grep -E "^${key}=" "$STAGING_EXAMPLE" | cut -d= -f2- || true)
+  prod_val=$(grep -E "^${key}=" "$PROD_EXAMPLE" | cut -d= -f2- || true)
+
+  if [[ "$staging_val" == "$prod_val" && -n "$staging_val" ]]; then
+    # Check if this key is expected to differ
+    expected=false
+    for expected_key in "${EXPECTED_DIFFS[@]}"; do
+      if [[ "$key" == "$expected_key" ]]; then
+        expected=true
+        break
+      fi
+    done
+    if [[ "$expected" == "false" ]]; then
+      unexpected_same+=("$key")
+    fi
+  fi
+done < <(comm -12 <(echo "$staging_keys") <(echo "$prod_keys"))
+
+if [[ ${#unexpected_same[@]} -gt 0 ]]; then
+  echo "ℹ  Keys with identical values in both environments (verify intentional):"
+  for k in "${unexpected_same[@]}"; do
+    echo "   - $k"
+  done
+  echo ""
+fi
+
+# ── 4. Summary ────────────────────────────────────────────────────────────────
+has_issues=false
+[[ -n "$missing_in_prod" || -n "$missing_in_staging" ]] && has_issues=true
+[[ "$STRICT" == "--strict" && ${#unexpected_same[@]} -gt 0 ]] && has_issues=true
+
+if [[ "$has_issues" == "true" ]]; then
+  echo "❌ Config drift detected. Review the items above."
+  exit 1
+else
+  echo "✅ No unexpected config drift detected."
+  exit 0
+fi


### PR DESCRIPTION
## Summary

Closes #628

Implements isolated, independently deployable infrastructure configurations for staging and production environments with appropriate resource sizing and drift detection.

## Changes

### New files
- `novaRewards/docker-compose.staging.yml` — staging compose with conservative resource limits
- `novaRewards/docker-compose.prod.yml` — production compose with HA sizing (2 replicas for backend/frontend)
- `novaRewards/.env.staging.example` — all required env vars documented for staging
- `novaRewards/.env.prod.example` — all required env vars documented for production
- `scripts/diff-env-configs.sh` — detects unexpected config drift between environments

### Modified
- `novaRewards/.gitignore` — added `.env.staging` and `.env.prod` to prevent accidental commits

## Acceptance Criteria

- [x] Separate `docker-compose.staging.yml` and `docker-compose.prod.yml` configurations
- [x] Environment variables documented and validated per environment (`:?` syntax enforces required vars at startup)
- [x] Database connection pooling configured per environment (staging: pool max=10, prod: pool max=50)
- [x] Resource limits (CPU/memory) defined for all containers in both files
- [x] `scripts/diff-env-configs.sh` detects unexpected differences between environments

## Usage

```bash
# Staging
docker compose -f novaRewards/docker-compose.staging.yml --env-file novaRewards/.env.staging up --build

# Production
docker compose -f novaRewards/docker-compose.prod.yml --env-file novaRewards/.env.prod up

# Check for config drift
./scripts/diff-env-configs.sh
./scripts/diff-env-configs.sh --strict   # also flags identical values
```