### PR TITLE
feat(ui): Skeleton loading state primitives (#894)

### DIFF
--- a/novaRewards/frontend/components/ui/Skeleton.jsx
+++ b/novaRewards/frontend/components/ui/Skeleton.jsx
@@ -1,0 +1,107 @@
+import React, { useEffect, useState } from 'react';
+
+/** Base shimmer block — composable building block for all skeletons. */
+export function SkeletonBlock({ className = '', style = {} }) {
+  return (
+    <div
+      aria-hidden="true"
+      className={`rounded bg-neutral-200 dark:bg-neutral-700 overflow-hidden relative ${className}`}
+      style={style}
+    >
+      <span className="absolute inset-0 -translate-x-full animate-[shimmer_1.5s_infinite] bg-gradient-to-r from-transparent via-white/40 dark:via-white/10 to-transparent" />
+    </div>
+  );
+}
+
+/**
+ * SkeletonText — one or more lines of text placeholder.
+ * @param {number} lines
+ * @param {string} className  applied to each line
+ */
+export function SkeletonText({ lines = 1, className = '' }) {
+  return (
+    <div role="status" aria-label="Loading text" className="space-y-2">
+      {Array.from({ length: lines }).map((_, i) => (
+        <SkeletonBlock
+          key={i}
+          className={`h-4 ${i === lines - 1 && lines > 1 ? 'w-3/4' : 'w-full'} ${className}`}
+        />
+      ))}
+    </div>
+  );
+}
+
+/**
+ * SkeletonCard — matches the shape of a campaign/reward card.
+ * @param {boolean} showImage
+ */
+export function SkeletonCard({ showImage = true }) {
+  return (
+    <div
+      role="status"
+      aria-label="Loading card"
+      className="rounded-xl border border-neutral-200 dark:border-neutral-700 bg-white dark:bg-neutral-800 p-5 flex flex-col gap-3"
+    >
+      {showImage && <SkeletonBlock className="h-40 w-full rounded-lg" />}
+      <SkeletonBlock className="h-4 w-2/3" />
+      <SkeletonBlock className="h-3 w-full" />
+      <SkeletonBlock className="h-3 w-4/5" />
+      <SkeletonBlock className="h-9 w-full rounded-lg mt-1" />
+    </div>
+  );
+}
+
+/**
+ * SkeletonTable — matches a data table with header + rows.
+ * @param {number} rows
+ * @param {number} cols
+ */
+export function SkeletonTable({ rows = 5, cols = 4 }) {
+  return (
+    <div role="status" aria-label="Loading table" className="w-full">
+      {/* header */}
+      <div className="flex gap-4 px-4 py-3 border-b border-neutral-200 dark:border-neutral-700">
+        {Array.from({ length: cols }).map((_, i) => (
+          <SkeletonBlock key={i} className="h-3 flex-1" />
+        ))}
+      </div>
+      {/* rows */}
+      {Array.from({ length: rows }).map((_, r) => (
+        <div
+          key={r}
+          className="flex gap-4 px-4 py-4 border-b border-neutral-100 dark:border-neutral-800"
+        >
+          {Array.from({ length: cols }).map((_, c) => (
+            <SkeletonBlock key={c} className={`h-4 flex-1 ${c === 0 ? 'w-1/4' : ''}`} />
+          ))}
+        </div>
+      ))}
+    </div>
+  );
+}
+
+/**
+ * withSkeletonTimeout — HOC that shows skeleton for up to 10 s,
+ * then renders an error fallback if content hasn't loaded.
+ *
+ * @param {React.ComponentType} SkeletonComponent
+ * @param {React.ComponentType} ErrorFallback
+ * @param {number} timeout  ms (default 10 000)
+ */
+export function withSkeletonTimeout(SkeletonComponent, ErrorFallback, timeout = 10000) {
+  return function TimedSkeleton({ isLoading, children, ...props }) {
+    const [timedOut, setTimedOut] = useState(false);
+
+    useEffect(() => {
+      if (!isLoading) return;
+      const id = setTimeout(() => setTimedOut(true), timeout);
+      return () => clearTimeout(id);
+    }, [isLoading]);
+
+    if (!isLoading) return children;
+    if (timedOut) return ErrorFallback ? <ErrorFallback /> : <p className="text-sm text-error-600">Failed to load. Please refresh.</p>;
+    return <SkeletonComponent {...props} />;
+  };
+}
+
+export default SkeletonBlock;

--- a/novaRewards/frontend/styles/globals.css
+++ b/novaRewards/frontend/styles/globals.css
@@ -1468,3 +1468,7 @@ td {
     max-width: calc(100vw - 2rem);
   }
 }
+
+@keyframes shimmer {
+  100% { transform: translateX(200%); }
+}


### PR DESCRIPTION
## Summary
Implements reusable skeleton loading primitives to eliminate layout shift and improve perceived performance for async content areas.

## Changes
- **SkeletonBlock** — base shimmer block, fully composable
- **SkeletonText** — 1-N lines of text placeholder, last line 75% width
- **SkeletonCard** — matches campaign/reward card dimensions
- **SkeletonTable** — configurable rows/cols matching data table layout
- **withSkeletonTimeout** — HOC that caps skeleton display at 10 s then shows an error state
- Shimmer animation: left-to-right gradient sweep (`@keyframes shimmer`) added to `globals.css`
- All skeleton containers use `role="status"` + `aria-label` for screen reader announcements
- Exported from `ui/index.js`

## Testing
- Skeletons match content dimensions (no layout shift on transition)
- Shimmer animation runs smoothly
- Timeout fallback renders after 10 s when `isLoading` stays true

Closes #894