### PR TITLE
feat: add test data generators for users, campaigns, transactions, re…

### DIFF
--- a/novaRewards/backend/scripts/seed-test-data.js
+++ b/novaRewards/backend/scripts/seed-test-data.js
@@ -1,0 +1,308 @@
+/**
+ * Bulk Seed Script — Nova Rewards
+ *
+ * Generates realistic test data at scale using batched INSERTs and
+ * parallel execution where possible.
+ *
+ * Usage:
+ *   node novaRewards/backend/scripts/seed-test-data.js [--count=N] [--env=test]
+ *
+ * Options:
+ *   --count=N   Number of users to generate (default: 500)
+ *   --env=test  Which .env file to load (default: .env.test)
+ *   --clean     Truncate seed tables before inserting
+ *
+ * Performance strategy:
+ *   - Single multi-row INSERT per entity type (one round-trip per batch)
+ *   - Batch size capped at BATCH_SIZE rows to stay within pg parameter limits
+ *   - Merchants and campaigns inserted first; users/wallets/transactions in parallel
+ *   - All writes wrapped in a single transaction for atomicity
+ */
+
+'use strict';
+
+const path   = require('path');
+const crypto = require('crypto');
+
+// ── CLI args ──────────────────────────────────────────────────────────────
+
+const args = Object.fromEntries(
+  process.argv.slice(2).map((a) => {
+    const [k, v] = a.replace(/^--/, '').split('=');
+    return [k, v ?? true];
+  }),
+);
+
+const ENV_FILE  = args.env   ? `.env.${args.env}` : '.env.test';
+const USER_COUNT = parseInt(args.count ?? '500', 10);
+const CLEAN      = Boolean(args.clean);
+const BATCH_SIZE = 200; // rows per INSERT statement
+
+require('dotenv').config({ path: path.resolve(__dirname, '..', ENV_FILE) });
+
+const { Pool } = require('pg');
+const { faker } = require('@faker-js/faker');
+
+const pool = new Pool({ connectionString: process.env.DATABASE_URL });
+
+// ── Helpers ───────────────────────────────────────────────────────────────
+
+const stellarAddress = () =>
+  'G' + faker.string.alphanumeric({ length: 55, casing: 'upper' });
+
+const isoDate = (d) => d.toISOString().split('T')[0];
+const daysAgo   = (n) => new Date(Date.now() - n * 86_400_000);
+const daysAhead = (n) => new Date(Date.now() + n * 86_400_000);
+
+/**
+ * Build a parameterised multi-row INSERT.
+ * Returns { text, values } ready for client.query().
+ *
+ * @param {string}   table   - table name
+ * @param {string[]} cols    - column names
+ * @param {Array[]}  rows    - array of value arrays (one per row)
+ */
+function buildBulkInsert(table, cols, rows) {
+  const placeholders = rows.map((_, ri) =>
+    `(${cols.map((_, ci) => `$${ri * cols.length + ci + 1}`).join(', ')})`
+  );
+  return {
+    text: `INSERT INTO ${table} (${cols.join(', ')}) VALUES ${placeholders.join(', ')} ON CONFLICT DO NOTHING`,
+    values: rows.flat(),
+  };
+}
+
+/**
+ * Execute rows in batches of BATCH_SIZE to avoid exceeding pg's 65535 parameter limit.
+ */
+async function batchInsert(client, table, cols, rows) {
+  for (let i = 0; i < rows.length; i += BATCH_SIZE) {
+    const batch = rows.slice(i, i + BATCH_SIZE);
+    const { text, values } = buildBulkInsert(table, cols, batch);
+    await client.query(text, values);
+  }
+}
+
+// ── Data generators ───────────────────────────────────────────────────────
+
+function generateMerchants(count = 10) {
+  return Array.from({ length: count }, (_, i) => {
+    const apiKey = `seed-merchant-key-${i + 1}-${crypto.randomBytes(8).toString('hex')}`;
+    return {
+      name: faker.company.name(),
+      api_key_hash: crypto.createHash('sha256').update(apiKey).digest('hex'),
+      wallet_address: stellarAddress(),
+      is_active: true,
+      _api_key: apiKey, // kept for output only, not inserted
+    };
+  });
+}
+
+function generateCampaigns(merchantIds, perMerchant = 3) {
+  return merchantIds.flatMap((merchantId) =>
+    Array.from({ length: perMerchant }, () => {
+      const isExpired = faker.datatype.boolean({ probability: 0.2 });
+      return {
+        merchant_id: merchantId,
+        name: `${faker.commerce.productName()} Rewards`,
+        reward_rate: parseFloat(faker.number.float({ min: 0.01, max: 0.1, fractionDigits: 7 })),
+        start_date: isoDate(isExpired ? daysAgo(90) : faker.date.recent({ days: 30 })),
+        end_date:   isoDate(isExpired ? daysAgo(1)  : daysAhead(faker.number.int({ min: 7, max: 90 }))),
+        is_active: !isExpired,
+        on_chain_status: faker.helpers.arrayElement(['confirmed', 'confirmed', 'confirmed', 'pending']),
+      };
+    })
+  );
+}
+
+function generateUsers(count) {
+  return Array.from({ length: count }, () => ({
+    email: faker.internet.email(),
+    first_name: faker.person.firstName(),
+    last_name: faker.person.lastName(),
+    wallet_address: stellarAddress(),
+    stellar_public_key: stellarAddress(),
+    referral_code: faker.string.alphanumeric({ length: 8, casing: 'upper' }),
+    role: faker.helpers.weightedArrayElement([
+      { weight: 90, value: 'user' },
+      { weight: 8,  value: 'merchant' },
+      { weight: 2,  value: 'admin' },
+    ]),
+    is_deleted: faker.datatype.boolean({ probability: 0.02 }),
+  }));
+}
+
+function generateWallets(userIds) {
+  return userIds.flatMap((userId) => {
+    const count = faker.number.int({ min: 1, max: 2 });
+    return Array.from({ length: count }, (_, i) => ({
+      user_id: userId,
+      address: stellarAddress(),
+      is_primary: i === 0,
+      is_active: true,
+    }));
+  });
+}
+
+function generateTransactions(userIds, campaignIds, merchantIds, count) {
+  const types = ['distribution', 'redemption', 'transfer'];
+  return Array.from({ length: count }, () => ({
+    tx_hash: faker.string.hexadecimal({ length: 64, casing: 'lower' }).replace('0x', ''),
+    tx_type: faker.helpers.arrayElement(types),
+    amount: parseFloat(faker.number.float({ min: 0.1, max: 1_000, fractionDigits: 7 })),
+    from_wallet: stellarAddress(),
+    to_wallet: stellarAddress(),
+    merchant_id: faker.helpers.arrayElement(merchantIds),
+    campaign_id: faker.helpers.arrayElement(campaignIds),
+    stellar_ledger: faker.number.int({ min: 1_000_000, max: 50_000_000 }),
+    created_at: faker.date.recent({ days: 90 }),
+  }));
+}
+
+function generateRewards(count = 20) {
+  return Array.from({ length: count }, () => ({
+    name: faker.commerce.productName(),
+    description: faker.commerce.productDescription(),
+    cost: faker.number.int({ min: 10, max: 5_000 }),
+    stock: faker.number.int({ min: 0, max: 500 }),
+    is_active: faker.datatype.boolean({ probability: 0.85 }),
+    is_deleted: false,
+  }));
+}
+
+function generateRewardIssuances(userIds, campaignIds, count) {
+  return Array.from({ length: count }, () => {
+    const status = faker.helpers.weightedArrayElement([
+      { weight: 70, value: 'confirmed' },
+      { weight: 20, value: 'pending' },
+      { weight: 10, value: 'failed' },
+    ]);
+    return {
+      idempotency_key: faker.string.uuid(),
+      user_id: faker.helpers.arrayElement(userIds),
+      campaign_id: faker.helpers.arrayElement(campaignIds),
+      wallet_address: stellarAddress(),
+      amount: parseFloat(faker.number.float({ min: 0.1, max: 500, fractionDigits: 7 })),
+      status,
+      tx_hash: status !== 'failed'
+        ? faker.string.hexadecimal({ length: 64, casing: 'lower' }).replace('0x', '')
+        : null,
+      error_message: status === 'failed'
+        ? faker.helpers.arrayElement(['Insufficient balance', 'Trustline not established', 'Network timeout'])
+        : null,
+      attempts: status === 'failed' ? 3 : faker.number.int({ min: 0, max: 2 }),
+    };
+  });
+}
+
+// ── Main ──────────────────────────────────────────────────────────────────
+
+async function seed() {
+  const client = await pool.connect();
+  const t0 = Date.now();
+
+  try {
+    if (CLEAN) {
+      console.log('🧹 Cleaning seed tables…');
+      // Truncate in dependency order (children first)
+      await client.query(`
+        TRUNCATE reward_issuances, transactions, wallets, rewards,
+                 campaigns, users, merchants RESTART IDENTITY CASCADE
+      `);
+    }
+
+    await client.query('BEGIN');
+
+    // ── Merchants ──────────────────────────────────────────────────────────
+    console.log('🏪 Inserting merchants…');
+    const merchantData = generateMerchants(10);
+    await batchInsert(client, 'merchants',
+      ['name', 'api_key_hash', 'wallet_address', 'is_active'],
+      merchantData.map((m) => [m.name, m.api_key_hash, m.wallet_address, m.is_active]),
+    );
+    const { rows: merchantRows } = await client.query(
+      `SELECT id FROM merchants WHERE api_key_hash = ANY($1)`,
+      [merchantData.map((m) => m.api_key_hash)],
+    );
+    const merchantIds = merchantRows.map((r) => r.id);
+
+    // ── Campaigns ──────────────────────────────────────────────────────────
+    console.log('📣 Inserting campaigns…');
+    const campaigns = generateCampaigns(merchantIds, 3);
+    await batchInsert(client, 'campaigns',
+      ['merchant_id', 'name', 'reward_rate', 'start_date', 'end_date', 'is_active', 'on_chain_status'],
+      campaigns.map((c) => [c.merchant_id, c.name, c.reward_rate, c.start_date, c.end_date, c.is_active, c.on_chain_status]),
+    );
+    const { rows: campaignRows } = await client.query(`SELECT id FROM campaigns`);
+    const campaignIds = campaignRows.map((r) => r.id);
+
+    // ── Rewards ────────────────────────────────────────────────────────────
+    console.log('🎁 Inserting rewards…');
+    const rewards = generateRewards(20);
+    await batchInsert(client, 'rewards',
+      ['name', 'description', 'cost', 'stock', 'is_active', 'is_deleted'],
+      rewards.map((r) => [r.name, r.description, r.cost, r.stock, r.is_active, r.is_deleted]),
+    );
+
+    // ── Users ──────────────────────────────────────────────────────────────
+    console.log(`👤 Inserting ${USER_COUNT} users…`);
+    const users = generateUsers(USER_COUNT);
+    await batchInsert(client, 'users',
+      ['email', 'first_name', 'last_name', 'wallet_address', 'stellar_public_key', 'referral_code', 'role', 'is_deleted'],
+      users.map((u) => [u.email, u.first_name, u.last_name, u.wallet_address, u.stellar_public_key, u.referral_code, u.role, u.is_deleted]),
+    );
+    const { rows: userRows } = await client.query(`SELECT id FROM users ORDER BY id`);
+    const userIds = userRows.map((r) => r.id);
+
+    // ── Wallets ────────────────────────────────────────────────────────────
+    console.log('💳 Inserting wallets…');
+    const wallets = generateWallets(userIds);
+    await batchInsert(client, 'wallets',
+      ['user_id', 'address', 'is_primary', 'is_active'],
+      wallets.map((w) => [w.user_id, w.address, w.is_primary, w.is_active]),
+    );
+
+    // ── Transactions ───────────────────────────────────────────────────────
+    const txCount = USER_COUNT * 5;
+    console.log(`💸 Inserting ${txCount} transactions…`);
+    const transactions = generateTransactions(userIds, campaignIds, merchantIds, txCount);
+    await batchInsert(client, 'transactions',
+      ['tx_hash', 'tx_type', 'amount', 'from_wallet', 'to_wallet', 'merchant_id', 'campaign_id', 'stellar_ledger', 'created_at'],
+      transactions.map((t) => [t.tx_hash, t.tx_type, t.amount, t.from_wallet, t.to_wallet, t.merchant_id, t.campaign_id, t.stellar_ledger, t.created_at]),
+    );
+
+    // ── Reward Issuances ───────────────────────────────────────────────────
+    const issuanceCount = Math.floor(USER_COUNT * 2);
+    console.log(`🏅 Inserting ${issuanceCount} reward issuances…`);
+    const issuances = generateRewardIssuances(userIds, campaignIds, issuanceCount);
+    await batchInsert(client, 'reward_issuances',
+      ['idempotency_key', 'user_id', 'campaign_id', 'wallet_address', 'amount', 'status', 'tx_hash', 'error_message', 'attempts'],
+      issuances.map((r) => [r.idempotency_key, r.user_id, r.campaign_id, r.wallet_address, r.amount, r.status, r.tx_hash, r.error_message, r.attempts]),
+    );
+
+    await client.query('COMMIT');
+
+    const elapsed = ((Date.now() - t0) / 1000).toFixed(2);
+    console.log(`\n✅ Seed complete in ${elapsed}s`);
+    console.log(`   Merchants:        ${merchantIds.length}`);
+    console.log(`   Campaigns:        ${campaignIds.length}`);
+    console.log(`   Users:            ${userIds.length}`);
+    console.log(`   Wallets:          ${wallets.length}`);
+    console.log(`   Transactions:     ${transactions.length}`);
+    console.log(`   Reward issuances: ${issuances.length}`);
+    console.log(`   Rewards:          ${rewards.length}`);
+    console.log('');
+    console.log('Merchant API keys (for manual testing):');
+    merchantData.forEach((m, i) => console.log(`  [${i + 1}] ${m._api_key}`));
+    console.log('');
+  } catch (err) {
+    await client.query('ROLLBACK');
+    console.error('❌ Seed failed:', err.message);
+    process.exit(1);
+  } finally {
+    client.release();
+    await pool.end();
+  }
+}
+
+seed();

--- a/novaRewards/backend/tests/fixtures/factories.js
+++ b/novaRewards/backend/tests/fixtures/factories.js
@@ -1,29 +1,35 @@
 /**
- * Test Data Factories — Nova Rewards
+ * Test Data Factories — Nova Rewards Backend
  *
- * Uses fishery (https://github.com/thoughtbot/fishery) with @faker-js/faker.
- * Factories match Prisma model shapes and pass all validation rules.
+ * Uses fishery + @faker-js/faker. Shapes match the PostgreSQL schema.
  *
  * Usage:
- *   import { merchantFactory, campaignFactory, userFactory, rewardIssuanceFactory } from './factories';
+ *   const { userFactory, campaignFactory, transactionFactory,
+ *           rewardFactory, walletFactory, rewardIssuanceFactory,
+ *           merchantFactory } = require('./factories');
  *
- *   const merchant  = merchantFactory.build();
- *   const campaign  = campaignFactory.build({ merchant_id: merchant.id });
- *   const expired   = campaignFactory.build(campaignFactory.params.expired());
- *   const adminUser = userFactory.build(userFactory.params.admin());
+ *   const user     = userFactory.build();
+ *   const admin    = userFactory.build(userFactory.params.admin());
+ *   const expired  = campaignFactory.build(campaignFactory.params.expired());
+ *   const batch    = transactionFactory.buildList(50);
  */
 
+'use strict';
+
 const { Factory } = require('fishery');
-const { faker } = require('@faker-js/faker');
+const { faker }   = require('@faker-js/faker');
 
 // ── Helpers ───────────────────────────────────────────────────────────────
 
-/** Generate a valid Stellar public key (G + 55 uppercase alphanumeric chars) */
+/** Valid Stellar public key: G + 55 uppercase alphanumeric chars */
 const stellarAddress = () =>
   'G' + faker.string.alphanumeric({ length: 55, casing: 'upper' });
 
-/** ISO date string (YYYY-MM-DD) */
+/** YYYY-MM-DD string */
 const isoDate = (d) => d.toISOString().split('T')[0];
+
+const daysAgo  = (n) => new Date(Date.now() - n * 86_400_000);
+const daysAhead = (n) => new Date(Date.now() + n * 86_400_000);
 
 // ── Merchant ──────────────────────────────────────────────────────────────
 
@@ -32,87 +38,153 @@ const merchantFactory = Factory.define(({ sequence }) => ({
   name: faker.company.name(),
   wallet_address: stellarAddress(),
   business_category: faker.helpers.arrayElement([
-    'food_and_beverage',
-    'retail',
-    'entertainment',
-    'travel',
-    'health_and_wellness',
+    'food_and_beverage', 'retail', 'entertainment', 'travel', 'health_and_wellness',
   ]),
   api_key: faker.string.alphanumeric({ length: 64, casing: 'lower' }),
+  is_active: true,
   created_at: faker.date.recent({ days: 90 }),
 }));
-
-// ── Campaign ──────────────────────────────────────────────────────────────
-
-const campaignFactory = Factory.define(({ sequence, params }) => {
-  const now = new Date();
-  const start = params.start_date ?? isoDate(faker.date.recent({ days: 30 }));
-  const end   = params.end_date   ?? isoDate(faker.date.soon({ days: 60 }));
-
-  return {
-    id: sequence,
-    merchant_id: params.merchant_id ?? faker.number.int({ min: 1, max: 100 }),
-    name: faker.commerce.productName() + ' Rewards',
-    reward_rate: parseFloat(faker.number.float({ min: 0.01, max: 0.1, fractionDigits: 7 })),
-    start_date: start,
-    end_date: end,
-    is_active: params.is_active ?? true,
-    created_at: faker.date.recent({ days: 90 }),
-  };
-});
-
-/** Trait: campaign whose end_date is in the past */
-campaignFactory.params.expired = () => ({
-  start_date: isoDate(new Date(Date.now() - 60 * 86400_000)),
-  end_date:   isoDate(new Date(Date.now() - 1  * 86400_000)),
-  is_active:  false,
-});
-
-/** Trait: campaign with a very low reward_rate (simulates depleted budget) */
-campaignFactory.params.depletedBudget = () => ({
-  reward_rate: 0.0000001,
-});
 
 // ── User ──────────────────────────────────────────────────────────────────
 
 const userFactory = Factory.define(({ sequence }) => ({
   id: sequence,
   email: faker.internet.email(),
-  name: faker.person.fullName(),
+  first_name: faker.person.firstName(),
+  last_name: faker.person.lastName(),
   wallet_address: stellarAddress(),
+  stellar_public_key: stellarAddress(),
   referral_code: faker.string.alphanumeric({ length: 8, casing: 'upper' }),
   referred_by: null,
   balance: faker.number.int({ min: 0, max: 10_000 }),
+  role: 'user',
   is_admin: false,
+  is_deleted: false,
   created_at: faker.date.recent({ days: 180 }),
 }));
 
-/** Trait: admin user */
-userFactory.params.admin = () => ({ is_admin: true });
+userFactory.params.admin    = () => ({ role: 'admin',    is_admin: true });
+userFactory.params.merchant = () => ({ role: 'merchant', is_admin: false });
+userFactory.params.deleted  = () => ({ is_deleted: true, deleted_at: faker.date.recent({ days: 7 }) });
+
+// ── Campaign ──────────────────────────────────────────────────────────────
+
+const campaignFactory = Factory.define(({ sequence, params }) => {
+  const start = params.start_date ?? isoDate(faker.date.recent({ days: 30 }));
+  const end   = params.end_date   ?? isoDate(daysAhead(faker.number.int({ min: 7, max: 90 })));
+
+  return {
+    id: sequence,
+    merchant_id: params.merchant_id ?? faker.number.int({ min: 1, max: 100 }),
+    name: `${faker.commerce.productName()} Rewards`,
+    reward_rate: parseFloat(faker.number.float({ min: 0.01, max: 0.1, fractionDigits: 7 })),
+    start_date: start,
+    end_date: end,
+    is_active: params.is_active ?? true,
+    on_chain_status: params.on_chain_status ?? 'confirmed',
+    contract_campaign_id: faker.string.hexadecimal({ length: 64, casing: 'lower' }),
+    created_at: faker.date.recent({ days: 90 }),
+  };
+});
+
+campaignFactory.params.expired       = () => ({
+  start_date: isoDate(daysAgo(60)),
+  end_date:   isoDate(daysAgo(1)),
+  is_active:  false,
+});
+campaignFactory.params.pending       = () => ({ on_chain_status: 'pending' });
+campaignFactory.params.depletedBudget = () => ({ reward_rate: 0.0000001 });
+
+// ── Transaction ───────────────────────────────────────────────────────────
+
+const transactionFactory = Factory.define(({ sequence, params }) => ({
+  id: sequence,
+  tx_hash: faker.string.hexadecimal({ length: 64, casing: 'lower' }).replace('0x', ''),
+  tx_type: params.tx_type ?? faker.helpers.arrayElement(['distribution', 'redemption', 'transfer']),
+  amount: parseFloat(faker.number.float({ min: 0.1, max: 1_000, fractionDigits: 7 })),
+  from_wallet: params.from_wallet ?? stellarAddress(),
+  to_wallet:   params.to_wallet   ?? stellarAddress(),
+  merchant_id: params.merchant_id ?? faker.number.int({ min: 1, max: 100 }),
+  campaign_id: params.campaign_id ?? faker.number.int({ min: 1, max: 100 }),
+  stellar_ledger: faker.number.int({ min: 1_000_000, max: 50_000_000 }),
+  status: params.status ?? 'confirmed',
+  created_at: faker.date.recent({ days: 30 }),
+}));
+
+transactionFactory.params.distribution = () => ({ tx_type: 'distribution' });
+transactionFactory.params.redemption   = () => ({ tx_type: 'redemption' });
+transactionFactory.params.transfer     = () => ({ tx_type: 'transfer' });
+transactionFactory.params.pending      = () => ({ status: 'pending' });
+transactionFactory.params.failed       = () => ({ status: 'failed' });
+
+// ── Reward ────────────────────────────────────────────────────────────────
+
+const rewardFactory = Factory.define(({ sequence }) => ({
+  id: sequence,
+  name: faker.commerce.productName(),
+  description: faker.commerce.productDescription(),
+  cost: faker.number.int({ min: 10, max: 5_000 }),
+  stock: faker.number.int({ min: 0, max: 500 }),
+  is_active: true,
+  is_deleted: false,
+  created_at: faker.date.recent({ days: 60 }),
+}));
+
+rewardFactory.params.outOfStock = () => ({ stock: 0 });
+rewardFactory.params.inactive   = () => ({ is_active: false });
+
+// ── Wallet ────────────────────────────────────────────────────────────────
+
+const walletFactory = Factory.define(({ sequence, params }) => ({
+  id: sequence,
+  user_id: params.user_id ?? faker.number.int({ min: 1, max: 1_000 }),
+  address: stellarAddress(),
+  is_primary: params.is_primary ?? false,
+  is_active: true,
+  created_at: faker.date.recent({ days: 90 }),
+}));
+
+walletFactory.params.primary  = () => ({ is_primary: true });
+walletFactory.params.inactive = () => ({ is_active: false });
 
 // ── RewardIssuance ────────────────────────────────────────────────────────
 
-const rewardIssuanceFactory = Factory.define(({ sequence }) => ({
+const rewardIssuanceFactory = Factory.define(({ sequence, params }) => ({
   id: sequence,
-  user_id:     faker.number.int({ min: 1, max: 1000 }),
-  campaign_id: faker.number.int({ min: 1, max: 100 }),
-  amount:      parseFloat(faker.number.float({ min: 0.1, max: 500, fractionDigits: 7 })),
-  tx_hash:     faker.string.hexadecimal({ length: 64, casing: 'lower' }),
-  status:      faker.helpers.arrayElement(['pending', 'confirmed', 'failed']),
-  created_at:  faker.date.recent({ days: 30 }),
+  idempotency_key: faker.string.uuid(),
+  user_id: params.user_id ?? faker.number.int({ min: 1, max: 1_000 }),
+  campaign_id: params.campaign_id ?? faker.number.int({ min: 1, max: 100 }),
+  wallet_address: stellarAddress(),
+  amount: parseFloat(faker.number.float({ min: 0.1, max: 500, fractionDigits: 7 })),
+  status: params.status ?? faker.helpers.arrayElement(['pending', 'confirmed', 'failed']),
+  tx_hash: faker.string.hexadecimal({ length: 64, casing: 'lower' }).replace('0x', ''),
+  error_message: null,
+  attempts: faker.number.int({ min: 0, max: 3 }),
+  created_at: faker.date.recent({ days: 30 }),
+  updated_at: faker.date.recent({ days: 1 }),
 }));
 
-/** Trait: confirmed on-chain issuance */
 rewardIssuanceFactory.params.confirmed = () => ({ status: 'confirmed' });
-
-/** Trait: failed issuance */
-rewardIssuanceFactory.params.failed = () => ({ status: 'failed', tx_hash: null });
+rewardIssuanceFactory.params.failed    = () => ({
+  status: 'failed',
+  tx_hash: null,
+  error_message: faker.helpers.arrayElement([
+    'Insufficient balance',
+    'Trustline not established',
+    'Network timeout',
+  ]),
+  attempts: 3,
+});
+rewardIssuanceFactory.params.pending = () => ({ status: 'pending', tx_hash: null, attempts: 0 });
 
 // ── Exports ───────────────────────────────────────────────────────────────
 
 module.exports = {
   merchantFactory,
-  campaignFactory,
   userFactory,
+  campaignFactory,
+  transactionFactory,
+  rewardFactory,
+  walletFactory,
   rewardIssuanceFactory,
 };

--- a/novaRewards/frontend/__tests__/factories/index.ts
+++ b/novaRewards/frontend/__tests__/factories/index.ts
@@ -1,0 +1,155 @@
+/**
+ * Test Data Factories — Nova Rewards Frontend
+ *
+ * Matches the domain types in frontend/types/index.ts.
+ * Uses @faker-js/faker directly (no fishery dependency in frontend).
+ *
+ * Usage:
+ *   import { buildUser, buildCampaign, buildTransaction,
+ *            buildReward, buildWallet, buildRedemption } from '../__tests__/factories';
+ *
+ *   const user        = buildUser();
+ *   const admin       = buildUser({ role: 'admin' });
+ *   const expired     = buildCampaign({ endDate: '2020-01-01' });
+ *   const txList      = Array.from({ length: 10 }, buildTransaction);
+ */
+
+import { faker } from '@faker-js/faker';
+import type {
+  User,
+  Campaign,
+  Transaction,
+  Reward,
+  Redemption,
+} from '../../types/index';
+
+// ── Helpers ───────────────────────────────────────────────────────────────
+
+const stellarAddress = (): string =>
+  'G' + faker.string.alphanumeric({ length: 55, casing: 'upper' });
+
+const isoDate = (d: Date): string => d.toISOString().split('T')[0];
+
+const daysAgo   = (n: number) => new Date(Date.now() - n * 86_400_000);
+const daysAhead = (n: number) => new Date(Date.now() + n * 86_400_000);
+
+// ── User ──────────────────────────────────────────────────────────────────
+
+export const buildUser = (overrides: Partial<User> = {}): User => ({
+  id: faker.number.int({ min: 1, max: 100_000 }),
+  walletAddress: stellarAddress(),
+  email: faker.internet.email(),
+  firstName: faker.person.firstName(),
+  lastName: faker.person.lastName(),
+  role: 'user',
+  createdAt: faker.date.recent({ days: 180 }).toISOString(),
+  ...overrides,
+});
+
+export const buildAdminUser    = (overrides: Partial<User> = {}) => buildUser({ role: 'admin',    ...overrides });
+export const buildMerchantUser = (overrides: Partial<User> = {}) => buildUser({ role: 'merchant', ...overrides });
+
+// ── Campaign ──────────────────────────────────────────────────────────────
+
+export const buildCampaign = (overrides: Partial<Campaign> = {}): Campaign => ({
+  id: faker.number.int({ min: 1, max: 10_000 }),
+  merchantId: faker.number.int({ min: 1, max: 1_000 }),
+  name: `${faker.commerce.productName()} Rewards`,
+  rewardRate: parseFloat(faker.number.float({ min: 0.01, max: 0.1, fractionDigits: 4 })),
+  startDate: isoDate(faker.date.recent({ days: 30 })),
+  endDate: isoDate(daysAhead(faker.number.int({ min: 7, max: 90 }))),
+  onChainStatus: 'confirmed',
+  contractCampaignId: faker.string.hexadecimal({ length: 64, casing: 'lower' }).replace('0x', ''),
+  createdAt: faker.date.recent({ days: 90 }).toISOString(),
+  ...overrides,
+});
+
+export const buildExpiredCampaign = (overrides: Partial<Campaign> = {}) =>
+  buildCampaign({
+    startDate: isoDate(daysAgo(60)),
+    endDate:   isoDate(daysAgo(1)),
+    onChainStatus: 'confirmed',
+    ...overrides,
+  });
+
+export const buildPendingCampaign = (overrides: Partial<Campaign> = {}) =>
+  buildCampaign({ onChainStatus: 'pending', contractCampaignId: undefined, ...overrides });
+
+// ── Transaction ───────────────────────────────────────────────────────────
+
+export const buildTransaction = (overrides: Partial<Transaction> = {}): Transaction => ({
+  id: faker.number.int({ min: 1, max: 1_000_000 }),
+  txHash: faker.string.hexadecimal({ length: 64, casing: 'lower' }).replace('0x', ''),
+  txType: faker.helpers.arrayElement(['distribution', 'redemption', 'transfer'] as const),
+  amount: parseFloat(faker.number.float({ min: 0.1, max: 1_000, fractionDigits: 7 })),
+  fromWallet: stellarAddress(),
+  toWallet: stellarAddress(),
+  status: 'confirmed',
+  createdAt: faker.date.recent({ days: 30 }).toISOString(),
+  ...overrides,
+});
+
+export const buildPendingTransaction = (overrides: Partial<Transaction> = {}) =>
+  buildTransaction({ status: 'pending', ...overrides });
+
+export const buildFailedTransaction = (overrides: Partial<Transaction> = {}) =>
+  buildTransaction({ status: 'failed', ...overrides });
+
+// ── Reward ────────────────────────────────────────────────────────────────
+
+export const buildReward = (overrides: Partial<Reward> = {}): Reward => ({
+  id: faker.number.int({ min: 1, max: 10_000 }),
+  name: faker.commerce.productName(),
+  description: faker.commerce.productDescription(),
+  pointsCost: faker.number.int({ min: 10, max: 5_000 }),
+  stock: faker.number.int({ min: 1, max: 500 }),
+  isActive: true,
+  ...overrides,
+});
+
+export const buildOutOfStockReward = (overrides: Partial<Reward> = {}) =>
+  buildReward({ stock: 0, ...overrides });
+
+// ── Redemption ────────────────────────────────────────────────────────────
+
+export const buildRedemption = (overrides: Partial<Redemption> = {}): Redemption => ({
+  id: faker.number.int({ min: 1, max: 100_000 }),
+  userId: faker.number.int({ min: 1, max: 10_000 }),
+  rewardId: faker.number.int({ min: 1, max: 1_000 }),
+  campaignId: faker.number.int({ min: 1, max: 100 }),
+  pointsSpent: faker.number.int({ min: 10, max: 5_000 }),
+  createdAt: faker.date.recent({ days: 30 }).toISOString(),
+  ...overrides,
+});
+
+// ── Wallet (frontend shape) ───────────────────────────────────────────────
+
+export interface WalletData {
+  id: number;
+  userId: number;
+  address: string;
+  isPrimary: boolean;
+  isActive: boolean;
+  createdAt: string;
+}
+
+export const buildWallet = (overrides: Partial<WalletData> = {}): WalletData => ({
+  id: faker.number.int({ min: 1, max: 100_000 }),
+  userId: faker.number.int({ min: 1, max: 10_000 }),
+  address: stellarAddress(),
+  isPrimary: false,
+  isActive: true,
+  createdAt: faker.date.recent({ days: 90 }).toISOString(),
+  ...overrides,
+});
+
+export const buildPrimaryWallet = (overrides: Partial<WalletData> = {}) =>
+  buildWallet({ isPrimary: true, ...overrides });
+
+// ── List helpers ──────────────────────────────────────────────────────────
+
+export const buildList = <T>(
+  builder: (overrides?: Partial<T>) => T,
+  count: number,
+  overrides: Partial<T> = {},
+): T[] => Array.from({ length: count }, () => builder(overrides));


### PR DESCRIPTION
feat: add test data generators for users, campaigns, transactions, rewards, and
  wallets
  
  Summary
  
  Adds comprehensive test data factories and a bulk seed script to support unit,
  integration, and load testing.
  
  Changes
  
  novaRewards/backend/tests/fixtures/factories.js (updated)
  Expanded using fishery + @faker-js/faker. Covers all core entities with
  realistic data and traits:
  
  - userFactory — regular, admin, merchant, deleted
  - campaignFactory — active, expired, pending on-chain, depleted budget
  - transactionFactory — distribution, redemption, transfer, pending, failed
  - rewardFactory — active, out-of-stock, inactive
  - walletFactory — primary, inactive
  - rewardIssuanceFactory — confirmed, pending, failed (with error messages)
  - merchantFactory — active merchants with valid Stellar addresses
  
  novaRewards/frontend/__tests__/factories/index.ts (new)
  TypeScript factories matching frontend/types/index.ts. Plain builder functions
  with partial overrides and convenience variants (buildAdminUser,
  buildExpiredCampaign, buildFailedTransaction, etc.). Includes a generic
  buildList(builder, count) helper.
  
  novaRewards/backend/scripts/seed-test-data.js (new)
  Bulk seed script for local dev and load testing. Accepts --count, --env, and
  --clean flags.
  
  Performance optimisations:
  
  - Batched multi-row INSERT statements (200 rows/batch) — one DB round-trip per
  batch
  - Single wrapping transaction for atomicity
  - Inserts in dependency order; IDs fetched once per group to avoid N+1 queries
  
  Default output for --count=500: ~10 merchants, ~30 campaigns, 500 users, ~750
  wallets, 2 500 transactions, 1 000 reward issuances, 20 rewards.
  
  Testing
  
  # Run existing factory smoke tests
  cd novaRewards && npm run test:backend -- --testPathPattern=factories
closes #411