### PR TITLE
fix: audit and expand .gitignore for missing entries

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,11 +1,36 @@
 node_modules/
 coverage/
 novaRewards/backend/coverage/
+
+# Environment files
 .env
 .env.local
+.env.*.local
+.env.production
+.env.staging
+.env.development.local
+.env.test.local
+.env.production.local
+
+# Build output
 dist/
 build/
+.next/
+out/
+
+# Rust / Cargo build artifacts
+target/
+**/*.wasm
+
+# IDE
+.idea/
+.vscode/
+!.vscode/extensions.json
+!.vscode/settings.json.example
+
+# OS files
 .DS_Store
+Thumbs.db
 
 # Sentry
 .sentryclirc


### PR DESCRIPTION
Closes #926

## Changes
- Add `.env.production`, `.env.staging`, `.env.*.local` variants
- Add `.next/` and `out/` build output directories
- Add `target/` and `*.wasm` for Rust/Cargo artifacts
- Add `.idea/` and `.vscode/` IDE directories (shared settings kept)
- Add `Thumbs.db` OS file

## Acceptance Criteria
- [x] `.env` files and all variants ignored
- [x] Build output directories (`dist/`, `.next/`, `target/`) ignored
- [x] IDE directories (`.idea/`, `.vscode/` except shared settings) ignored
- [x] OS files (`.DS_Store`, `Thumbs.db`) ignored
- [x] Compiled WASM files and Rust build artifacts ignored