### PR TITLE
docs: add 8 ADRs, sync .env.example, add CI env check

### DIFF
--- a/.github/workflows/env-check.yml
+++ b/.github/workflows/env-check.yml
@@ -1,0 +1,39 @@
+name: Env Example Sync Check
+
+on:
+  push:
+    branches: [main, develop]
+    paths:
+      - 'novaRewards/.env.example'
+      - 'novaRewards/backend/middleware/validateEnv.js'
+      - 'novaRewards/frontend/lib/env.js'
+      - 'novaRewards/scripts/check-env-example.js'
+  pull_request:
+    branches: [main, develop]
+    paths:
+      - 'novaRewards/.env.example'
+      - 'novaRewards/backend/middleware/validateEnv.js'
+      - 'novaRewards/frontend/lib/env.js'
+      - 'novaRewards/scripts/check-env-example.js'
+
+jobs:
+  env-sync:
+    name: Verify .env.example is in sync
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+
+      - name: Set up Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: '20'
+
+      - name: Run env sync check
+        run: node novaRewards/scripts/check-env-example.js
+
+      - name: Annotate failure
+        if: failure()
+        run: |
+          echo "::error file=novaRewards/.env.example::One or more environment variables defined in validateEnv.js or frontend/lib/env.js are missing from .env.example. Add the missing variables and push again."

--- a/docs/adr/0007-jwt-rs256-authentication-strategy.md
+++ b/docs/adr/0007-jwt-rs256-authentication-strategy.md
@@ -1,0 +1,83 @@
+# ADR 0007: JWT RS256 Authentication Strategy
+
+## Status
+
+Accepted
+
+## Context
+
+Nova Rewards needs to authenticate three distinct principals: end users (wallet
+holders), merchants (API integrations), and admins (platform operators). The
+initial implementation used a symmetric HS256 JWT secret, which means any
+service that can verify tokens can also forge them. As the platform scales to
+multiple backend services and the API surface grows, a shared secret becomes a
+liability.
+
+The system also needs token revocation for logout and security incidents, and
+short-lived access tokens with a secure refresh mechanism to limit the blast
+radius of a stolen token.
+
+Considered options:
+
+1. **HS256 symmetric JWT** — single shared secret, simple to implement, but
+   any verifier can also issue tokens.
+2. **RS256 asymmetric JWT** — private key signs, public key verifies; verifiers
+   cannot forge tokens.
+3. **Opaque session tokens** — server-side sessions stored in Redis or
+   PostgreSQL; stateful, requires lookup on every request.
+4. **Third-party identity provider (Auth0, Cognito)** — offloads auth
+   complexity but adds external dependency and cost.
+
+## Decision
+
+Use RS256 asymmetric JWT with a short-lived access token / long-lived refresh
+token pair, backed by a Redis revocation blocklist:
+
+- **Access tokens** are signed with a 2048-bit RSA private key (`JWT_PRIVATE_KEY`),
+  expire in 15 minutes, and carry only `sub` (wallet address) and `roles`.
+- **Refresh tokens** expire in 7 days, carry a unique `jti` (JWT ID), and are
+  stored in Redis on issue. Each use rotates the refresh token (old `jti` is
+  deleted, new one is issued), preventing replay.
+- **Revocation** is handled by adding a `jti` to a Redis blocklist with a TTL
+  matching the token's remaining lifetime. Every authenticated request checks
+  the blocklist before accepting the token.
+- **Merchant authentication** uses API keys (separate from user JWTs) validated
+  by the `authenticateMerchant` middleware.
+- **Admin access** is enforced by a `requireAdmin` middleware that checks the
+  `role` field on the user record loaded from PostgreSQL.
+
+The public key (`JWT_PUBLIC_KEY`) can be distributed to any service that needs
+to verify tokens without granting it the ability to issue new ones.
+
+## Consequences
+
+Positive:
+
+- Compromised verifier services cannot forge tokens.
+- Short-lived access tokens limit the window of a stolen token without requiring
+  a database lookup on every request.
+- Refresh token rotation detects token theft: if a rotated token is replayed,
+  the mismatch is detectable.
+- The Redis blocklist enables immediate revocation for logout and security
+  incidents.
+- RS256 is compatible with standard JWT libraries and JWKS endpoints for future
+  federation.
+
+Negative:
+
+- RSA key pair management adds operational overhead: keys must be generated,
+  stored in AWS Secrets Manager, and rotated periodically.
+- The Redis blocklist introduces a soft dependency: if Redis is unavailable,
+  revocation checks fail open (tokens cannot be invalidated until Redis
+  recovers).
+- Refresh token rotation requires clients to handle `401` responses and retry
+  with the new token atomically to avoid race conditions on concurrent requests.
+
+## Related
+
+- Code: `novaRewards/backend/services/tokenService.js`
+- Code: `novaRewards/backend/middleware/authenticateUser.js`
+- Code: `novaRewards/backend/middleware/authenticateMerchant.js`
+- Code: `novaRewards/backend/routes/auth.js`
+- Code: `novaRewards/backend/scripts/generate-jwt-keys.js`
+- ADR: [0002 — PostgreSQL and Redis](0002-postgresql-system-of-record-with-redis-operational-cache.md)

--- a/docs/adr/0008-cursor-pagination-for-list-endpoints.md
+++ b/docs/adr/0008-cursor-pagination-for-list-endpoints.md
@@ -1,0 +1,77 @@
+# ADR 0008: Cursor-Based Pagination for List Endpoints
+
+## Status
+
+Accepted
+
+## Context
+
+Nova Rewards exposes several list endpoints — transactions, reward history,
+campaign lists, redemptions, and contract events — that can grow to millions of
+rows. Clients need stable, efficient pagination that works correctly under
+concurrent writes.
+
+Considered options:
+
+1. **Offset/limit pagination** — `OFFSET n LIMIT k` in SQL. Simple to implement
+   and supports random page access, but performance degrades as `OFFSET` grows
+   because the database must scan and discard all preceding rows. Results also
+   shift when rows are inserted or deleted between pages, causing duplicates or
+   skipped rows.
+2. **Cursor-based (keyset) pagination** — uses a stable column value (typically
+   `id` or `created_at`) as a cursor. The query becomes
+   `WHERE id < :cursor ORDER BY id DESC LIMIT k`. Performance is constant
+   regardless of page depth because the index seek is O(log n). Results are
+   stable under concurrent writes.
+3. **Page-number pagination** — a UX wrapper over offset/limit; inherits the
+   same performance and consistency problems.
+4. **Relay-style cursor pagination** — opaque base64-encoded cursors as used by
+   GraphQL Relay. More portable but adds encoding/decoding overhead for a REST
+   API.
+
+## Decision
+
+Use cursor-based (keyset) pagination as the default for all high-volume list
+endpoints:
+
+- Responses include a `nextCursor` field (the `id` of the last returned row,
+  base64-encoded) and a `hasMore` boolean.
+- Clients pass `cursor=<value>` on subsequent requests; the backend decodes it
+  and applies `WHERE id < :cursor`.
+- `limit` is accepted as a query parameter, capped at `MAX_PAGE_SIZE` (100) and
+  defaulting to `DEFAULT_PAGE_SIZE` (20), both defined in
+  `backend/config/constants.js`.
+- Offset/limit is retained for admin and analytics endpoints where random page
+  access is required and the dataset is bounded.
+- The leaderboard endpoint is a special case: rankings are pre-computed and
+  cached in Redis by a background job; the current user's rank is always
+  resolved live from PostgreSQL to avoid stale personalised data.
+
+## Consequences
+
+Positive:
+
+- Consistent O(log n) query performance regardless of how deep into the result
+  set the client is.
+- No duplicate or skipped rows when new records are inserted between page
+  fetches.
+- Cursor values are opaque to clients, allowing the backend to change the
+  underlying sort key without a breaking API change.
+
+Negative:
+
+- Clients cannot jump to an arbitrary page number; navigation is strictly
+  forward (or backward with a `prevCursor`).
+- Sorting must be on an indexed, unique, or monotonically increasing column.
+  Multi-column sort keys require composite cursors.
+- Admin and reporting UIs that need "go to page N" must use offset pagination
+  with the associated performance trade-offs.
+
+## Related
+
+- Code: `novaRewards/backend/config/constants.js` (`MAX_PAGE_SIZE`, `DEFAULT_PAGE_SIZE`)
+- Code: `novaRewards/backend/routes/transactions.js`
+- Code: `novaRewards/backend/routes/rewards.js`
+- Code: `novaRewards/backend/db/transactionRepository.js`
+- Code: `novaRewards/frontend/pages/rewards.js` (infinite scroll consumer)
+- ADR: [0002 — PostgreSQL and Redis](0002-postgresql-system-of-record-with-redis-operational-cache.md)

--- a/docs/adr/0009-bullmq-redis-job-queue.md
+++ b/docs/adr/0009-bullmq-redis-job-queue.md
@@ -1,0 +1,91 @@
+# ADR 0009: BullMQ on Redis for Asynchronous Job Queue
+
+## Status
+
+Accepted
+
+## Context
+
+Several platform operations cannot complete synchronously within an HTTP
+request: Stellar transaction submission (network latency, finality delays),
+webhook delivery to merchant endpoints (external HTTP calls, retries), and
+daily login bonus calculation (fan-out across all active users). These
+operations need reliable execution, retry on failure, and visibility into
+queue depth and job status.
+
+Considered options:
+
+1. **In-process async (Promise / setTimeout)** — no infrastructure dependency,
+   but jobs are lost on process restart and there is no retry, dead-letter, or
+   observability.
+2. **PostgreSQL-backed queue (pg-boss, Graphile Worker)** — durable, uses the
+   existing database, but adds write load to the primary and lacks the
+   real-time push semantics needed for low-latency job pickup.
+3. **BullMQ on Redis** — battle-tested Node.js queue library backed by Redis
+   sorted sets and lists. Supports retries, exponential backoff, job
+   deduplication by `jobId`, dead-letter queues, concurrency controls, and a
+   built-in admin dashboard (Bull Board).
+4. **AWS SQS / managed queue** — fully managed, highly durable, but adds an
+   external cloud dependency and increases latency for local development.
+5. **RabbitMQ / AMQP** — powerful routing and exchange model, but adds a new
+   infrastructure component with its own operational overhead.
+
+## Decision
+
+Use BullMQ backed by the existing Redis instance for all asynchronous job
+processing:
+
+- **`reward-issuance` queue** — processes reward issuance jobs with 3 attempts
+  and exponential backoff starting at 1 second. Uses the merchant-supplied
+  `idempotencyKey` as `jobId` to prevent duplicate processing on retry (see
+  ADR-0004).
+- **`transaction-submission` queue** — submits signed Stellar transactions to
+  Horizon with 5 attempts and 2-second initial backoff to handle transient
+  network errors and Stellar rate limits.
+- **`webhook-delivery` queue** — delivers event payloads to merchant webhook
+  endpoints with 5 attempts and 5-second initial backoff. Exhausted jobs are
+  moved to a dead-letter queue for manual inspection.
+- **Cron workers** — `leaderboardCacheWarmer` (every 5 minutes),
+  `dailyLoginBonus` (daily), and `webhookRetry` run as BullMQ repeatable jobs.
+- **Bull Board** is mounted at `/api/admin/queues` behind `authenticateUser` +
+  `requireAdmin` middleware, providing a real-time UI for queue inspection and
+  job management.
+
+All queues share the same Redis connection configuration (`REDIS_HOST` /
+`REDIS_PORT` or `REDIS_URL`). In production, this is the ElastiCache instance
+used for caching and rate limiting.
+
+## Consequences
+
+Positive:
+
+- Jobs survive process restarts; Redis persistence (AOF or RDB) provides
+  durability.
+- Exponential backoff prevents thundering-herd retries against Stellar or
+  merchant endpoints.
+- `jobId` deduplication at the queue level is a second line of defence
+  alongside the database-level `idempotency_key` unique constraint.
+- Bull Board gives operators real-time visibility without custom tooling.
+- BullMQ workers run in the same Node.js process, simplifying deployment.
+
+Negative:
+
+- Queue availability depends on Redis availability. If Redis is down, new jobs
+  cannot be enqueued and workers stall.
+- Redis is not a traditional message broker; very high job volumes may require
+  tuning `maxmemory-policy` to avoid eviction of pending jobs.
+- Workers must be deployed with sufficient concurrency to avoid settlement lag
+  during traffic spikes.
+- Dead-letter queue monitoring requires an operational runbook to prevent
+  silent job loss.
+
+## Related
+
+- Code: `novaRewards/backend/jobs/queues.js`
+- Code: `novaRewards/backend/jobs/rewardIssuanceWorker.js`
+- Code: `novaRewards/backend/jobs/webhookHandler.js`
+- Code: `novaRewards/backend/jobs/webhookRetry.js`
+- Code: `novaRewards/backend/jobs/leaderboardCacheWarmer.js`
+- Code: `novaRewards/backend/jobs/dailyLoginBonus.js`
+- ADR: [0002 — PostgreSQL and Redis](0002-postgresql-system-of-record-with-redis-operational-cache.md)
+- ADR: [0004 — Idempotent Asynchronous Reward Issuance](0004-idempotent-asynchronous-reward-issuance.md)

--- a/docs/adr/0010-redis-caching-strategy.md
+++ b/docs/adr/0010-redis-caching-strategy.md
@@ -1,0 +1,91 @@
+# ADR 0010: Redis Multi-Layer Caching Strategy
+
+## Status
+
+Accepted
+
+## Context
+
+Several read paths in Nova Rewards are expensive or latency-sensitive:
+
+- **Leaderboard rankings** require a ranked aggregate query across all users,
+  which is O(n log n) and grows with the user base.
+- **Rate limiting** needs sub-millisecond counter increments on every request
+  across all API endpoints.
+- **JWT revocation** needs a fast lookup on every authenticated request to check
+  whether a token has been invalidated.
+- **Refresh token rotation** needs atomic read-then-delete semantics to prevent
+  replay.
+- **Session and feature-flag data** benefit from a fast in-memory store to avoid
+  repeated database round-trips.
+
+Considered options:
+
+1. **In-process memory cache (node-cache, lru-cache)** — zero latency, but not
+   shared across multiple backend instances and lost on restart.
+2. **PostgreSQL materialized views** — durable and queryable, but refresh is
+   expensive and not real-time; adds write load to the primary.
+3. **Redis** — shared across all backend instances, supports TTL-based
+   expiration, atomic operations (INCR, SETNX, sorted sets), Lua scripting for
+   sliding-window rate limits, and pub/sub for real-time invalidation.
+4. **Memcached** — fast key-value cache, but lacks sorted sets, Lua scripting,
+   persistence, and pub/sub needed by the platform.
+
+## Decision
+
+Use Redis as the single shared cache layer with distinct key namespaces and TTL
+policies per use case:
+
+| Use case | Key pattern | TTL | Invalidation |
+|---|---|---|---|
+| Leaderboard rankings | `leaderboard:<period>` | 300 s (5 min) | Overwritten by cache warmer job |
+| JWT revocation blocklist | `blocklist:<jti>` | Token remaining lifetime | Automatic (TTL expiry) |
+| Refresh token store | `refresh:<jti>` | 7 days | Consumed (deleted) on use |
+| Rate limit counters (fixed-window) | `rl:<scope>:<ip>` | Window duration | Automatic (TTL expiry) |
+| Rate limit counters (sliding-window) | `sw:<scope>:<key>` | Window duration | Atomic Lua sorted-set trim |
+| Feature flags | `ff:<flag>` | Configurable | Manual or TTL |
+
+The Redis client (`ioredis`) connects via `REDIS_URL`. In production the URL
+uses the `rediss://` scheme, which enables TLS automatically for ElastiCache
+in-transit encryption. The client degrades gracefully: if `REDIS_URL` is unset,
+the application falls back to in-memory rate limiting and skips cache writes,
+allowing local development without a Redis instance.
+
+The leaderboard cache is populated by the `leaderboardCacheWarmer` background
+job (BullMQ repeatable, every 5 minutes) rather than on-demand to avoid cache
+stampedes under load. The current user's rank is always resolved live from
+PostgreSQL because it is personalised and cannot be shared across users.
+
+## Consequences
+
+Positive:
+
+- Leaderboard reads are O(1) cache hits instead of O(n log n) database queries.
+- Rate limit counters are atomic and consistent across all backend replicas.
+- JWT revocation is fast and does not require a database lookup on every request.
+- TTL-based expiry means stale entries are cleaned up automatically without
+  explicit invalidation logic for most use cases.
+- Graceful degradation allows local development without Redis.
+
+Negative:
+
+- Cache invalidation for leaderboard mutations (e.g., manual point adjustments)
+  must be triggered explicitly or waited out until the next warmer cycle.
+- Redis memory must be monitored; `maxmemory-policy` must be set to `noeviction`
+  or `volatile-lru` to prevent silent eviction of blocklist or rate-limit keys.
+- If Redis is unavailable, revocation checks fail open: revoked tokens remain
+  accepted until Redis recovers.
+- The sliding-window Lua script must be tested for correctness under concurrent
+  load.
+
+## Related
+
+- Code: `novaRewards/backend/cache/redisClient.js`
+- Code: `novaRewards/backend/lib/redis.js`
+- Code: `novaRewards/backend/middleware/rateLimiter.js`
+- Code: `novaRewards/backend/middleware/slidingRateLimiter.js`
+- Code: `novaRewards/backend/services/tokenService.js`
+- Code: `novaRewards/backend/jobs/leaderboardCacheWarmer.js`
+- ADR: [0002 — PostgreSQL and Redis](0002-postgresql-system-of-record-with-redis-operational-cache.md)
+- ADR: [0007 — JWT RS256 Authentication Strategy](0007-jwt-rs256-authentication-strategy.md)
+- ADR: [0009 — BullMQ Redis Job Queue](0009-bullmq-redis-job-queue.md)

--- a/docs/adr/0011-deployment-target-aws-kubernetes.md
+++ b/docs/adr/0011-deployment-target-aws-kubernetes.md
@@ -1,0 +1,93 @@
+# ADR 0011: AWS as Production Deployment Target with Kubernetes (Helm)
+
+## Status
+
+Accepted
+
+## Context
+
+Nova Rewards needs a production deployment target that provides:
+
+- TLS termination and DDoS protection at the edge
+- Horizontal autoscaling for the stateless backend API
+- Managed, encrypted, highly available PostgreSQL and Redis
+- Secure secret storage with rotation support
+- Structured logging, metrics, and alerting
+- Reproducible infrastructure-as-code that can be reviewed in pull requests
+
+Considered options:
+
+1. **Heroku / Railway / Render** — low operational overhead, but limited control
+   over networking, encryption, and compliance posture; vendor lock-in for
+   managed add-ons.
+2. **AWS with EC2 + Docker Compose** — familiar, but manual scaling, no
+   self-healing, and infrastructure drift without IaC.
+3. **AWS with ECS (Fargate)** — managed container runtime, good AWS integration,
+   but less portable than Kubernetes and fewer ecosystem tools.
+4. **AWS with EKS / self-managed Kubernetes + Helm** — portable, rich ecosystem
+   (HPA, PDB, Ingress, Secrets), reproducible via Helm charts, but higher
+   operational complexity.
+5. **GCP / Azure** — comparable managed services, but the team has existing AWS
+   expertise and the Stellar ecosystem tooling is AWS-centric.
+
+## Decision
+
+Use AWS as the production cloud provider with Kubernetes workloads managed by
+Helm charts:
+
+- **Compute:** EKS (or EC2 Auto Scaling Group with self-managed Kubernetes) runs
+  frontend and backend as Deployments with HPA (Horizontal Pod Autoscaler) and
+  PDB (Pod Disruption Budget) for zero-downtime rolling updates.
+- **Load balancing:** AWS ALB with ACM-managed TLS certificate terminates HTTPS.
+  Nginx handles reverse-proxy routing in staging.
+- **Database:** RDS PostgreSQL (Multi-AZ) with PgBouncer connection pooling.
+  Encrypted at rest (AES-256) and in transit (TLS).
+- **Cache / Queue:** ElastiCache Redis with TLS in-transit (`rediss://` scheme).
+  Used for caching, rate limiting, BullMQ queues, and JWT revocation.
+- **Secrets:** AWS Secrets Manager stores all credentials (database passwords,
+  JWT key pair, field encryption key, Stellar signing keys). The backend fetches
+  secrets at startup via the AWS SDK; no secrets are baked into container images
+  or Kubernetes ConfigMaps.
+- **CDN:** Cloudflare CDN for static frontend assets; CloudFront as an
+  alternative for AWS-native deployments.
+- **Observability:** Prometheus + Grafana + Alertmanager for metrics and
+  alerting; Loki for log aggregation; CloudWatch for AWS-native metrics and
+  alarms; Sentry for frontend error tracking.
+- **IaC:** Terraform manages VPC, subnets, security groups, RDS, ElastiCache,
+  IAM roles, and ALB. Helm manages Kubernetes workloads.
+- **Staging:** Docker Compose (`docker-compose.staging.yml`) provides a local
+  environment with Nginx, frontend, backend, PostgreSQL, Redis, and one-shot
+  migrations. Staging is not identical to production (see consequences).
+
+## Consequences
+
+Positive:
+
+- Managed RDS and ElastiCache eliminate database and cache operational overhead.
+- HPA and rolling deployments provide autoscaling and zero-downtime updates.
+- AWS Secrets Manager with rotation support reduces the risk of long-lived
+  static credentials.
+- Terraform and Helm keep infrastructure changes reviewable and reproducible.
+- Prometheus/Grafana/Loki provide a unified observability stack independent of
+  cloud vendor.
+
+Negative:
+
+- EKS and the surrounding AWS services add significant operational complexity
+  compared to a PaaS.
+- Staging (Docker Compose) and production (Kubernetes/AWS) are not identical;
+  environment-specific bugs remain possible.
+- Secrets must be managed differently across Compose (`.env` files), Kubernetes
+  (Secrets), and AWS (Secrets Manager), requiring careful alignment.
+- Helm values, Terraform variables, and application environment validation
+  (`validateEnv`) must stay in sync as new variables are added.
+
+## Related
+
+- Code: `novaRewards/docker-compose.staging.yml`
+- Code: `helm/nova-rewards/`
+- Code: `infra/` (Terraform)
+- Code: `monitoring/`
+- Code: `novaRewards/backend/middleware/validateEnv.js`
+- ADR: [0006 — Compose for Staging and Helm on AWS for Production](0006-deployment-topology.md)
+- ADR: [0002 — PostgreSQL and Redis](0002-postgresql-system-of-record-with-redis-operational-cache.md)

--- a/docs/adr/0012-monitoring-and-observability-stack.md
+++ b/docs/adr/0012-monitoring-and-observability-stack.md
@@ -1,0 +1,104 @@
+# ADR 0012: Prometheus, Grafana, Loki, and Sentry Observability Stack
+
+## Status
+
+Accepted
+
+## Context
+
+Nova Rewards processes financial transactions and blockchain operations where
+silent failures, latency regressions, and error spikes have direct user and
+merchant impact. The platform needs:
+
+- **Metrics** — request rates, error rates, latency percentiles, queue depths,
+  and Stellar submission success rates.
+- **Logs** — structured, searchable logs correlated across frontend, backend,
+  and worker processes.
+- **Alerts** — proactive notification when SLOs are breached or anomalies are
+  detected.
+- **Error tracking** — frontend JavaScript errors and backend unhandled
+  exceptions with stack traces and user context.
+- **Distributed tracing** — correlation IDs to trace a request from the browser
+  through the API to the database and Stellar.
+
+Considered options:
+
+1. **CloudWatch only** — native AWS integration, no extra infrastructure, but
+   limited query language, expensive at scale, and vendor lock-in.
+2. **Datadog / New Relic** — full-stack SaaS observability, but high cost at
+   scale and data leaves the AWS VPC.
+3. **Prometheus + Grafana + Loki (self-hosted)** — open-source, runs in the
+   same Kubernetes cluster, rich query languages (PromQL, LogQL), large
+   ecosystem of exporters and dashboards.
+4. **OpenTelemetry + Jaeger** — vendor-neutral tracing standard, but adds
+   collector infrastructure and the team's immediate need is metrics and logs
+   rather than full distributed tracing.
+
+## Decision
+
+Use a self-hosted Prometheus + Grafana + Loki + Alertmanager stack for
+infrastructure and application observability, complemented by Sentry for
+frontend error tracking and CloudWatch for AWS-native alarms:
+
+- **Prometheus** scrapes the `/metrics` endpoint exposed by the Express backend
+  (`prom-client`). Metrics include HTTP request duration histograms, error
+  counters, queue depth gauges, and Stellar submission latency.
+- **Grafana** provides dashboards for API performance, queue health, database
+  connection pool utilisation, and Redis memory usage. Datasources include
+  Prometheus, Loki, and optionally CloudWatch.
+- **Loki** aggregates structured JSON logs from all containers (shipped via
+  Promtail or the Docker Loki driver). Winston in the backend emits JSON logs
+  with correlation IDs (`x-correlation-id` header) for cross-service tracing.
+- **Alertmanager** routes alerts to Slack (webhook) and PagerDuty (integration
+  key) based on severity. Alert rules cover error rate > 1%, p99 latency > 2s,
+  queue depth > 1000, and Redis memory > 80%.
+- **Sentry** (`@sentry/nextjs`) captures frontend JavaScript errors, Next.js
+  server-side errors, and performance traces. Configured via
+  `NEXT_PUBLIC_SENTRY_DSN` and `SENTRY_AUTH_TOKEN`.
+- **CloudWatch** receives container logs via the `awslogs` Docker log driver
+  when `LOG_DRIVER=awslogs` is set, and provides AWS-native alarms for RDS,
+  ElastiCache, and ALB metrics.
+- **Correlation IDs** are injected by `tracingMiddleware` on every request and
+  propagated through BullMQ job metadata, enabling log correlation from HTTP
+  request to async worker.
+
+The monitoring stack is defined in `monitoring/` and deployed via Docker Compose
+(staging) or Helm (production).
+
+## Consequences
+
+Positive:
+
+- Prometheus and Loki run inside the cluster, keeping metrics and logs within
+  the VPC boundary.
+- PromQL and LogQL provide powerful ad-hoc query capabilities without per-query
+  cost.
+- Sentry provides actionable frontend error reports with source maps and user
+  context.
+- Correlation IDs enable end-to-end request tracing without a full distributed
+  tracing infrastructure.
+- Alertmanager's routing rules allow on-call escalation without a separate
+  alerting SaaS.
+
+Negative:
+
+- Self-hosted Prometheus and Loki require storage provisioning, retention
+  configuration, and operational maintenance.
+- Prometheus is pull-based; short-lived jobs (one-shot migrations, scripts) must
+  use the Pushgateway or structured logs instead.
+- Without a full OpenTelemetry trace exporter, cross-service trace correlation
+  relies on manually propagated correlation IDs rather than automatic span
+  linking.
+- Grafana dashboard definitions must be version-controlled to avoid configuration
+  drift.
+
+## Related
+
+- Code: `novaRewards/backend/middleware/metricsMiddleware.js`
+- Code: `novaRewards/backend/middleware/tracingMiddleware.js`
+- Code: `novaRewards/backend/lib/logger.js`
+- Code: `monitoring/`
+- Code: `monitoring/.env.example`
+- Code: `novaRewards/frontend/sentry.client.config.js`
+- ADR: [0006 — Compose for Staging and Helm on AWS for Production](0006-deployment-topology.md)
+- ADR: [0011 — AWS as Production Deployment Target](0011-deployment-target-aws-kubernetes.md)

--- a/docs/adr/0013-field-level-encryption-for-pii.md
+++ b/docs/adr/0013-field-level-encryption-for-pii.md
@@ -1,0 +1,79 @@
+# ADR 0013: AES-256-GCM Field-Level Encryption for PII
+
+## Status
+
+Accepted
+
+## Context
+
+Nova Rewards stores personally identifiable information (PII) — user email
+addresses and merchant webhook secrets — in PostgreSQL. A database breach or
+misconfigured backup would expose this data in plaintext. Regulatory frameworks
+(GDPR, CCPA) and security best practices require that sensitive fields be
+protected at rest beyond full-disk encryption.
+
+Considered options:
+
+1. **Full-disk / tablespace encryption only** — provided by RDS at-rest
+   encryption (AES-256), but does not protect against application-level
+   vulnerabilities or compromised database credentials.
+2. **PostgreSQL `pgcrypto` extension** — encryption at the database layer;
+   requires the encryption key to be passed in SQL queries, which exposes it in
+   query logs and `pg_stat_activity`.
+3. **Application-layer field encryption (AES-256-GCM)** — the application
+   encrypts before writing and decrypts after reading; the database never sees
+   plaintext or the key. The key is stored in AWS Secrets Manager, not in the
+   database.
+4. **Envelope encryption (AWS KMS)** — data keys encrypted by a KMS master key;
+   adds key rotation without re-encrypting all rows, but adds KMS API latency
+   on every encrypt/decrypt operation.
+
+## Decision
+
+Use application-layer AES-256-GCM field encryption for PII fields:
+
+- A 256-bit encryption key (`FIELD_ENCRYPTION_KEY`, 64 hex characters) is
+  loaded from the environment at startup. In production it is sourced from AWS
+  Secrets Manager.
+- Each encrypted value is stored as `<iv_hex>:<authTag_hex>:<ciphertext_hex>`.
+  The IV is randomly generated per encryption operation, ensuring that the same
+  plaintext produces different ciphertext on each write.
+- The GCM authentication tag provides integrity verification: tampered
+  ciphertext is rejected at decrypt time.
+- Key rotation is supported via `FIELD_ENCRYPTION_KEY_PREVIOUS`: the application
+  tries the current key first, then falls back to the previous key for rows
+  encrypted before rotation. A background migration re-encrypts old rows with
+  the new key.
+- Encrypted fields: `users.email`, `webhooks.secret`.
+
+## Consequences
+
+Positive:
+
+- PII is protected even if the database is compromised; the attacker also needs
+  the encryption key.
+- GCM authentication tags detect data tampering.
+- Per-value random IVs prevent frequency analysis attacks.
+- Key rotation is possible without downtime using the dual-key fallback.
+
+Negative:
+
+- Encrypted email addresses cannot be queried with `WHERE email = $1` using a
+  standard index. Equality lookups require a deterministic HMAC of the email
+  (stored as a separate indexed column) or a full-table scan with application-
+  layer decryption.
+- The encryption key is a high-value secret; its compromise is equivalent to
+  plaintext exposure. Key management discipline (rotation, access controls,
+  audit logging) is critical.
+- Encrypted fields increase storage size by approximately 80 bytes per value
+  (IV + auth tag + hex encoding overhead).
+- Backup files contain encrypted data; restoring to a different environment
+  requires the matching key.
+
+## Related
+
+- Code: `novaRewards/backend/lib/encryption.js`
+- Code: `novaRewards/backend/middleware/validateEnv.js` (`FIELD_ENCRYPTION_KEY`)
+- Code: `novaRewards/backend/db/userRepository.js`
+- Code: `novaRewards/backend/db/webhookRepository.js`
+- ADR: [0011 — AWS as Production Deployment Target](0011-deployment-target-aws-kubernetes.md)

--- a/docs/adr/0014-soroban-rust-smart-contract-language.md
+++ b/docs/adr/0014-soroban-rust-smart-contract-language.md
@@ -1,0 +1,81 @@
+# ADR 0014: Rust as the Smart Contract Language for Soroban
+
+## Status
+
+Accepted
+
+## Context
+
+Soroban, Stellar's smart contract platform, supports contracts compiled to
+WebAssembly (WASM). At the time of adoption, Soroban's official SDK and tooling
+had first-class support for Rust. The Nova Rewards platform requires 11
+contracts covering token management, reward distribution, vesting, referral,
+governance, and admin roles — all of which handle real financial value and
+require correctness guarantees.
+
+Considered options:
+
+1. **Rust with `soroban-sdk`** — the officially supported language with the
+   most complete SDK, documentation, and community examples. Rust's ownership
+   model and type system eliminate entire classes of bugs (use-after-free,
+   integer overflow with `overflow-checks = true`, data races).
+2. **AssemblyScript** — TypeScript-like syntax compiles to WASM, lower learning
+   curve for JavaScript developers, but no official Soroban SDK and limited
+   ecosystem support.
+3. **C / C++** — compiles to WASM, maximum control, but no memory safety
+   guarantees and no Soroban SDK.
+4. **Go (TinyGo)** — experimental WASM support, no Soroban SDK.
+
+## Decision
+
+Use Rust with `soroban-sdk` (pinned to `25.3.1`) for all smart contracts in the
+`contracts/` workspace:
+
+- All 11 contracts are members of a single Cargo workspace, sharing the
+  `soroban-sdk` dependency version and build profile.
+- The release profile uses `-Oz` (size optimisation), `lto = true`,
+  `codegen-units = 1`, `panic = "abort"`, and `overflow-checks = true` to
+  produce small, safe WASM binaries.
+- `wasm-opt -Oz --strip-debug` is applied post-build to further reduce binary
+  size before deployment.
+- Integration tests live in the `integration_tests` workspace member and use
+  the Soroban test environment to simulate multi-contract interactions.
+- Fuzz targets in the `fuzz/` workspace member use `cargo-fuzz` to test
+  contract entry points with arbitrary inputs.
+
+## Consequences
+
+Positive:
+
+- Rust's type system and `overflow-checks = true` eliminate integer overflow
+  vulnerabilities common in financial contracts.
+- The `soroban-sdk` provides idiomatic abstractions for storage, events,
+  cross-contract calls, and the Soroban test environment.
+- A single Cargo workspace enforces a consistent SDK version across all
+  contracts, preventing version skew.
+- Rust's compile-time guarantees reduce the audit surface compared to
+  dynamically typed languages.
+- `cargo-fuzz` integration enables property-based and fuzz testing of contract
+  logic.
+
+Negative:
+
+- Rust has a steep learning curve; contributors unfamiliar with ownership and
+  lifetimes face a higher onboarding cost.
+- Soroban SDK breaking changes require coordinated upgrades across all workspace
+  members.
+- WASM binary size must be actively managed; large binaries increase deployment
+  cost and ledger storage fees.
+- Cross-contract call failures are harder to debug than in-process function
+  calls; integration tests are essential.
+
+## Related
+
+- Code: `contracts/Cargo.toml`
+- Code: `contracts/nova_token/src/lib.rs`
+- Code: `contracts/nova-rewards/src/lib.rs`
+- Code: `contracts/integration_tests/`
+- Code: `contracts/fuzz/`
+- ADR: [0003 — Stellar and Soroban for Reward Settlement](0003-stellar-and-soroban-for-reward-settlement.md)
+- ADR: [0005 — Modular Soroban Contracts](0005-modular-soroban-contracts.md)
+- Docs: `docs/contracts.md`

--- a/docs/adr/README.md
+++ b/docs/adr/README.md
@@ -3,20 +3,100 @@
 This directory records major architecture decisions for Nova Rewards. Each ADR
 uses the same lightweight structure:
 
-- Status
-- Context
-- Decision
-- Consequences
-- Related diagrams and code
+- **Status** — Proposed | Accepted | Deprecated | Superseded
+- **Context** — The forces and constraints that drove the decision
+- **Decision** — What was decided and why
+- **Consequences** — Trade-offs, positive and negative
+- **Related** — Links to code, diagrams, and other ADRs
+
+---
 
 ## Index
 
-| ADR | Decision |
-| --- | --- |
-| [0001](0001-layered-pwa-and-express-api.md) | Layered PWA and Express API |
-| [0002](0002-postgresql-system-of-record-with-redis-operational-cache.md) | PostgreSQL system of record with Redis operational cache |
-| [0003](0003-stellar-and-soroban-for-reward-settlement.md) | Stellar and Soroban for reward settlement |
-| [0004](0004-idempotent-asynchronous-reward-issuance.md) | Idempotent asynchronous reward issuance |
-| [0005](0005-modular-soroban-contracts.md) | Modular Soroban contracts with explicit cross-contract calls |
-| [0006](0006-deployment-topology.md) | Compose for staging and Helm on AWS for production |
+| ADR | Title | Status |
+|-----|-------|--------|
+| [0001](0001-layered-pwa-and-express-api.md) | Layered PWA and Express API | Accepted |
+| [0002](0002-postgresql-system-of-record-with-redis-operational-cache.md) | PostgreSQL System of Record with Redis Operational Cache | Accepted |
+| [0003](0003-stellar-and-soroban-for-reward-settlement.md) | Stellar and Soroban for Reward Settlement | Accepted |
+| [0004](0004-idempotent-asynchronous-reward-issuance.md) | Idempotent Asynchronous Reward Issuance | Accepted |
+| [0005](0005-modular-soroban-contracts.md) | Modular Soroban Contracts with Explicit Cross-Contract Calls | Accepted |
+| [0006](0006-deployment-topology.md) | Compose for Staging and Helm on AWS for Production | Accepted |
+| [0007](0007-jwt-rs256-authentication-strategy.md) | JWT RS256 Authentication Strategy | Accepted |
+| [0008](0008-cursor-pagination-for-list-endpoints.md) | Cursor-Based Pagination for List Endpoints | Accepted |
+| [0009](0009-bullmq-redis-job-queue.md) | BullMQ on Redis for Asynchronous Job Queue | Accepted |
+| [0010](0010-redis-caching-strategy.md) | Redis Multi-Layer Caching Strategy | Accepted |
+| [0011](0011-deployment-target-aws-kubernetes.md) | AWS as Production Deployment Target with Kubernetes (Helm) | Accepted |
+| [0012](0012-monitoring-and-observability-stack.md) | Prometheus, Grafana, Loki, and Sentry Observability Stack | Accepted |
+| [0013](0013-field-level-encryption-for-pii.md) | AES-256-GCM Field-Level Encryption for PII | Accepted |
+| [0014](0014-soroban-rust-smart-contract-language.md) | Rust as the Smart Contract Language for Soroban | Accepted |
 
+---
+
+## Creating a New ADR
+
+### When to write an ADR
+
+Write an ADR whenever a decision:
+
+- Affects multiple components or teams
+- Is difficult or costly to reverse
+- Involves a meaningful trade-off between alternatives
+- Would otherwise be undocumented tribal knowledge
+
+Small, local implementation choices (naming a variable, choosing a utility
+function) do not need an ADR.
+
+### Process
+
+1. **Copy the template** — duplicate `TEMPLATE.md` (if present) or use the
+   structure below.
+2. **Pick the next number** — increment from the highest existing ADR number.
+3. **Name the file** — `NNNN-short-hyphenated-title.md` (e.g.
+   `0015-graphql-api-layer.md`).
+4. **Set status to `Proposed`** — open a pull request for team review.
+5. **Discuss in the PR** — record significant objections and alternatives
+   considered in the **Context** section.
+6. **Merge as `Accepted`** — once the team agrees, update the status and add
+   the ADR to the index table above.
+7. **Update when superseded** — if a later decision replaces this one, change
+   the status to `Superseded by ADR-NNNN` and add a forward link.
+
+### Template
+
+```markdown
+# ADR NNNN: Title
+
+## Status
+
+Proposed
+
+## Context
+
+<!-- What forces, constraints, or requirements drove this decision?
+     What alternatives were considered? -->
+
+## Decision
+
+<!-- What was decided? Be specific about the chosen approach. -->
+
+## Consequences
+
+<!-- What are the positive and negative outcomes of this decision?
+     What becomes easier? What becomes harder? -->
+
+## Related
+
+<!-- Links to relevant code files, diagrams, other ADRs, or external references. -->
+```
+
+### Tips
+
+- Write in the past tense for **Accepted** ADRs ("We decided to use…") and
+  present tense for **Proposed** ones ("We are considering…").
+- Keep each ADR focused on a single decision. If two decisions are tightly
+  coupled, consider whether they belong in one ADR or two.
+- Link to the specific code files that implement the decision so future readers
+  can navigate from the ADR to the implementation.
+- If a decision is later reversed, do not delete the ADR — mark it
+  `Deprecated` or `Superseded` and explain why. The history of *why* a decision
+  was made is as valuable as the decision itself.

--- a/novaRewards/.env.example
+++ b/novaRewards/.env.example
@@ -1,61 +1,256 @@
-# Stellar Issuer Account (creates and issues the NOVA asset)
-ISSUER_PUBLIC=G...
-ISSUER_SECRET=S...
+# =============================================================================
+# Nova Rewards — Environment Variables Reference
+# =============================================================================
+#
+# This file is the authoritative reference for every environment variable
+# consumed by the Nova Rewards backend and frontend.
+#
+# HOW TO USE
+# ----------
+# 1. Copy this file:
+#      cp .env.example .env.local        # frontend (Next.js)
+#      cp .env.example backend/.env      # backend (Express)
+# 2. Replace every placeholder value with a real value for your environment.
+# 3. Never commit files containing real secrets to version control.
+#
+# VALIDATION
+# ----------
+# Backend:  novaRewards/backend/middleware/validateEnv.js
+#           Called at server startup — missing required vars abort the process.
+# Frontend: novaRewards/frontend/lib/env.js  (Zod schema)
+#           Called at Next.js build time — missing required vars abort the build.
+#
+# CI CHECK
+# --------
+# .github/workflows/env-check.yml verifies that every variable defined in
+# validateEnv.js and frontend/lib/env.js is present in this file.
+# Run locally: node scripts/check-env-example.js
+#
+# GROUPING
+# --------
+# Variables are grouped by service. Required variables are marked [REQUIRED].
+# Optional variables include their default value in a comment.
+# =============================================================================
 
-# Stellar Distribution Account (sends NOVA tokens to customers)
-DISTRIBUTION_PUBLIC=G...
-DISTRIBUTION_SECRET=S...
 
-# Stellar Network Configuration
-# Use 'testnet' for development, 'mainnet' for production
+# =============================================================================
+# ── Server ───────────────────────────────────────────────────────────────────
+# =============================================================================
+
+# TCP port the Express backend listens on.
+# [OPTIONAL] Default: 3001
+PORT=3001
+
+# Runtime environment. Controls CORS policy, Swagger UI visibility, and logging.
+# Values: development | test | staging | production
+# [REQUIRED]
+NODE_ENV=development
+
+# Comma-separated list of allowed CORS origins.
+# In production, list exact origins — no wildcards.
+# [REQUIRED in production]
+ALLOWED_ORIGIN=http://localhost:3000
+
+
+# =============================================================================
+# ── Stellar / Horizon ────────────────────────────────────────────────────────
+# =============================================================================
+
+# Stellar network to connect to.
+# Values: testnet | mainnet
+# [REQUIRED]
 STELLAR_NETWORK=testnet
+
+# Stellar Horizon REST API endpoint.
+# Testnet:  https://horizon-testnet.stellar.org
+# Mainnet:  https://horizon.stellar.org
+# [REQUIRED]
 HORIZON_URL=https://horizon-testnet.stellar.org
 
-# PostgreSQL Database
-# When running via docker-compose, DATABASE_URL is overridden by the compose file.
-# These vars are used by both docker-compose and DATABASE_URL for local dev.
+# Stellar Issuer Account — creates and issues the NOVA asset.
+# Public key starts with G (56 characters).
+# [REQUIRED]
+ISSUER_PUBLIC=GXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX
+
+# Stellar Issuer Account secret key — signs issuance transactions.
+# Secret key starts with S (56 characters). NEVER expose to the browser.
+# [REQUIRED]
+ISSUER_SECRET=SXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX
+
+# Stellar Distribution Account — sends NOVA tokens to user wallets.
+# [REQUIRED]
+DISTRIBUTION_PUBLIC=GXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX
+
+# [REQUIRED]
+DISTRIBUTION_SECRET=SXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX
+
+
+# =============================================================================
+# ── Soroban Smart Contracts ──────────────────────────────────────────────────
+# =============================================================================
+
+# Contract IDs are written automatically by scripts/deploy-contracts.sh.
+# Leave blank until contracts are deployed to the target network.
+
+# [OPTIONAL]
+NOVA_TOKEN_CONTRACT_ID=CXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX
+
+# [OPTIONAL]
+REWARD_POOL_CONTRACT_ID=CXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX
+
+# [OPTIONAL]
+VESTING_CONTRACT_ID=CXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX
+
+# [OPTIONAL]
+REFERRAL_CONTRACT_ID=CXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX
+
+# [OPTIONAL]
+DISTRIBUTION_CONTRACT_ID=CXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX
+
+# [OPTIONAL]
+ADMIN_ROLES_CONTRACT_ID=CXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX
+
+# [OPTIONAL]
+NOVA_REWARDS_CONTRACT_ID=CXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX
+
+
+# =============================================================================
+# ── Database (PostgreSQL) ────────────────────────────────────────────────────
+# =============================================================================
+
+# Full PostgreSQL connection string used by the backend and Prisma.
+# Format: postgresql://<user>:<password>@<host>:<port>/<database>
+# [REQUIRED]
+DATABASE_URL=postgresql://nova:changeme@localhost:5432/nova_rewards
+
+# Individual connection components (used by Docker Compose and pg_dump scripts).
 POSTGRES_USER=nova
 POSTGRES_PASSWORD=changeme
 POSTGRES_DB=nova_rewards
-DATABASE_URL=postgresql://nova:changeme@localhost:5432/nova_rewards
 
-# Migration credentials (dev override; in production DB_MIGRATE_SECRET_ARN is used instead)
+# Migration-only connection string (limited privileges — CREATE TABLE, ALTER TABLE).
+# In production, sourced from AWS Secrets Manager via DB_MIGRATE_SECRET_ARN.
+# [OPTIONAL] Falls back to DATABASE_URL if unset.
 DATABASE_MIGRATE_URL=postgresql://nova_migrate:changeme@localhost:5432/nova_rewards
 
-# AWS — production migration credentials via Secrets Manager
-# DB_MIGRATE_SECRET_ARN=arn:aws:secretsmanager:us-east-1:123456789012:secret:nova-rewards/production/db-migrate-password
-# AWS_REGION=us-east-1
+# AWS Secrets Manager ARN for the migration password (production only).
+# [OPTIONAL]
+# DB_MIGRATE_SECRET_ARN=arn:aws:secretsmanager:us-east-1:123456789012:secret:nova/db-migrate
 
-# CloudWatch Logs
-# Set LOG_DRIVER=awslogs to ship container stdout/stderr to CloudWatch (requires AWS credentials).
-# Leave unset (defaults to json-file) for local development without AWS access.
-# LOG_DRIVER=awslogs
-# AWS_REGION=us-east-1
-# AWS_ACCESS_KEY_ID=
-# AWS_SECRET_ACCESS_KEY=
-# CLOUDWATCH_LOG_GROUP_PREFIX=/nova-rewards
-# CLOUDWATCH_LOG_GROUP=/nova-rewards/development/backend
-# LOG_LEVEL=info
 
-# Redis
-# Used by: rate limiting, leaderboard cache, Socket.IO adapter, and BullMQ batch job queues
+# =============================================================================
+# ── Redis ────────────────────────────────────────────────────────────────────
+# =============================================================================
+
+# Redis connection URL.
+# Local development:  redis://localhost:6379
+# Production (TLS):   rediss://:<auth_token>@<elasticache-endpoint>:6379
+#   The "rediss://" scheme enables TLS automatically (ioredis).
+# [REQUIRED]
 REDIS_URL=redis://localhost:6379
-# REDIS_MODE=single          # single | cluster | sentinel
-# REDIS_CLUSTER_NODES=host1:6379,host2:6379,host3:6379
-# REDIS_SENTINEL_NODES=host1:26379,host2:26379
-# REDIS_SENTINEL_NAME=mymaster
+
+# Redis host and port (used by BullMQ queue configuration).
+# [OPTIONAL] Derived from REDIS_URL if not set explicitly.
+REDIS_HOST=localhost
+REDIS_PORT=6379
+
+# Maximum memory Redis is allowed to use before eviction kicks in.
+# [OPTIONAL] Default: 256mb
 REDIS_MAXMEMORY=256mb
 
-# PostgreSQL Backups
-BACKUP_RETAIN_DAYS=7
-# BACKUP_S3_BUCKET=nova-rewards-backups
-# AWS_ACCESS_KEY_ID=
-# AWS_SECRET_ACCESS_KEY=
 
-# Rate Limiting — comma-separated IPs exempt from rate limits (health-check / monitoring)
+# =============================================================================
+# ── Authentication (JWT RS256) ───────────────────────────────────────────────
+# =============================================================================
+#
+# Nova Rewards uses RS256 asymmetric JWT signing (ADR-0007).
+# JWT_SECRET is no longer used; it has been replaced by the RS256 key pair.
+#
+# Generate a new key pair:
+#   node novaRewards/backend/scripts/generate-jwt-keys.js
+#
+# Store the real keys in AWS Secrets Manager in production.
+# Newlines in the PEM must be escaped as \n when stored in a single-line env var.
+
+# RSA private key (2048-bit) — used to SIGN tokens. Keep secret.
+# [REQUIRED]
+JWT_PRIVATE_KEY="-----BEGIN PRIVATE KEY-----\nMIIEvQIBADANBgkqhkiG9w0BAQEFAASCBKcwggSjAgEAAoIBAQC7...<replace>\n-----END PRIVATE KEY-----"
+
+# RSA public key — used to VERIFY tokens. Safe to distribute to other services.
+# [REQUIRED]
+JWT_PUBLIC_KEY="-----BEGIN PUBLIC KEY-----\nMIIBIjANBgkqhkiG9w0BAQEFAAOCAQ8AMIIBCgKCAQEAu...<replace>\n-----END PUBLIC KEY-----"
+
+
+# =============================================================================
+# ── Field-Level Encryption (AES-256-GCM) ────────────────────────────────────
+# =============================================================================
+#
+# Used to encrypt PII fields (user email, webhook secrets) before writing to
+# PostgreSQL (ADR-0013). The database never stores plaintext PII.
+#
+# Generate a new key:
+#   node -e "console.log(require('crypto').randomBytes(32).toString('hex'))"
+#
+# The output is a 64-character hex string (32 bytes = 256-bit key).
+# Store the real key in AWS Secrets Manager in production.
+
+# [REQUIRED]
+FIELD_ENCRYPTION_KEY=0000000000000000000000000000000000000000000000000000000000000000
+
+# Previous encryption key — set during key rotation so existing rows can still
+# be decrypted. Remove after all rows have been re-encrypted.
+# [OPTIONAL]
+# FIELD_ENCRYPTION_KEY_PREVIOUS=<old-64-char-hex-key>
+
+
+# =============================================================================
+# ── Email ────────────────────────────────────────────────────────────────────
+# =============================================================================
+
+# SMTP configuration for transactional email (local development / staging).
+# [OPTIONAL] Required if SENDGRID_API_KEY is not set.
+SMTP_HOST=smtp.example.com
+SMTP_PORT=587
+SMTP_USER=your-smtp-username@example.com
+SMTP_PASSWORD=your-smtp-password
+
+# Sender address shown in the From header.
+# [OPTIONAL] Default: noreply@novarewards.com
+EMAIL_FROM=noreply@novarewards.com
+
+# SendGrid API key (production alternative to SMTP).
+# [OPTIONAL] Takes precedence over SMTP settings when set.
+SENDGRID_API_KEY=SG.xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx
+
+
+# =============================================================================
+# ── Webhooks ─────────────────────────────────────────────────────────────────
+# =============================================================================
+
+# Timeout for outbound webhook HTTP requests (milliseconds).
+# [OPTIONAL] Default: 10000
+WEBHOOK_TIMEOUT_MS=10000
+
+# Interval between webhook retry attempts (milliseconds).
+# [OPTIONAL] Default: 60000
+WEBHOOK_RETRY_INTERVAL_MS=60000
+
+# Maximum number of delivery attempts before a webhook is moved to the DLQ.
+# [OPTIONAL] Default: 5
+WEBHOOK_MAX_ATTEMPTS=5
+
+
+# =============================================================================
+# ── Rate Limiting ────────────────────────────────────────────────────────────
+# =============================================================================
+
+# Comma-separated IP addresses exempt from rate limiting (health checks, monitors).
+# [OPTIONAL] Default: 127.0.0.1,::1
 RATE_LIMIT_WHITELIST=127.0.0.1,::1
 
-# Sliding-window rate limit overrides (requests per 60s window)
+# Per-window request caps (requests per 60-second window).
+# Override the defaults defined in backend/config/constants.js.
+# [OPTIONAL]
 RL_GLOBAL_MAX=100
 RL_AUTH_MAX=5
 RL_USER_MAX=200
@@ -64,71 +259,166 @@ RL_WEBHOOK_MAX=60
 RL_REWARDS_MAX=20
 RL_ADMIN_MAX=120
 
-# Daily Login Bonus
-DAILY_BONUS_POINTS=10
 
-# Redis Cache (ElastiCache in production)
-# Format: rediss://:<auth_token>@<elasticache-endpoint>:6379
-# Sourced from AWS Secrets Manager in production; leave blank for local dev (falls back to in-memory)
-REDIS_URL=
+# =============================================================================
+# ── Rewards & Referrals ──────────────────────────────────────────────────────
+# =============================================================================
 
-# Backend Server
-PORT=3001
-NODE_ENV=development
-# Comma-separated list of allowed CORS origins (no wildcards in production)
-ALLOWED_ORIGINS=http://localhost:3000
-
-# JWT Authentication — RS256 (issue #648)
-# Generate keys: node novaRewards/backend/scripts/generate-jwt-keys.js
-# JWT_SECRET is no longer used; replaced by RS256 key pair below.
-JWT_PRIVATE_KEY="-----BEGIN PRIVATE KEY-----\n<your-2048-bit-rsa-private-key>\n-----END PRIVATE KEY-----"
-JWT_PUBLIC_KEY="-----BEGIN PUBLIC KEY-----\n<your-2048-bit-rsa-public-key>\n-----END PUBLIC KEY-----"
-
-# Field-level Encryption (AES-256-GCM) — Requirements: #651
-# Generate with: node -e "console.log(require('crypto').randomBytes(32).toString('hex'))"
-# Store in AWS Secrets Manager in production; never commit the real value.
-FIELD_ENCRYPTION_KEY=replace-with-64-char-hex-string-generated-by-command-above
-# During key rotation, set the OLD key here so existing rows can still be decrypted:
-# FIELD_ENCRYPTION_KEY_PREVIOUS=old-64-char-hex-key
-
-# Referral Configuration
+# Points awarded for each successful referral.
+# [OPTIONAL] Default: 100
 REFERRAL_BONUS_POINTS=100
 
-# Email Configuration (SMTP for local development)
-SMTP_HOST=smtp.example.com
-SMTP_PORT=587
-SMTP_USER=your-email@example.com
-SMTP_PASSWORD=your-password
-EMAIL_FROM=noreply@novarewards.com
+# Points awarded for the daily login bonus.
+# [OPTIONAL] Default: 10
+DAILY_BONUS_POINTS=10
 
-# Email Configuration (SendGrid for production - optional)
-SENDGRID_API_KEY=your-sendgrid-api-key
 
-# Webhooks
-WEBHOOK_TIMEOUT_MS=10000
-WEBHOOK_RETRY_INTERVAL_MS=60000
-WEBHOOK_MAX_ATTEMPTS=5
+# =============================================================================
+# ── Elasticsearch (Search) ───────────────────────────────────────────────────
+# =============================================================================
 
-# Elasticsearch
+# Elasticsearch endpoint for full-text search (campaigns, merchants, users).
+# [OPTIONAL] Search features are disabled if unset.
 ELASTICSEARCH_URL=http://localhost:9200
-# Optional: use API key auth for Elastic Cloud
-# ELASTICSEARCH_API_KEY=your-api-key
-# Optional: CA cert for TLS (PEM string or file path)
+
+# API key for Elastic Cloud authentication.
+# [OPTIONAL] Used instead of username/password for cloud deployments.
+# ELASTICSEARCH_API_KEY=your-elastic-cloud-api-key
+
+# CA certificate for TLS verification (PEM string or file path).
+# [OPTIONAL]
 # ELASTICSEARCH_CA_CERT=
 
-# Contract Configuration (for webhook listener)
-NOVA_TOKEN_CONTRACT_ID=your-contract-id
-REWARD_POOL_CONTRACT_ID=your-contract-id
 
-# Frontend (Next.js public vars — safe to expose to browser)
+# =============================================================================
+# ── AWS ──────────────────────────────────────────────────────────────────────
+# =============================================================================
+
+# AWS region for Secrets Manager, CloudWatch, and S3.
+# [OPTIONAL] Required when using AWS services.
+AWS_REGION=us-east-1
+
+# AWS credentials (not needed when running on EC2/ECS with an IAM role).
+# [OPTIONAL]
+# AWS_ACCESS_KEY_ID=AKIAIOSFODNN7EXAMPLE
+# AWS_SECRET_ACCESS_KEY=wJalrXUtnFEMI/K7MDENG/bPxRfiCYEXAMPLEKEY
+
+
+# =============================================================================
+# ── Logging ──────────────────────────────────────────────────────────────────
+# =============================================================================
+
+# Minimum log level emitted by Winston.
+# Values: error | warn | info | http | verbose | debug | silly
+# [OPTIONAL] Default: info
+LOG_LEVEL=info
+
+# Docker log driver. Set to "awslogs" to ship container logs to CloudWatch.
+# [OPTIONAL] Default: json-file (local development)
+# LOG_DRIVER=awslogs
+
+# CloudWatch log group for the backend container.
+# [OPTIONAL] Required when LOG_DRIVER=awslogs.
+# CLOUDWATCH_LOG_GROUP=/nova-rewards/production/backend
+
+
+# =============================================================================
+# ── Database Backups ─────────────────────────────────────────────────────────
+# =============================================================================
+
+# Number of days to retain PostgreSQL backup files.
+# [OPTIONAL] Default: 7
+BACKUP_RETAIN_DAYS=7
+
+# Enable automated PostgreSQL backups.
+# [OPTIONAL] Default: false
+# BACKUP_ENABLED=true
+
+# S3 bucket for backup storage.
+# [OPTIONAL] Required when BACKUP_ENABLED=true.
+# BACKUP_S3_BUCKET=nova-rewards-backups
+
+# Passphrase used to encrypt backup archives (GPG symmetric encryption).
+# [OPTIONAL] Required when BACKUP_ENABLED=true.
+# BACKUP_PASSPHRASE=replace-with-strong-random-passphrase
+
+
+# =============================================================================
+# ── PWA Push Notifications (VAPID) ──────────────────────────────────────────
+# =============================================================================
+#
+# Generate VAPID keys:
+#   npx web-push generate-vapid-keys
+
+# VAPID public key — embedded in the browser service worker.
+# [OPTIONAL] Required to enable push notifications.
+VAPID_PUBLIC_KEY=your-vapid-public-key-base64url
+
+# VAPID private key — used by the backend to sign push requests. Keep secret.
+# [OPTIONAL] Required to enable push notifications.
+VAPID_PRIVATE_KEY=your-vapid-private-key-base64url
+
+# Contact email included in VAPID requests (required by push services).
+# [OPTIONAL] Default: admin@novarewards.com
+VAPID_EMAIL=admin@novarewards.com
+
+
+# =============================================================================
+# ── Frontend (Next.js — NEXT_PUBLIC_* vars are exposed to the browser) ───────
+# =============================================================================
+#
+# NEXT_PUBLIC_* variables are embedded in the browser bundle at build time.
+# Never put secrets or private keys in NEXT_PUBLIC_* variables.
+#
+# Validated by: novaRewards/frontend/lib/env.js (Zod schema)
+
+# Backend API base URL.
+# [REQUIRED by frontend]
 NEXT_PUBLIC_API_URL=http://localhost:3001
+
+# Stellar Horizon endpoint used by the frontend for balance and trustline checks.
+# [REQUIRED by frontend]
 NEXT_PUBLIC_HORIZON_URL=https://horizon-testnet.stellar.org
-NEXT_PUBLIC_ISSUER_PUBLIC=G...
+
+# Stellar issuer public key (safe to expose — public key only).
+# Must match ISSUER_PUBLIC above.
+# [REQUIRED by frontend]
+NEXT_PUBLIC_ISSUER_PUBLIC=GXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX
+
+# Stellar network identifier.
+# Values: testnet | mainnet | public
+# [REQUIRED by frontend]
 NEXT_PUBLIC_STELLAR_NETWORK=testnet
 
-# PWA Push Notifications (VAPID keys)
-# Generate keys with: npx web-push generate-vapid-keys
-VAPID_PUBLIC_KEY=your-vapid-public-key
-VAPID_PRIVATE_KEY=your-vapid-private-key
-VAPID_EMAIL=admin@novarewards.com
-NEXT_PUBLIC_VAPID_PUBLIC_KEY=your-vapid-public-key
+# Soroban multisig contract ID (optional — not deployed in all environments).
+# [OPTIONAL]
+NEXT_PUBLIC_MULTISIG_CONTRACT_ID=CXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX
+
+# Feature flags — enable/disable platform features per environment.
+# [OPTIONAL] Default: false
+NEXT_PUBLIC_STAKING_ENABLED=false
+NEXT_PUBLIC_REFERRAL_ENABLED=false
+
+# VAPID public key for the browser service worker (must match VAPID_PUBLIC_KEY above).
+# [OPTIONAL] Required to enable push notifications in the browser.
+NEXT_PUBLIC_VAPID_PUBLIC_KEY=your-vapid-public-key-base64url
+
+# Sentry DSN for frontend error tracking.
+# [OPTIONAL] Error tracking is disabled if unset.
+NEXT_PUBLIC_SENTRY_DSN=https://examplePublicKey@o0.ingest.sentry.io/0
+
+# Environment label sent to Sentry with each event.
+# [OPTIONAL] Default: development
+NEXT_PUBLIC_ENVIRONMENT=development
+
+# Sentry organisation slug (used by the Sentry CLI for source map uploads).
+# [OPTIONAL] Required for source map uploads in CI.
+SENTRY_ORG=your-sentry-org-slug
+
+# Sentry project slug.
+# [OPTIONAL] Required for source map uploads in CI.
+SENTRY_PROJECT=nova-rewards-frontend
+
+# Sentry auth token for source map uploads (CI only — not needed at runtime).
+# [OPTIONAL]
+SENTRY_AUTH_TOKEN=sntrys_xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx

--- a/novaRewards/scripts/check-env-example.js
+++ b/novaRewards/scripts/check-env-example.js
@@ -1,0 +1,161 @@
+#!/usr/bin/env node
+/**
+ * check-env-example.js
+ *
+ * CI guard: verifies that every environment variable declared as required in
+ * the backend validateEnv.js and the frontend Zod env schema is present in
+ * novaRewards/.env.example.
+ *
+ * Usage:
+ *   node novaRewards/scripts/check-env-example.js
+ *
+ * Exit codes:
+ *   0 — all required variables are documented in .env.example
+ *   1 — one or more variables are missing from .env.example
+ */
+
+'use strict';
+
+const fs = require('fs');
+const path = require('path');
+
+// ---------------------------------------------------------------------------
+// Paths (relative to repo root)
+// ---------------------------------------------------------------------------
+
+const ROOT = path.resolve(__dirname, '..', '..');
+
+const ENV_EXAMPLE_PATH = path.join(ROOT, 'novaRewards', '.env.example');
+const BACKEND_VALIDATE_ENV_PATH = path.join(
+  ROOT,
+  'novaRewards',
+  'backend',
+  'middleware',
+  'validateEnv.js'
+);
+const FRONTEND_ENV_SCHEMA_PATH = path.join(
+  ROOT,
+  'novaRewards',
+  'frontend',
+  'lib',
+  'env.js'
+);
+
+// ---------------------------------------------------------------------------
+// Parse .env.example — collect every key that appears as an assignment
+// ---------------------------------------------------------------------------
+
+function parseEnvExample(filePath) {
+  const content = fs.readFileSync(filePath, 'utf8');
+  const keys = new Set();
+  for (const line of content.split('\n')) {
+    const trimmed = line.trim();
+    // Skip comments and blank lines
+    if (!trimmed || trimmed.startsWith('#')) continue;
+    const match = trimmed.match(/^([A-Z][A-Z0-9_]*)=/);
+    if (match) keys.add(match[1]);
+  }
+  return keys;
+}
+
+// ---------------------------------------------------------------------------
+// Extract required backend variables from validateEnv.js
+// ---------------------------------------------------------------------------
+
+function parseBackendRequiredVars(filePath) {
+  const content = fs.readFileSync(filePath, 'utf8');
+  const vars = new Set();
+
+  // Match array literals: ['VAR1', 'VAR2', ...]
+  const arrayMatches = content.matchAll(/\[\s*((?:'[A-Z][A-Z0-9_]*'\s*,?\s*)+)\]/g);
+  for (const match of arrayMatches) {
+    const items = match[1].matchAll(/'([A-Z][A-Z0-9_]*)'/g);
+    for (const item of items) vars.add(item[1]);
+  }
+
+  // Match individual process.env references: process.env.VAR_NAME
+  const envMatches = content.matchAll(/process\.env\.([A-Z][A-Z0-9_]*)/g);
+  for (const match of envMatches) vars.add(match[1]);
+
+  return vars;
+}
+
+// ---------------------------------------------------------------------------
+// Extract required frontend variables from the Zod schema (env.js)
+// ---------------------------------------------------------------------------
+
+function parseFrontendRequiredVars(filePath) {
+  const content = fs.readFileSync(filePath, 'utf8');
+  const vars = new Set();
+
+  // Match Zod object keys: NEXT_PUBLIC_VAR_NAME: z.string()...
+  const keyMatches = content.matchAll(/^\s*(NEXT_PUBLIC_[A-Z][A-Z0-9_]*)\s*:/gm);
+  for (const match of keyMatches) vars.add(match[1]);
+
+  // Also catch any non-public keys defined in the schema
+  const allKeyMatches = content.matchAll(/^\s*([A-Z][A-Z0-9_]*)\s*:/gm);
+  for (const match of allKeyMatches) {
+    // Only include keys that look like env var names (all caps + underscores)
+    if (/^[A-Z][A-Z0-9_]+$/.test(match[1])) vars.add(match[1]);
+  }
+
+  return vars;
+}
+
+// ---------------------------------------------------------------------------
+// Main
+// ---------------------------------------------------------------------------
+
+function main() {
+  let hasErrors = false;
+
+  // Load .env.example keys
+  if (!fs.existsSync(ENV_EXAMPLE_PATH)) {
+    console.error(`❌  .env.example not found at: ${ENV_EXAMPLE_PATH}`);
+    process.exit(1);
+  }
+  const exampleKeys = parseEnvExample(ENV_EXAMPLE_PATH);
+  console.log(`✔  Parsed ${exampleKeys.size} keys from .env.example\n`);
+
+  // Check backend required vars
+  if (fs.existsSync(BACKEND_VALIDATE_ENV_PATH)) {
+    const backendVars = parseBackendRequiredVars(BACKEND_VALIDATE_ENV_PATH);
+    const missingFromBackend = [...backendVars].filter((v) => !exampleKeys.has(v));
+    if (missingFromBackend.length > 0) {
+      console.error('❌  Backend required variables missing from .env.example:');
+      missingFromBackend.forEach((v) => console.error(`     • ${v}`));
+      hasErrors = true;
+    } else {
+      console.log(`✔  All ${backendVars.size} backend required variables are documented`);
+    }
+  } else {
+    console.warn(`⚠   Backend validateEnv.js not found — skipping backend check`);
+  }
+
+  // Check frontend Zod schema vars
+  if (fs.existsSync(FRONTEND_ENV_SCHEMA_PATH)) {
+    const frontendVars = parseFrontendRequiredVars(FRONTEND_ENV_SCHEMA_PATH);
+    const missingFromFrontend = [...frontendVars].filter((v) => !exampleKeys.has(v));
+    if (missingFromFrontend.length > 0) {
+      console.error('\n❌  Frontend Zod schema variables missing from .env.example:');
+      missingFromFrontend.forEach((v) => console.error(`     • ${v}`));
+      hasErrors = true;
+    } else {
+      console.log(`✔  All ${frontendVars.size} frontend Zod schema variables are documented`);
+    }
+  } else {
+    console.warn(`⚠   Frontend env.js not found — skipping frontend check`);
+  }
+
+  if (hasErrors) {
+    console.error(
+      '\n❌  .env.example is out of sync. Add the missing variables and re-run this check.\n'
+    );
+    process.exit(1);
+  } else {
+    console.log('\n✅  .env.example is in sync with all env schemas.\n');
+    process.exit(0);
+  }
+}
+
+main();


### PR DESCRIPTION

closes #917 
closes #920 

## Summary

Closes two open issues: undocumented architectural decisions and an out-of-sync `.env.example`.

---

## ADRs — `docs/adr/`

Added 8 new Architecture Decision Records covering the most significant undocumented decisions:

| ADR | Decision |
|-----|----------|
| 0007 | JWT RS256 authentication strategy |
| 0008 | Cursor-based pagination for list endpoints |
| 0009 | BullMQ on Redis for async job queue |
| 0010 | Redis multi-layer caching strategy |
| 0011 | AWS as production deployment target (Kubernetes/Helm) |
| 0012 | Prometheus + Grafana + Loki + Sentry observability stack |
| 0013 | AES-256-GCM field-level encryption for PII |
| 0014 | Rust as the Soroban smart contract language |

Updated `docs/adr/README.md` with a full index table (all 14 ADRs with status), a documented process for creating new ADRs, and a copy-paste template.

---

## `.env.example` — `novaRewards/.env.example`

Complete rewrite. Now covers every variable defined in `validateEnv.js` (backend) and the frontend Zod schema (`frontend/lib/env.js`). Variables are grouped and commented by service with `[REQUIRED]` / `[OPTIONAL]` annotations. No real secrets — safe placeholder values only.

---

## CI env sync check

- `novaRewards/scripts/check-env-example.js` — diffs both env schemas against `.env.example`, exits non-zero on mismatch
- `.github/workflows/env-check.yml` — runs the check on every PR that touches `.env.example`, `validateEnv.js`, or `frontend/lib/env.js`

---

## Files changed

- `docs/adr/README.md` — updated index + process docs
- `docs/adr/0007` through `0014` — 8 new ADR files
- `novaRewards/.env.example` — complete rewrite
- `novaRewards/scripts/check-env-example.js` — new CI script
- `.github/workflows/env-check.yml` — new CI workflow
