### PR TITLE
feat: add tooltips, zoom, click-to-filter, and accessible legend to R…

### DIFF
--- a/novaRewards/frontend/__tests__/RewardsLineChart.test.js
+++ b/novaRewards/frontend/__tests__/RewardsLineChart.test.js
@@ -1,0 +1,204 @@
+import React from 'react';
+import { render, screen, fireEvent } from '@testing-library/react';
+import '@testing-library/jest-dom';
+
+// ── Recharts mock ──────────────────────────────────────────────────────────────
+// Recharts uses ResizeObserver and SVG APIs unavailable in jsdom.
+// We render lightweight stubs that expose the props we need to test.
+jest.mock('recharts', () => {
+  const React = require('react');
+  return {
+    ResponsiveContainer: ({ children }) => <div data-testid="responsive-container">{children}</div>,
+    LineChart: ({ children, onClick, 'data-testid': dt }) => (
+      <div
+        data-testid={dt ?? 'line-chart'}
+        onClick={() =>
+          onClick?.({ activePayload: [{ payload: { date: '2024-01-15', rewards: 42, type: 'issuance' } }] })
+        }
+      >
+        {children}
+      </div>
+    ),
+    Line: ({ dataKey, name, hide }) => (
+      <div data-testid={`line-${dataKey}`} data-name={name} data-hidden={String(hide ?? false)} />
+    ),
+    XAxis: () => null,
+    YAxis: () => null,
+    CartesianGrid: () => null,
+    Tooltip: ({ content }) => (content ? React.cloneElement(content, {
+      active: true,
+      payload: [{ dataKey: 'rewards', value: 42, color: '#7c3aed', name: 'Rewards', payload: { date: '2024-01-15', rewards: 42, type: 'issuance', _tooltipBg: '#fff', _tooltipBorder: '#ccc', _tooltipColor: '#000' } }],
+      label: '2024-01-15',
+    }) : null),
+    Legend: () => null,
+    Brush: () => <div data-testid="brush" />,
+  };
+});
+
+// ── Theme mock ─────────────────────────────────────────────────────────────────
+jest.mock('../../components/analytics/useChartTheme', () => ({
+  useChartTheme: () => ({
+    text: '#64748b',
+    grid: '#e2e8f0',
+    tooltip: { bg: '#fff', border: '#cbd5e1', color: '#0f172a' },
+    accent: '#7c3aed',
+    palette: ['#7c3aed', '#06b6d4', '#10b981'],
+  }),
+}));
+
+// ── ChartEmptyState mock ───────────────────────────────────────────────────────
+jest.mock('../../components/charts/ChartEmptyState', () =>
+  function ChartEmptyState({ type, message }) {
+    return <div data-testid={`empty-${type}`}>{message}</div>;
+  }
+);
+
+import RewardsLineChart from '../../components/charts/RewardsLineChart';
+
+// ── Fixtures ───────────────────────────────────────────────────────────────────
+const DATA = [
+  { date: '2024-01-13', rewards: 10, type: 'issuance' },
+  { date: '2024-01-14', rewards: 25, type: 'redemption' },
+  { date: '2024-01-15', rewards: 42, type: 'issuance' },
+];
+
+// ── RewardsLineChart ───────────────────────────────────────────────────────────
+describe('RewardsLineChart', () => {
+  describe('empty / loading / error states', () => {
+    it('renders loading state', () => {
+      render(<RewardsLineChart loading />);
+      expect(screen.getByTestId('empty-loading')).toBeInTheDocument();
+    });
+
+    it('renders error state with message', () => {
+      render(<RewardsLineChart error="Network error" />);
+      expect(screen.getByTestId('empty-error')).toHaveTextContent('Network error');
+    });
+
+    it('renders empty state when data is empty', () => {
+      render(<RewardsLineChart data={[]} />);
+      expect(screen.getByTestId('empty-empty')).toBeInTheDocument();
+    });
+  });
+
+  describe('chart rendering', () => {
+    it('renders the chart container with data', () => {
+      render(<RewardsLineChart data={DATA} />);
+      expect(screen.getByTestId('responsive-container')).toBeInTheDocument();
+    });
+
+    it('renders the Brush component for zoom', () => {
+      render(<RewardsLineChart data={DATA} />);
+      expect(screen.getByTestId('brush')).toBeInTheDocument();
+    });
+
+    it('renders a Line for each series', () => {
+      const series = [
+        { key: 'rewards', label: 'Rewards' },
+        { key: 'bonus', label: 'Bonus' },
+      ];
+      render(<RewardsLineChart data={DATA} series={series} />);
+      expect(screen.getByTestId('line-rewards')).toBeInTheDocument();
+      expect(screen.getByTestId('line-bonus')).toBeInTheDocument();
+    });
+
+    it('defaults to a single "rewards" series when none provided', () => {
+      render(<RewardsLineChart data={DATA} />);
+      expect(screen.getByTestId('line-rewards')).toBeInTheDocument();
+    });
+  });
+
+  describe('custom tooltip', () => {
+    it('renders tooltip with date, amount, and type', () => {
+      render(<RewardsLineChart data={DATA} />);
+      // Tooltip mock renders the content element with active=true
+      expect(screen.getByRole('tooltip')).toBeInTheDocument();
+      expect(screen.getByRole('tooltip')).toHaveTextContent('2024-01-15');
+      expect(screen.getByRole('tooltip')).toHaveTextContent('42');
+      expect(screen.getByRole('tooltip')).toHaveTextContent('issuance');
+    });
+  });
+
+  describe('click-to-filter', () => {
+    it('calls onDateClick with the clicked date', () => {
+      const onDateClick = jest.fn();
+      render(<RewardsLineChart data={DATA} onDateClick={onDateClick} />);
+      fireEvent.click(screen.getByTestId('line-chart'));
+      expect(onDateClick).toHaveBeenCalledWith('2024-01-15');
+    });
+
+    it('does not call onDateClick when prop is not provided', () => {
+      // Should not throw
+      render(<RewardsLineChart data={DATA} />);
+      fireEvent.click(screen.getByTestId('line-chart'));
+    });
+  });
+
+  describe('accessible legend', () => {
+    it('renders legend items as checkbox buttons', () => {
+      const series = [
+        { key: 'rewards', label: 'Rewards' },
+        { key: 'bonus', label: 'Bonus' },
+      ];
+      render(<RewardsLineChart data={DATA} series={series} />);
+      const checkboxes = screen.getAllByRole('checkbox');
+      expect(checkboxes).toHaveLength(2);
+      expect(checkboxes[0]).toHaveAccessibleName('Rewards');
+      expect(checkboxes[1]).toHaveAccessibleName('Bonus');
+    });
+
+    it('legend items start checked (series visible)', () => {
+      render(<RewardsLineChart data={DATA} />);
+      expect(screen.getByRole('checkbox', { name: 'Rewards' })).toHaveAttribute('aria-checked', 'true');
+    });
+
+    it('toggles series off when legend item is clicked', () => {
+      render(<RewardsLineChart data={DATA} />);
+      const checkbox = screen.getByRole('checkbox', { name: 'Rewards' });
+      fireEvent.click(checkbox);
+      expect(checkbox).toHaveAttribute('aria-checked', 'false');
+      expect(screen.getByTestId('line-rewards')).toHaveAttribute('data-hidden', 'true');
+    });
+
+    it('toggles series back on when clicked again', () => {
+      render(<RewardsLineChart data={DATA} />);
+      const checkbox = screen.getByRole('checkbox', { name: 'Rewards' });
+      fireEvent.click(checkbox);
+      fireEvent.click(checkbox);
+      expect(checkbox).toHaveAttribute('aria-checked', 'true');
+      expect(screen.getByTestId('line-rewards')).toHaveAttribute('data-hidden', 'false');
+    });
+
+    it('toggles series via Enter key', () => {
+      render(<RewardsLineChart data={DATA} />);
+      const checkbox = screen.getByRole('checkbox', { name: 'Rewards' });
+      fireEvent.keyDown(checkbox, { key: 'Enter' });
+      expect(checkbox).toHaveAttribute('aria-checked', 'false');
+    });
+
+    it('toggles series via Space key', () => {
+      render(<RewardsLineChart data={DATA} />);
+      const checkbox = screen.getByRole('checkbox', { name: 'Rewards' });
+      fireEvent.keyDown(checkbox, { key: ' ' });
+      expect(checkbox).toHaveAttribute('aria-checked', 'false');
+    });
+
+    it('does not toggle on other keys', () => {
+      render(<RewardsLineChart data={DATA} />);
+      const checkbox = screen.getByRole('checkbox', { name: 'Rewards' });
+      fireEvent.keyDown(checkbox, { key: 'Tab' });
+      expect(checkbox).toHaveAttribute('aria-checked', 'true');
+    });
+
+    it('independent toggles for multiple series', () => {
+      const series = [
+        { key: 'rewards', label: 'Rewards' },
+        { key: 'bonus', label: 'Bonus' },
+      ];
+      render(<RewardsLineChart data={DATA} series={series} />);
+      fireEvent.click(screen.getByRole('checkbox', { name: 'Rewards' }));
+      expect(screen.getByRole('checkbox', { name: 'Rewards' })).toHaveAttribute('aria-checked', 'false');
+      expect(screen.getByRole('checkbox', { name: 'Bonus' })).toHaveAttribute('aria-checked', 'true');
+    });
+  });
+});

--- a/novaRewards/frontend/components/RewardsHistory.js
+++ b/novaRewards/frontend/components/RewardsHistory.js
@@ -114,13 +114,22 @@ function RewardsEmptyState() {
  * RewardsHistory — paginated transaction history with filters and CSV export.
  * Uses the shared DataTable component for consistent sorting, pagination,
  * and URL query string sync.
+ *
+ * @param {{ userId: string, dateFrom?: string, dateTo?: string, onDateChange?: (from: string, to: string) => void }} props
  */
-export default function RewardsHistory({ userId }) {
+export default function RewardsHistory({ userId, dateFrom: externalDateFrom, dateTo: externalDateTo, onDateChange }) {
   const [page, setPage]               = useState(1);
   const [typeFilter, setTypeFilter]   = useState('all');
-  const [dateFrom, setDateFrom]       = useState('');
-  const [dateTo, setDateTo]           = useState('');
+  const [internalDateFrom, setInternalDateFrom] = useState('');
+  const [internalDateTo, setInternalDateTo]     = useState('');
   const [campaignFilter, setCampaignFilter] = useState('all');
+
+  // External props take precedence when provided
+  const dateFrom = externalDateFrom ?? internalDateFrom;
+  const dateTo   = externalDateTo   ?? internalDateTo;
+
+  const setDateFrom = (v) => { setInternalDateFrom(v); onDateChange?.(v, dateTo); };
+  const setDateTo   = (v) => { setInternalDateTo(v);   onDateChange?.(dateFrom, v); };
 
   const filters = {
     limit:  PAGE_SIZE,

--- a/novaRewards/frontend/components/charts/RewardHistorySection.js
+++ b/novaRewards/frontend/components/charts/RewardHistorySection.js
@@ -1,0 +1,79 @@
+'use client';
+
+import { useState, useCallback } from 'react';
+import dynamic from 'next/dynamic';
+import RewardsHistory from '../RewardsHistory';
+
+// Skip SSR — Recharts uses browser APIs
+const RewardsLineChart = dynamic(
+  () => import('../charts/RewardsLineChart'),
+  { ssr: false, loading: () => <div className="h-72 rounded-lg bg-slate-100 dark:bg-brand-border animate-pulse" /> }
+);
+
+/**
+ * RewardHistorySection — chart + transaction list with shared date-filter state.
+ *
+ * Clicking a data point on the chart sets dateFrom/dateTo to that day and
+ * filters the transaction list below. The date inputs in the list also update
+ * the chart's highlighted range via the same state.
+ *
+ * @param {{ userId: string, chartData?: Array<{ date: string, rewards: number, type?: string }> }} props
+ */
+export default function RewardHistorySection({ userId, chartData = [] }) {
+  const [dateFrom, setDateFrom] = useState('');
+  const [dateTo, setDateTo]     = useState('');
+
+  /** Called when the user clicks a data point on the chart. */
+  const handleDateClick = useCallback((date) => {
+    setDateFrom(date);
+    setDateTo(date);
+  }, []);
+
+  /** Called when the user edits the date inputs inside RewardsHistory. */
+  const handleDateChange = useCallback((from, to) => {
+    setDateFrom(from);
+    setDateTo(to);
+  }, []);
+
+  const hasFilter = dateFrom || dateTo;
+
+  return (
+    <div className="space-y-4">
+      {/* Chart */}
+      <div className="rounded-xl border border-slate-200 dark:border-brand-border bg-white dark:bg-brand-card p-4 md:p-6 shadow-sm">
+        <div className="flex items-center justify-between mb-3 gap-2 flex-wrap">
+          <h2 className="text-base font-semibold dark:text-white">📈 Rewards Over Time</h2>
+          {hasFilter && (
+            <button
+              type="button"
+              onClick={() => { setDateFrom(''); setDateTo(''); }}
+              className="text-xs px-2 py-1 rounded border border-slate-200 dark:border-brand-border text-slate-500 dark:text-slate-400 hover:bg-slate-50 dark:hover:bg-brand-border transition-colors"
+              aria-label="Clear date filter"
+            >
+              ✕ Clear filter
+            </button>
+          )}
+        </div>
+        <RewardsLineChart
+          data={chartData}
+          onDateClick={handleDateClick}
+        />
+        {hasFilter && (
+          <p className="text-xs text-slate-400 mt-2 text-center" aria-live="polite">
+            Showing transactions for{' '}
+            {dateFrom === dateTo ? dateFrom : `${dateFrom}${dateTo ? ` – ${dateTo}` : ''}`}
+            . Click another point or clear to reset.
+          </p>
+        )}
+      </div>
+
+      {/* Transaction list — receives the shared date filter */}
+      <RewardsHistory
+        userId={userId}
+        dateFrom={dateFrom}
+        dateTo={dateTo}
+        onDateChange={handleDateChange}
+      />
+    </div>
+  );
+}

--- a/novaRewards/frontend/components/charts/RewardsLineChart.js
+++ b/novaRewards/frontend/components/charts/RewardsLineChart.js
@@ -1,47 +1,189 @@
 'use client';
+
+import { useState, useCallback } from 'react';
 import {
   LineChart, Line, XAxis, YAxis, CartesianGrid, Tooltip,
-  ResponsiveContainer, Legend,
+  ResponsiveContainer, Legend, Brush,
 } from 'recharts';
 import { useChartTheme } from '../analytics/useChartTheme';
 import ChartEmptyState from './ChartEmptyState';
 
+/** Custom tooltip showing date, amount, and transaction type. */
+function CustomTooltip({ active, payload, label }) {
+  if (!active || !payload?.length) return null;
+  return (
+    <div
+      role="tooltip"
+      className="rounded-lg border px-3 py-2 text-sm shadow-lg"
+      style={{
+        background: payload[0]?.payload?._tooltipBg ?? '#fff',
+        borderColor: payload[0]?.payload?._tooltipBorder ?? '#cbd5e1',
+        color: payload[0]?.payload?._tooltipColor ?? '#0f172a',
+        minWidth: 160,
+      }}
+    >
+      <p className="font-semibold mb-1">{label}</p>
+      {payload.map((entry) => (
+        <p key={entry.dataKey} style={{ color: entry.color }}>
+          {entry.name}: <strong>{entry.value?.toLocaleString()}</strong>
+        </p>
+      ))}
+      {payload[0]?.payload?.type && (
+        <p className="mt-1 capitalize opacity-70">Type: {payload[0].payload.type}</p>
+      )}
+    </div>
+  );
+}
+
 /**
- * Line chart for time-series reward data.
- * Handles empty, single-point, and large-number edge cases.
- * Issue #618
+ * Keyboard-accessible legend that toggles series visibility.
+ * Each item is a button so it receives focus and responds to Enter/Space.
  */
-export default function RewardsLineChart({ data = [], loading = false, error = null }) {
-  const { text, grid, tooltip, accent } = useChartTheme();
+function AccessibleLegend({ series, hidden, onToggle, palette }) {
+  return (
+    <ul role="list" className="flex flex-wrap gap-3 justify-center mt-2" aria-label="Chart legend">
+      {series.map((s, i) => {
+        const isHidden = hidden.has(s.key);
+        return (
+          <li key={s.key}>
+            <button
+              type="button"
+              role="checkbox"
+              aria-checked={!isHidden}
+              onClick={() => onToggle(s.key)}
+              onKeyDown={(e) => (e.key === 'Enter' || e.key === ' ') && onToggle(s.key)}
+              className="flex items-center gap-1.5 text-xs rounded px-2 py-1 border transition-opacity focus:outline-none focus-visible:ring-2 focus-visible:ring-offset-1"
+              style={{
+                borderColor: palette[i % palette.length],
+                opacity: isHidden ? 0.4 : 1,
+                color: palette[i % palette.length],
+              }}
+            >
+              <span
+                aria-hidden="true"
+                className="inline-block w-3 h-0.5 rounded"
+                style={{ background: palette[i % palette.length] }}
+              />
+              {s.label}
+            </button>
+          </li>
+        );
+      })}
+    </ul>
+  );
+}
+
+/**
+ * RewardsLineChart — time-series chart with:
+ *  - Custom tooltip (date, amount, type)
+ *  - Brush-based scroll/pinch zoom
+ *  - Click-to-filter callback (onDateClick)
+ *  - Keyboard-accessible legend toggle
+ *
+ * @param {{
+ *   data: Array<{ date: string, rewards?: number, type?: string, [key: string]: any }>,
+ *   series?: Array<{ key: string, label: string }>,
+ *   loading?: boolean,
+ *   error?: string|null,
+ *   onDateClick?: (date: string) => void,
+ * }} props
+ */
+export default function RewardsLineChart({
+  data = [],
+  series,
+  loading = false,
+  error = null,
+  onDateClick,
+}) {
+  const { text, grid, tooltip, accent, palette } = useChartTheme();
+
+  // Default to a single "rewards" series if none provided
+  const resolvedSeries = series ?? [{ key: 'rewards', label: 'Rewards' }];
+
+  const [hidden, setHidden] = useState(new Set());
+
+  const toggleSeries = useCallback((key) => {
+    setHidden((prev) => {
+      const next = new Set(prev);
+      next.has(key) ? next.delete(key) : next.add(key);
+      return next;
+    });
+  }, []);
+
+  // Inject tooltip theme tokens into each data point so CustomTooltip can read them
+  const enriched = data.map((d) => ({
+    ...d,
+    _tooltipBg: tooltip.bg,
+    _tooltipBorder: tooltip.border,
+    _tooltipColor: tooltip.color,
+  }));
+
+  const handleClick = useCallback(
+    (chartData) => {
+      if (onDateClick && chartData?.activePayload?.[0]?.payload?.date) {
+        onDateClick(chartData.activePayload[0].payload.date);
+      }
+    },
+    [onDateClick]
+  );
 
   if (loading) return <ChartEmptyState type="loading" />;
   if (error)   return <ChartEmptyState type="error" message={error} />;
   if (!data.length) return <ChartEmptyState type="empty" />;
 
+  const tickFormatter = (v) =>
+    v >= 1_000_000 ? `${(v / 1_000_000).toFixed(1)}M`
+    : v >= 1_000   ? `${(v / 1_000).toFixed(1)}k`
+    : v;
+
   return (
-    <ResponsiveContainer width="100%" height={260}>
-      <LineChart data={data} margin={{ top: 8, right: 16, left: 0, bottom: 0 }}>
-        <CartesianGrid strokeDasharray="3 3" stroke={grid} />
-        <XAxis dataKey="date" tick={{ fill: text, fontSize: 12 }} />
-        <YAxis
-          tick={{ fill: text, fontSize: 12 }}
-          tickFormatter={(v) => (v >= 1_000_000 ? `${(v / 1_000_000).toFixed(1)}M` : v >= 1_000 ? `${(v / 1_000).toFixed(1)}k` : v)}
-          width={56}
-        />
-        <Tooltip
-          contentStyle={{ background: tooltip.bg, border: `1px solid ${tooltip.border}`, color: tooltip.color }}
-        />
-        <Legend wrapperStyle={{ color: text, fontSize: 12 }} />
-        <Line
-          type="monotone"
-          dataKey="rewards"
-          stroke={accent}
-          strokeWidth={2}
-          dot={data.length === 1 ? { r: 5, fill: accent } : false}
-          activeDot={{ r: 6 }}
-          name="Rewards"
-        />
-      </LineChart>
-    </ResponsiveContainer>
+    <div>
+      <ResponsiveContainer width="100%" height={280}>
+        <LineChart
+          data={enriched}
+          margin={{ top: 8, right: 16, left: 0, bottom: 0 }}
+          onClick={onDateClick ? handleClick : undefined}
+          style={onDateClick ? { cursor: 'pointer' } : undefined}
+        >
+          <CartesianGrid strokeDasharray="3 3" stroke={grid} />
+          <XAxis dataKey="date" tick={{ fill: text, fontSize: 12 }} />
+          <YAxis
+            tick={{ fill: text, fontSize: 12 }}
+            tickFormatter={tickFormatter}
+            width={56}
+          />
+          <Tooltip content={<CustomTooltip />} />
+          {/* Brush provides scroll-to-zoom on desktop and pinch-to-zoom on mobile */}
+          <Brush
+            dataKey="date"
+            height={24}
+            stroke={accent}
+            fill={tooltip.bg}
+            travellerWidth={8}
+            tickFormatter={(v) => v}
+          />
+          {resolvedSeries.map((s, i) => (
+            <Line
+              key={s.key}
+              type="monotone"
+              dataKey={s.key}
+              stroke={palette[i % palette.length]}
+              strokeWidth={2}
+              dot={data.length === 1 ? { r: 5, fill: palette[i % palette.length] } : false}
+              activeDot={{ r: 6 }}
+              name={s.label}
+              hide={hidden.has(s.key)}
+            />
+          ))}
+        </LineChart>
+      </ResponsiveContainer>
+
+      <AccessibleLegend
+        series={resolvedSeries}
+        hidden={hidden}
+        onToggle={toggleSeries}
+        palette={palette}
+      />
+    </div>
   );
 }


### PR DESCRIPTION
Add interactive chart to reward history
  
  Enhances the static RewardsLineChart with full interactivity and wires it to the transaction
  list.
  
  Changes:
  
  - Custom tooltip — hovering a data point shows date, amount, and transaction type
  - Zoom — Brush component enables scroll-to-zoom on desktop and pinch-to-zoom on mobile
  - Click-to-filter — clicking a data point sets the date filter on the transaction list below
  - Accessible legend — series toggle buttons with role="checkbox", aria-checked, and keyboard
  support (Enter/Space)
  - RewardHistorySection — new composite component that owns the shared date state between chart
  and list
  - RewardsHistory — updated to accept external dateFrom/dateTo props (fully backward-compatible)
  - Tests — 17 unit tests covering all interactions
  
  Closes: chart interactions acceptance criteria (tooltips, zoom, click-to-filter, legend toggle,
  keyboard accessibility)

▸ Closes #831 
