### PR TITLE
Implement GET /api/campaigns endpoint with filtering and pagination (#854)

### DIFF
--- a/src/app.module.ts
+++ b/src/app.module.ts
@@ -1,0 +1,20 @@
+import { Module } from '@nestjs/common';
+import { TypeOrmModule } from '@nestjs/typeorm';
+import { CampaignsModule } from './campaigns/campaigns.module';
+import { AuthModule } from './auth/auth.module';
+import { MerchantsModule } from './merchants/merchants.module';
+
+@Module({
+  imports: [
+    TypeOrmModule.forRoot({
+      type: 'postgres',
+      url: process.env.DATABASE_URL,
+      entities: [__dirname + '/**/*.entity{.ts,.js}'],
+      synchronize: process.env.NODE_ENV !== 'production',
+    }),
+    AuthModule,
+    MerchantsModule,
+    CampaignsModule,
+  ],
+})
+export class AppModule {}

--- a/src/campaigns/__tests__/campaigns.service.spec.ts
+++ b/src/campaigns/__tests__/campaigns.service.spec.ts
@@ -1,0 +1,76 @@
+import { Test, TestingModule } from '@nestjs/testing';
+import { getRepositoryToken } from '@nestjs/typeorm';
+import { CampaignsService } from '../campaigns.service';
+import { Campaign } from '../entities/campaign.entity';
+import { BadRequestException } from '@nestjs/common';
+
+describe('CampaignsService', () => {
+  let service: CampaignsService;
+  let mockRepository: any;
+
+  beforeEach(async () => {
+    mockRepository = {
+      findAndCount: jest.fn(),
+      findOne: jest.fn(),
+    };
+
+    const module: TestingModule = await Test.createTestingModule({
+      providers: [
+        CampaignsService,
+        {
+          provide: getRepositoryToken(Campaign),
+          useValue: mockRepository,
+        },
+      ],
+    }).compile();
+
+    service = module.get<CampaignsService>(CampaignsService);
+  });
+
+  it('should be defined', () => {
+    expect(service).toBeDefined();
+  });
+
+  describe('findAll', () => {
+    it('should return paginated results', async () => {
+      const mockCampaigns = [{ id: '1', title: 'Test Campaign' }];
+      mockRepository.findAndCount.mockResolvedValue([mockCampaigns, 1]);
+
+      const result = await service.findAll({ page: 1, pageSize: 20 });
+      
+      expect(result.data).toEqual(expect.any(Array));
+      expect(result.pagination).toHaveProperty('page', 1);
+      expect(result.pagination).toHaveProperty('total', 1);
+    });
+
+    it('should filter by status', async () => {
+      await service.findAll({ status: 'active', page: 1, pageSize: 20 });
+      
+      expect(mockRepository.findAndCount).toHaveBeenCalledWith(
+        expect.objectContaining({
+          where: expect.objectContaining({ status: 'active' }),
+        })
+      );
+    });
+
+    it('should filter by merchantId', async () => {
+      await service.findAll({ merchantId: 'merchant-123', page: 1, pageSize: 20 });
+      
+      expect(mockRepository.findAndCount).toHaveBeenCalledWith(
+        expect.objectContaining({
+          where: expect.objectContaining({ merchantId: 'merchant-123' }),
+        })
+      );
+    });
+
+    it('should order by createdAt DESC', async () => {
+      await service.findAll({ page: 1, pageSize: 20 });
+      
+      expect(mockRepository.findAndCount).toHaveBeenCalledWith(
+        expect.objectContaining({
+          order: { createdAt: 'DESC' },
+        })
+      );
+    });
+  });
+});

--- a/src/campaigns/campaigns.controller.ts
+++ b/src/campaigns/campaigns.controller.ts
@@ -1,0 +1,53 @@
+import { Controller, Get, Query, Param, UseGuards, BadRequestException, ValidationPipe } from '@nestjs/common';
+import { CampaignsService } from './campaigns.service';
+import { QueryCampaignsDto } from './dto/query-campaigns.dto';
+import { JwtAuthGuard } from '../auth/guards/jwt-auth.guard';
+import { ApiTags, ApiOperation, ApiResponse, ApiBearerAuth, ApiQuery } from '@nestjs/swagger';
+
+@ApiTags('campaigns')
+@Controller('api/campaigns')
+@UseGuards(JwtAuthGuard)
+@ApiBearerAuth()
+export class CampaignsController {
+  constructor(private readonly campaignsService: CampaignsService) {}
+
+  @Get()
+  @ApiOperation({ summary: 'Get all campaigns with filtering and pagination' })
+  @ApiResponse({ status: 200, description: 'Returns paginated campaigns' })
+  @ApiResponse({ status: 400, description: 'Invalid query parameters' })
+  @ApiResponse({ status: 401, description: 'Unauthorized' })
+  @ApiQuery({ name: 'status', required: false, enum: ['draft', 'active', 'paused', 'completed', 'cancelled'] })
+  @ApiQuery({ name: 'merchantId', required: false, type: 'string' })
+  @ApiQuery({ name: 'page', required: false, type: 'number', example: 1 })
+  @ApiQuery({ name: 'pageSize', required: false, type: 'number', example: 20 })
+  async findAll(@Query(new ValidationPipe({ transform: true })) query: QueryCampaignsDto) {
+    try {
+      return await this.campaignsService.findAll(query);
+    } catch (error) {
+      if (error instanceof BadRequestException) {
+        throw error;
+      }
+      throw new BadRequestException('Invalid query parameters');
+    }
+  }
+
+  @Get(':id')
+  @ApiOperation({ summary: 'Get a single campaign by ID' })
+  @ApiResponse({ status: 200, description: 'Returns the campaign' })
+  @ApiResponse({ status: 404, description: 'Campaign not found' })
+  @ApiResponse({ status: 401, description: 'Unauthorized' })
+  async findOne(@Param('id') id: string) {
+    return await this.campaignsService.findOne(id);
+  }
+
+  @Get('merchant/:merchantId')
+  @ApiOperation({ summary: 'Get campaigns by merchant ID' })
+  @ApiResponse({ status: 200, description: 'Returns merchant campaigns' })
+  @ApiResponse({ status: 401, description: 'Unauthorized' })
+  async findByMerchant(
+    @Param('merchantId') merchantId: string,
+    @Query(new ValidationPipe({ transform: true })) query: QueryCampaignsDto,
+  ) {
+    return await this.campaignsService.findByMerchant(merchantId, query);
+  }
+}

--- a/src/campaigns/campaigns.module.ts
+++ b/src/campaigns/campaigns.module.ts
@@ -1,0 +1,13 @@
+import { Module } from '@nestjs/common';
+import { TypeOrmModule } from '@nestjs/typeorm';
+import { CampaignsController } from './campaigns.controller';
+import { CampaignsService } from './campaigns.service';
+import { Campaign } from './entities/campaign.entity';
+
+@Module({
+  imports: [TypeOrmModule.forFeature([Campaign])],
+  controllers: [CampaignsController],
+  providers: [CampaignsService],
+  exports: [CampaignsService],
+})
+export class CampaignsModule {}

--- a/src/campaigns/campaigns.service.ts
+++ b/src/campaigns/campaigns.service.ts
@@ -1,0 +1,81 @@
+import { Injectable, BadRequestException, NotFoundException } from '@nestjs/common';
+import { InjectRepository } from '@nestjs/typeorm';
+import { Repository, Like, FindOptionsWhere, Between } from 'typeorm';
+import { Campaign } from './entities/campaign.entity';
+import { QueryCampaignsDto, CampaignsQueryResult } from './dto/query-campaigns.dto';
+import { CampaignResponseDto } from './dto/campaign-response.dto';
+import { plainToInstance } from 'class-transformer';
+
+@Injectable()
+export class CampaignsService {
+  constructor(
+    @InjectRepository(Campaign)
+    private campaignRepository: Repository<Campaign>,
+  ) {}
+
+  async findAll(query: QueryCampaignsDto): Promise<CampaignsQueryResult> {
+    const { status, merchantId, page = 1, pageSize = 20 } = query;
+    
+    // Build where clause
+    const where: FindOptionsWhere<Campaign> = {};
+    
+    if (status) {
+      where.status = status;
+    }
+    
+    if (merchantId) {
+      where.merchantId = merchantId;
+    }
+    
+    // Calculate skip for pagination
+    const skip = (page - 1) * pageSize;
+    
+    // Execute query with pagination
+    const [data, total] = await this.campaignRepository.findAndCount({
+      where,
+      order: { createdAt: 'DESC' },
+      skip,
+      take: pageSize,
+      relations: ['merchant'],
+    });
+    
+    // Transform to response DTO
+    const transformedData = data.map(campaign => 
+      plainToInstance(CampaignResponseDto, campaign, { excludeExtraneousValues: true })
+    );
+    
+    // Calculate pagination metadata
+    const totalPages = Math.ceil(total / pageSize);
+    const hasNext = page < totalPages;
+    const hasPrev = page > 1;
+    
+    return {
+      data: transformedData,
+      pagination: {
+        page,
+        pageSize,
+        total,
+        totalPages,
+        hasNext,
+        hasPrev,
+      },
+    };
+  }
+
+  async findOne(id: string): Promise<CampaignResponseDto> {
+    const campaign = await this.campaignRepository.findOne({
+      where: { id },
+      relations: ['merchant'],
+    });
+    
+    if (!campaign) {
+      throw new NotFoundException(`Campaign with ID ${id} not found`);
+    }
+    
+    return plainToInstance(CampaignResponseDto, campaign, { excludeExtraneousValues: true });
+  }
+
+  async findByMerchant(merchantId: string, query: QueryCampaignsDto): Promise<CampaignsQueryResult> {
+    return this.findAll({ ...query, merchantId });
+  }
+}

--- a/src/campaigns/dto/campaign-response.dto.ts
+++ b/src/campaigns/dto/campaign-response.dto.ts
@@ -1,0 +1,60 @@
+import { Expose, Transform } from 'class-transformer';
+
+export class CampaignResponseDto {
+  @Expose()
+  id: string;
+
+  @Expose()
+  title: string;
+
+  @Expose()
+  description: string;
+
+  @Expose()
+  merchantId: string;
+
+  @Expose()
+  merchantName?: string;
+
+  @Expose()
+  status: 'draft' | 'active' | 'paused' | 'completed' | 'cancelled';
+
+  @Expose()
+  rewardAmount: string;
+
+  @Expose()
+  totalBudget: string;
+
+  @Expose()
+  remainingBudget: string;
+
+  @Expose()
+  startDate: Date;
+
+  @Expose()
+  endDate: Date;
+
+  @Expose()
+  maxClaims?: number;
+
+  @Expose()
+  totalClaims: number;
+
+  @Expose()
+  createdAt: Date;
+
+  @Expose()
+  updatedAt: Date;
+
+  @Expose()
+  @Transform(({ obj }) => obj.createdAt > new Date(Date.now() - 7 * 24 * 60 * 60 * 1000))
+  isNew?: boolean;
+
+  @Expose()
+  @Transform(({ obj }) => {
+    const now = new Date();
+    const end = new Date(obj.endDate);
+    return end < now ? 'ended' : end < new Date(now.getTime() + 3 * 24 * 60 * 60 * 1000) ? 'ending-soon' : 'active';
+  })
+  statusDisplay?: string;
+}

--- a/src/campaigns/dto/query-campaigns.dto.ts
+++ b/src/campaigns/dto/query-campaigns.dto.ts
@@ -1,0 +1,38 @@
+import { IsOptional, IsString, IsInt, Min, Max, IsIn } from 'class-validator';
+import { Type } from 'class-transformer';
+
+export class QueryCampaignsDto {
+  @IsOptional()
+  @IsString()
+  @IsIn(['draft', 'active', 'paused', 'completed', 'cancelled'])
+  status?: 'draft' | 'active' | 'paused' | 'completed' | 'cancelled';
+
+  @IsOptional()
+  @IsString()
+  merchantId?: string;
+
+  @IsOptional()
+  @Type(() => Number)
+  @IsInt()
+  @Min(1)
+  page?: number = 1;
+
+  @IsOptional()
+  @Type(() => Number)
+  @IsInt()
+  @Min(1)
+  @Max(100)
+  pageSize?: number = 20;
+}
+
+export class CampaignsQueryResult {
+  data: CampaignResponseDto[];
+  pagination: {
+    page: number;
+    pageSize: number;
+    total: number;
+    totalPages: number;
+    hasNext: boolean;
+    hasPrev: boolean;
+  };
+}

--- a/src/campaigns/entities/campaign.entity.ts
+++ b/src/campaigns/entities/campaign.entity.ts
@@ -1,0 +1,54 @@
+import { Entity, Column, PrimaryGeneratedColumn, CreateDateColumn, UpdateDateColumn, ManyToOne, JoinColumn, Index } from 'typeorm';
+import { Merchant } from '../../merchants/entities/merchant.entity';
+
+@Entity('campaigns')
+@Index(['status', 'createdAt'])
+@Index(['merchantId', 'status'])
+@Index(['startDate', 'endDate'])
+export class Campaign {
+  @PrimaryGeneratedColumn('uuid')
+  id: string;
+
+  @Column({ type: 'varchar', length: 255 })
+  title: string;
+
+  @Column({ type: 'text' })
+  description: string;
+
+  @Column({ name: 'merchant_id', type: 'uuid' })
+  merchantId: string;
+
+  @ManyToOne(() => Merchant)
+  @JoinColumn({ name: 'merchant_id' })
+  merchant: Merchant;
+
+  @Column({ type: 'enum', enum: ['draft', 'active', 'paused', 'completed', 'cancelled'], default: 'draft' })
+  status: 'draft' | 'active' | 'paused' | 'completed' | 'cancelled';
+
+  @Column({ name: 'reward_amount', type: 'decimal', precision: 20, scale: 7 })
+  rewardAmount: string;
+
+  @Column({ name: 'total_budget', type: 'decimal', precision: 20, scale: 7 })
+  totalBudget: string;
+
+  @Column({ name: 'remaining_budget', type: 'decimal', precision: 20, scale: 7 })
+  remainingBudget: string;
+
+  @Column({ name: 'start_date', type: 'timestamp' })
+  startDate: Date;
+
+  @Column({ name: 'end_date', type: 'timestamp' })
+  endDate: Date;
+
+  @Column({ name: 'max_claims', type: 'int', nullable: true })
+  maxClaims?: number;
+
+  @Column({ name: 'total_claims', type: 'int', default: 0 })
+  totalClaims: number;
+
+  @CreateDateColumn({ name: 'created_at' })
+  createdAt: Date;
+
+  @UpdateDateColumn({ name: 'updated_at' })
+  updatedAt: Date;
+}

--- a/src/migrations/20260101000000-create-campaigns-table.ts
+++ b/src/migrations/20260101000000-create-campaigns-table.ts
@@ -1,0 +1,34 @@
+import { MigrationInterface, QueryRunner } from 'typeorm';
+
+export class CreateCampaignsTable20260101000000 implements MigrationInterface {
+  public async up(queryRunner: QueryRunner): Promise<void> {
+    await queryRunner.query(`
+      CREATE TABLE IF NOT EXISTS campaigns (
+        id UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+        title VARCHAR(255) NOT NULL,
+        description TEXT NOT NULL,
+        merchant_id UUID NOT NULL REFERENCES merchants(id) ON DELETE CASCADE,
+        status VARCHAR(50) NOT NULL DEFAULT 'draft',
+        reward_amount DECIMAL(20,7) NOT NULL,
+        total_budget DECIMAL(20,7) NOT NULL,
+        remaining_budget DECIMAL(20,7) NOT NULL,
+        start_date TIMESTAMP NOT NULL,
+        end_date TIMESTAMP NOT NULL,
+        max_claims INT,
+        total_claims INT NOT NULL DEFAULT 0,
+        created_at TIMESTAMP NOT NULL DEFAULT NOW(),
+        updated_at TIMESTAMP NOT NULL DEFAULT NOW()
+      );
+    `);
+
+    await queryRunner.query(`
+      CREATE INDEX idx_campaigns_status_created ON campaigns(status, created_at);
+      CREATE INDEX idx_campaigns_merchant_status ON campaigns(merchant_id, status);
+      CREATE INDEX idx_campaigns_dates ON campaigns(start_date, end_date);
+    `);
+  }
+
+  public async down(queryRunner: QueryRunner): Promise<void> {
+    await queryRunner.query(`DROP TABLE IF EXISTS campaigns`);
+  }
+}


### PR DESCRIPTION
## Description
Implements GET /api/campaigns endpoint with filtering by status and merchant, and pagination support.

## Endpoint Features

### Query Parameters
- ✅ status - Filter by campaign status (draft, active, paused, completed, cancelled)
- ✅ merchantId - Filter by merchant ID
- ✅ page - Page number for pagination (default: 1)
- ✅ pageSize - Items per page, max 100 (default: 20)

### Response Structure
```json
{
  "data": [...],
  "pagination": {
    "page": 1,
    "pageSize": 20,
    "total": 100,
    "totalPages": 5,
    "hasNext": true,
    "hasPrev": false
  }
}

Closes #854
