### PR TITLE
Add Soroban smart contract security audit engagement plan and documen…

### DIFF
--- a/docs/audits/README.md
+++ b/docs/audits/README.md
@@ -20,6 +20,8 @@ This directory tracks security audits for all Nova Rewards smart contracts.
 | admin_roles | 0.1.0 | Scheduled | Scheduled | TBD |
 | governance | 0.1.0 | Scheduled | Scheduled | TBD |
 
+> A comprehensive third-party audit engagement is planned for all Soroban contracts before mainnet deployment. The audit scope includes token, distribution, campaign, staking, vesting, and treasury.
+
 ## Process
 
 1. New contracts must have an audit entry before production deployment.

--- a/docs/audits/reports/soroban-security-audit-engagement-plan.md
+++ b/docs/audits/reports/soroban-security-audit-engagement-plan.md
@@ -1,0 +1,46 @@
+# Soroban Smart Contract Security Audit Engagement
+
+## Overview
+
+Engage a third-party security firm to conduct a comprehensive audit of all Soroban smart contracts prior to mainnet deployment.
+
+This engagement will cover the following contract areas:
+- Token
+- Distribution
+- Campaign
+- Staking
+- Vesting
+- Treasury
+
+## Audit Scope
+
+The audit scope includes:
+- Reentrancy
+- Integer overflow and underflow
+- Access control and authorization
+- Economic attack vectors
+- Soroban-specific security considerations
+- Contract interaction and state transition risks
+
+## Acceptance Criteria
+
+1. Audit scope defined covering all contracts: token, distribution, campaign, staking, vesting, treasury.
+2. Audit report received with all findings categorized by severity.
+3. All critical and high severity findings remediated before mainnet deployment.
+4. Medium severity findings remediated or formally accepted with documented rationale.
+5. Final audit report published in `docs/audits/reports/`.
+
+## Deliverables
+
+- Signed engagement letter with the selected third-party auditor.
+- Final audit report in markdown and/or PDF form.
+- Findings categorized by severity: Critical, High, Medium, Low, Informational.
+- Remediation plan and evidence of fixes for Critical and High issues.
+- Documented rationale for any accepted Medium findings.
+
+## Next Steps
+
+- Select and engage a qualified Soroban smart contract security firm.
+- Provide the auditor with repository access and contract documentation.
+- Track findings and remediation progress in `docs/audits/reports/`.
+- Publish the final report and update `docs/audits/README.md` with completion status.


### PR DESCRIPTION
PR Description
Summary
Add a Soroban smart contract security audit engagement plan and document the audit scope for Nova Rewards prior to mainnet deployment.

What changed
Added [soroban-security-audit-engagement-plan.md](https://animated-cod-qvqpr6ww6gvq244g.github.dev/)
Updated [README.md](https://animated-cod-qvqpr6ww6gvq244g.github.dev/) with the audit engagement note and coverage summary
Why
This documents the third-party audit scope for Soroban contracts and ensures the project tracks required security review steps before launch.

Acceptance
Audit scope now explicitly covers token, distribution, campaign, staking, vesting, and treasury
Audit findings must be categorized by severity
Critical/high findings must be remediated before mainnet
Medium findings must be remediated or accepted with rationale
Final report will be published under [reports](https://animated-cod-qvqpr6ww6gvq244g.github.dev/)
Closes #645 