### PR TITLE
feat: Docker Compose local dev stack with Stellar, health checks, hot reload

### DIFF
--- a/README.md
+++ b/README.md
@@ -99,10 +99,9 @@ graph TD
 
 | Tool | Version | Install |
 |------|---------|---------|
-| Node.js | ≥ 20 | [nodejs.org](https://nodejs.org) |
-| Rust (stable) | see `rust-toolchain.toml` | [rustup.rs](https://rustup.rs) |
-| Stellar CLI | latest | [developers.stellar.org](https://developers.stellar.org/docs/tools/cli/install-cli) |
 | Docker Desktop | latest | [docker.com](https://www.docker.com/products/docker-desktop) |
+| Node.js | ≥ 20 | [nodejs.org](https://nodejs.org) (for running tests outside Docker) |
+| Rust (stable) | see `rust-toolchain.toml` | [rustup.rs](https://rustup.rs) (for contract development) |
 | Freighter wallet | latest | [freighter.app](https://www.freighter.app) |
 
 ### 1 — Clone
@@ -112,24 +111,54 @@ git clone https://github.com/barry01-hash/Nova-Rewards.git
 cd Nova-Rewards
 ```
 
-### 2 — Start infrastructure (Postgres + Redis + Backend + Frontend)
+### 2 — Configure environment
 
 ```bash
 cd novaRewards
-cp .env.example .env          # fill in secrets — see Environment Setup below
+cp .env.example .env   # fill in secrets — see Environment Setup below
+```
+
+### 3 — Start the full stack
+
+```bash
 docker compose up --build
 ```
 
-Services come up at:
-- Frontend → http://localhost:3000
-- Backend API → http://localhost:3001
-- Nginx gateway → http://localhost:8080
+This single command starts all services:
 
-### 3 — Set up Soroban contracts
+| Service | URL | Description |
+|---------|-----|-------------|
+| Frontend | http://localhost:3000 | Next.js PWA (hot reload via `next dev`) |
+| Backend API | http://localhost:3001 | Express API (hot reload via nodemon) |
+| Nginx gateway | http://localhost:8080 | Reverse proxy |
+| PostgreSQL | localhost:5432 | Primary database (data persisted in `postgres_data` volume) |
+| Redis | localhost:6379 | Cache & rate limiting (data persisted in `redis_data` volume) |
+| Stellar standalone | http://localhost:8000 | Local Soroban/Stellar node (RPC at `/rpc`) |
 
-**POSIX:**
+Database migrations run automatically before the backend starts. Hot reload is active for both backend (nodemon) and frontend (Next.js dev server) — saving a file triggers an instant reload with no container restart needed.
+
+To run only the infrastructure services (no app):
+
 ```bash
-./scripts/setup-soroban-dev.sh   # installs wasm32v1-none target, adds local network
+docker compose up postgres redis stellar
+```
+
+To stop and remove containers (volumes are preserved):
+
+```bash
+docker compose down
+```
+
+To also wipe persisted data:
+
+```bash
+docker compose down -v
+```
+
+### 4 — Set up Soroban contracts
+
+```bash
+./scripts/setup-soroban-dev.sh   # installs wasm32v1-none target, registers local network
 ./scripts/build-contracts.sh     # compiles all contracts to WASM
 ./scripts/test-contracts.sh      # runs contract test suite
 ```
@@ -139,16 +168,6 @@ Services come up at:
 ./scripts/setup-soroban-dev.ps1
 ./scripts/build-contracts.ps1
 ./scripts/test-contracts.ps1
-```
-
-### 4 — (Optional) Local Stellar testnet
-
-```bash
-./scripts/start-local-testnet.sh      # starts a standalone Soroban/Stellar node
-```
-
-```powershell
-./scripts/start-local-testnet.ps1
 ```
 
 ### 5 — Run application tests

--- a/novaRewards/docker-compose.yml
+++ b/novaRewards/docker-compose.yml
@@ -34,23 +34,6 @@ services:
       - -c
       - archive_command=/usr/local/bin/archive-wal.sh %p %f
 
-  # Runs pending migrations once on every `docker compose up`
-  migrate:
-    image: node:20-alpine
-    working_dir: /app
-    command: sh -c "npm install --prefix /app/database 2>/dev/null; node database/migrate.js"
-    env_file:
-      - .env.example
-    environment:
-      DATABASE_URL: postgresql://${POSTGRES_USER:-nova}:${POSTGRES_PASSWORD:-changeme}@postgres:5432/${POSTGRES_DB:-nova_rewards}
-      NODE_ENV: ${NODE_ENV:-development}
-    volumes:
-      - .:/app
-    depends_on:
-      postgres:
-        condition: service_healthy
-    restart: "no"
-
   redis:
     image: redis:7-alpine
     restart: unless-stopped
@@ -73,7 +56,36 @@ services:
       timeout: 3s
       retries: 5
 
-  # Scheduled PostgreSQL backups (runs every 6 hours via supercronic)
+  stellar:
+    image: stellar/quickstart:testing
+    command: --local --enable-stellar-rpc
+    ports:
+      - "8000:8000"
+    healthcheck:
+      test: ["CMD-SHELL", "curl -sf http://localhost:8000/rpc -d '{\"jsonrpc\":\"2.0\",\"id\":1,\"method\":\"getHealth\"}' -H 'Content-Type: application/json' | grep -q '\"status\":\"healthy\"'"]
+      interval: 10s
+      timeout: 5s
+      retries: 12
+      start_period: 30s
+
+  # Runs pending migrations once on every `docker compose up`
+  migrate:
+    image: node:20-alpine
+    working_dir: /app
+    command: sh -c "npm install --prefix /app/database 2>/dev/null; node database/migrate.js"
+    env_file:
+      - .env.example
+    environment:
+      DATABASE_URL: postgresql://${POSTGRES_USER:-nova}:${POSTGRES_PASSWORD:-changeme}@postgres:5432/${POSTGRES_DB:-nova_rewards}
+      NODE_ENV: ${NODE_ENV:-development}
+    volumes:
+      - .:/app
+    depends_on:
+      postgres:
+        condition: service_healthy
+    restart: "no"
+
+  # Scheduled PostgreSQL backups (runs every 6 hours via crond)
   pg-backup:
     image: postgres:16-alpine
     restart: unless-stopped
@@ -92,7 +104,6 @@ services:
     depends_on:
       postgres:
         condition: service_healthy
-    # Run backup on container start, then every 6 hours via crond
     command: >
       sh -c "
         apk add --no-cache aws-cli &&
@@ -101,24 +112,6 @@ services:
         /usr/local/bin/pg-backup.sh &&
         crond -f -l 8
       "
-
-  # One-shot service: runs all pending migrations then exits.
-  # backend depends on this completing successfully before it starts.
-  migrate:
-    build:
-      context: ./backend
-      dockerfile: Dockerfile
-    command: ["node", "/migrations/migrate.js"]
-    env_file:
-      - .env
-    environment:
-      DATABASE_URL: postgresql://${POSTGRES_USER:-nova}:${POSTGRES_PASSWORD}@postgres:5432/${POSTGRES_DB:-nova_rewards}
-    volumes:
-      - ./database:/migrations:ro
-    depends_on:
-      postgres:
-        condition: service_healthy
-    restart: on-failure
 
   backend:
     build:
@@ -134,6 +127,8 @@ services:
       REDIS_URL: redis://redis:6379
       REDIS_MODE: single
       ALLOWED_ORIGIN: http://localhost:3000
+      HORIZON_URL: http://stellar:8000
+      STELLAR_RPC_URL: http://stellar:8000/rpc
     ports:
       - "3001:3001"
     depends_on:
@@ -146,6 +141,12 @@ services:
     volumes:
       - ./backend:/app
       - backend_node_modules:/app/node_modules
+    healthcheck:
+      test: ["CMD-SHELL", "wget -qO- http://localhost:3001/health || exit 1"]
+      interval: 10s
+      timeout: 5s
+      retries: 5
+      start_period: 20s
 
   frontend:
     build:
@@ -158,6 +159,8 @@ services:
       NODE_ENV: development
       HOST: 0.0.0.0
       NEXT_PUBLIC_API_URL: http://localhost:3001
+      NEXT_PUBLIC_HORIZON_URL: http://localhost:8000
+      NEXT_PUBLIC_STELLAR_NETWORK: local
     ports:
       - "3000:3000"
     depends_on:
@@ -166,6 +169,12 @@ services:
     volumes:
       - ./frontend:/app
       - frontend_node_modules:/app/node_modules
+    healthcheck:
+      test: ["CMD-SHELL", "wget -qO- http://localhost:3000 || exit 1"]
+      interval: 10s
+      timeout: 5s
+      retries: 5
+      start_period: 30s
 
   gateway:
     image: nginx:1.25-alpine


### PR DESCRIPTION
Closes #622

---

## Summary

Closes the P0-critical DevOps/MVP task for local development setup.

**Changes:**
- Added `stellar` service (`stellar/quickstart:testing`) to `docker-compose.yml` — Soroban RPC available at `http://localhost:8000/rpc`
- Fixed duplicate `migrate` service (kept the lightweight `node:20-alpine` one-shot variant)
- Added health checks to `backend` and `frontend` services
- Wired `HORIZON_URL`, `STELLAR_RPC_URL` into backend and `NEXT_PUBLIC_HORIZON_URL`, `NEXT_PUBLIC_STELLAR_NETWORK=local` into frontend
- Updated `README.md` Quick Start: single `docker compose up --build` starts all 6 services; removed separate start-local-testnet step

**Services started by `docker compose up --build`:**
| Service | URL |
|---------|-----|
| Frontend (hot reload) | http://localhost:3000 |
| Backend API (hot reload) | http://localhost:3001 |
| Nginx gateway | http://localhost:8080 |
| PostgreSQL | localhost:5432 |
| Redis | localhost:6379 |
| Stellar standalone | http://localhost:8000 |

## Tested
- Compose file validated (no duplicate service keys)
- Hot reload works via existing volume mounts + nodemon/next dev
- Migrations run automatically via one-shot `migrate` service before backend starts