### PR TITLE
feat: configure container registry and image tagging strategy

### DIFF
--- a/.github/workflows/container-registry.yml
+++ b/.github/workflows/container-registry.yml
@@ -1,0 +1,77 @@
+name: Container Registry
+
+on:
+  push:
+    branches: [main]
+    tags: ["v*.*.*"]
+
+env:
+  REGISTRY: ghcr.io
+  BACKEND_IMAGE: ghcr.io/${{ github.repository_owner }}/nova-rewards-backend
+  FRONTEND_IMAGE: ghcr.io/${{ github.repository_owner }}/nova-rewards-frontend
+
+jobs:
+  build-and-push:
+    name: Build & Push Images
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      packages: write
+
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Log in to GitHub Container Registry
+        uses: docker/login-action@v3
+        with:
+          registry: ${{ env.REGISTRY }}
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
+
+      - name: Extract metadata — backend
+        id: meta-backend
+        uses: docker/metadata-action@v5
+        with:
+          images: ${{ env.BACKEND_IMAGE }}
+          tags: |
+            type=sha,prefix=sha-,format=short
+            type=semver,pattern={{version}}
+            type=semver,pattern={{major}}.{{minor}}
+            type=raw,value=latest,enable=${{ startsWith(github.ref, 'refs/tags/v') }}
+
+      - name: Extract metadata — frontend
+        id: meta-frontend
+        uses: docker/metadata-action@v5
+        with:
+          images: ${{ env.FRONTEND_IMAGE }}
+          tags: |
+            type=sha,prefix=sha-,format=short
+            type=semver,pattern={{version}}
+            type=semver,pattern={{major}}.{{minor}}
+            type=raw,value=latest,enable=${{ startsWith(github.ref, 'refs/tags/v') }}
+
+      - name: Build and push backend
+        uses: docker/build-push-action@v5
+        with:
+          context: novaRewards/backend
+          push: true
+          tags: ${{ steps.meta-backend.outputs.tags }}
+          labels: ${{ steps.meta-backend.outputs.labels }}
+          cache-from: type=gha
+          cache-to: type=gha,mode=max
+
+      - name: Build and push frontend
+        uses: docker/build-push-action@v5
+        with:
+          context: novaRewards/frontend
+          push: true
+          tags: ${{ steps.meta-frontend.outputs.tags }}
+          labels: ${{ steps.meta-frontend.outputs.labels }}
+          cache-from: type=gha
+          cache-to: type=gha,mode=max
+          build-args: |
+            NEXT_PUBLIC_API_URL=${{ vars.NEXT_PUBLIC_API_URL }}
+            NEXT_PUBLIC_STELLAR_NETWORK=${{ vars.NEXT_PUBLIC_STELLAR_NETWORK }}


### PR DESCRIPTION
Closes #928

## Changes
- New workflow `.github/workflows/container-registry.yml`
- Pushes backend and frontend images to GitHub Container Registry (`ghcr.io`)
- Tags with short git SHA (`sha-<hash>`) on every merge to `main`
- Tags with semver (`vX.Y.Z`, `X.Y`) on release tags
- Applies `latest` tag only on semver release tags (production-ready)
- Layer caching via GitHub Actions cache

## Acceptance Criteria
- [x] Container registry configured (GitHub Container Registry)
- [x] Images tagged with git SHA and semantic version on release
- [x] `latest` tag only applied to production-ready releases
- [x] CI pipeline pushes images on every merge to `main`
- [x] Uses `GITHUB_TOKEN` for registry auth (no additional secrets needed)