### PR TITLE
feat(api): add version routing and policy

### DIFF
--- a/docs/api-spec.yaml
+++ b/docs/api-spec.yaml
@@ -4,10 +4,14 @@ info:
   version: 1.0.0
   description: API documentation for NovaRewards backend
 servers:
+  - url: http://localhost:3001/api/v1
+    description: Local development server (current v1)
+  - url: https://api.novarewards.com/api/v1
+    description: Production server (current v1)
   - url: http://localhost:3001/api
-    description: Local development server
+    description: Local development legacy alias for v1
   - url: https://api.novarewards.com/api
-    description: Production server
+    description: Production legacy alias for v1
 components:
   securitySchemes:
     bearerAuth:

--- a/docs/api/README.md
+++ b/docs/api/README.md
@@ -1,12 +1,30 @@
 # Nova Rewards API Reference
 
-**Base URL:** `http://localhost:3001/api` (dev) · `https://api.novarewards.io/api` (prod)
+**Base URL:** `http://localhost:3001/api/v1` (dev) · `https://api.novarewards.io/api/v1` (prod)
 
-**OpenAPI spec:** [`openapi.json`](./openapi.json) — import into Postman or view at `/api/docs` when the server is running.
+**OpenAPI spec:** [`openapi.json`](./openapi.json) — import into Postman or view at `/api/v1/docs` when the server is running.
+
+**Legacy compatibility:** unversioned `/api/*` routes still resolve to v1 for existing clients, but they now return `Deprecation`, `Sunset`, `X-API-Version`, and `X-API-Migration-Guide` headers. New clients should use `/api/v1/*`.
 
 ---
 
 ## Authentication
+
+## API versioning
+
+NovaRewards uses URL-based API versioning. The current version is `v1`.
+
+| Route | Status | Notes |
+|---|---|---|
+| `/api/v1/*` | Current | Use this for all new integrations. |
+| `/api/*` | Legacy alias for v1 | Backward compatible, deprecated, sunset target `2027-01-01`. |
+| `/api/versions` | Discovery | Returns supported versions, current version, and migration policy. |
+
+Versioned responses include `X-API-Version: v1`. Legacy unversioned responses also include `Deprecation: true`, `Sunset: 2027-01-01`, `X-API-Deprecated: true`, and `X-API-Migration-Guide: /api/versioning`.
+
+Migration from the legacy path is mechanical: prefix existing `/api` URLs with `/api/v1`. For example, `POST /api/auth/login` becomes `POST /api/v1/auth/login`; request bodies, authentication headers, and response schemas are unchanged.
+
+---
 
 ### JWT Bearer (user endpoints)
 

--- a/docs/api/openapi.json
+++ b/docs/api/openapi.json
@@ -13,12 +13,20 @@
   },
   "servers": [
     {
+      "url": "http://localhost:3001/api/v1",
+      "description": "Local development (current v1)"
+    },
+    {
+      "url": "https://api.novarewards.io/api/v1",
+      "description": "Production (current v1)"
+    },
+    {
       "url": "http://localhost:3001/api",
-      "description": "Local development"
+      "description": "Local development legacy alias for v1"
     },
     {
       "url": "https://api.novarewards.io/api",
-      "description": "Production"
+      "description": "Production legacy alias for v1"
     }
   ],
   "components": {

--- a/docs/api/versioning.md
+++ b/docs/api/versioning.md
@@ -1,0 +1,53 @@
+# NovaRewards API Versioning
+
+NovaRewards uses URL versioning for public API stability.
+
+## Current version
+
+- Current version: `v1`
+- Current base URL: `/api/v1`
+- Legacy base URL: `/api`
+
+The unversioned `/api` path remains a backward-compatible alias for `v1`, but new integrations should call `/api/v1`.
+
+## Discovery endpoint
+
+Call `GET /api/versions` or `GET /api/v1/versions` to inspect the current version, supported versions, legacy status, and sunset date.
+
+## Deprecation headers
+
+Requests served through the legacy `/api` path include:
+
+- `X-API-Version: v1`
+- `X-API-Deprecated: true`
+- `Deprecation: true`
+- `Sunset: 2027-01-01`
+- `Link: </api/v1>; rel="successor-version"`
+- `X-API-Migration-Guide: /api/versioning`
+
+Requests served through `/api/v1` include:
+
+- `X-API-Version: v1`
+- `X-API-Deprecated: false`
+
+## Migration guide
+
+Migration is path-only for v1:
+
+| Legacy route | Versioned route |
+|---|---|
+| `POST /api/auth/login` | `POST /api/v1/auth/login` |
+| `GET /api/campaigns` | `GET /api/v1/campaigns` |
+| `GET /api/wallet/balance` | `GET /api/v1/wallet/balance` |
+| `POST /api/webhooks` | `POST /api/v1/webhooks` |
+
+Request payloads, authentication headers, response envelopes, and error formats are unchanged.
+
+## Sunset policy
+
+NovaRewards will keep the legacy `/api` alias available until `2027-01-01`. Before removing or changing a version, the API should:
+
+1. Publish the successor version in OpenAPI servers and API docs.
+2. Return deprecation and sunset headers for the retiring version.
+3. Keep a migration guide with route and schema changes.
+4. Maintain both versions during the announced migration window.

--- a/docs/openapi.json
+++ b/docs/openapi.json
@@ -13,12 +13,20 @@
   },
   "servers": [
     {
+      "url": "http://localhost:3001/api/v1",
+      "description": "Local development (current v1)"
+    },
+    {
+      "url": "https://api.novarewards.io/api/v1",
+      "description": "Production (current v1)"
+    },
+    {
       "url": "http://localhost:3001/api",
-      "description": "Local development"
+      "description": "Local development legacy alias for v1"
     },
     {
       "url": "https://api.novarewards.io/api",
-      "description": "Production"
+      "description": "Production legacy alias for v1"
     }
   ],
   "components": {

--- a/novaRewards/backend/middleware/apiVersioning.js
+++ b/novaRewards/backend/middleware/apiVersioning.js
@@ -1,0 +1,94 @@
+const API_VERSIONS = {
+  current: 'v1',
+  supported: ['v1'],
+  default: 'v1',
+  legacySunset: '2027-01-01',
+};
+
+function applyVersionHeaders(req, res, next) {
+  const version = req.apiVersion || API_VERSIONS.default;
+  res.setHeader('X-API-Version', version);
+
+  if (req.apiDeprecated) {
+    res.setHeader('Deprecation', 'true');
+    res.setHeader('Sunset', API_VERSIONS.legacySunset);
+    res.setHeader('Link', '</api/v1>; rel="successor-version"');
+    res.setHeader('X-API-Deprecated', 'true');
+    res.setHeader('X-API-Migration-Guide', '/api/versioning');
+  } else {
+    res.setHeader('X-API-Deprecated', 'false');
+  }
+
+  next();
+}
+
+function versionedApi(version = API_VERSIONS.current) {
+  return (req, res, next) => {
+    req.apiVersion = version;
+    req.apiDeprecated = false;
+    applyVersionHeaders(req, res, next);
+  };
+}
+
+function legacyApi(req, res, next) {
+  req.apiVersion = API_VERSIONS.default;
+  req.apiDeprecated = true;
+  applyVersionHeaders(req, res, next);
+}
+
+function versionsHandler(req, res) {
+  res.json({
+    success: true,
+    data: {
+      current: API_VERSIONS.current,
+      default: API_VERSIONS.default,
+      supported: API_VERSIONS.supported,
+      routes: {
+        current: `/api/${API_VERSIONS.current}`,
+        legacy: '/api',
+      },
+      deprecation: {
+        legacyApiDeprecated: true,
+        sunset: API_VERSIONS.legacySunset,
+        migrationGuide: '/api/versioning',
+        policy:
+          'Unversioned /api routes remain backward compatible through the sunset date. New integrations should use /api/v1.',
+      },
+    },
+  });
+}
+
+function migrationGuideHandler(req, res) {
+  res.json({
+    success: true,
+    data: {
+      current: API_VERSIONS.current,
+      legacyBasePath: '/api',
+      currentBasePath: `/api/${API_VERSIONS.current}`,
+      sunset: API_VERSIONS.legacySunset,
+      summary:
+        'Prefix legacy /api routes with /api/v1. Request bodies, authentication headers, response envelopes, and error formats are unchanged for v1.',
+      examples: [
+        { from: 'POST /api/auth/login', to: 'POST /api/v1/auth/login' },
+        { from: 'GET /api/campaigns', to: 'GET /api/v1/campaigns' },
+        { from: 'GET /api/wallet/balance', to: 'GET /api/v1/wallet/balance' },
+        { from: 'POST /api/webhooks', to: 'POST /api/v1/webhooks' },
+      ],
+      policy: [
+        'Publish the successor version in OpenAPI servers and API docs.',
+        'Return deprecation and sunset headers for retiring versions.',
+        'Keep migration guidance available during the announced migration window.',
+        'Maintain backward-compatible aliases until the sunset date.',
+      ],
+    },
+  });
+}
+
+module.exports = {
+  API_VERSIONS,
+  applyVersionHeaders,
+  legacyApi,
+  migrationGuideHandler,
+  versionedApi,
+  versionsHandler,
+};

--- a/novaRewards/backend/server.js
+++ b/novaRewards/backend/server.js
@@ -22,6 +22,12 @@ const {
 } = require("./middleware/metricsMiddleware");
 const { tracingMiddleware } = require("./middleware/tracingMiddleware");
 const { globalErrorHandler, notFoundHandler } = require('./middleware/errorHandler');
+const {
+  legacyApi,
+  migrationGuideHandler,
+  versionedApi,
+  versionsHandler,
+} = require('./middleware/apiVersioning');
 
 const app = express();
 
@@ -65,6 +71,8 @@ app.use(require('./middleware/auditMiddleware').auditMiddleware);
 app.use(globalLimiter);
 app.use("/api/auth/login", authLimiter);
 app.use("/api/auth/forgot-password", authLimiter);
+app.use("/api/v1/auth/login", authLimiter);
+app.use("/api/v1/auth/forgot-password", authLimiter);
 
 // Health / readiness checks — /health, /health/detailed, /ready
 app.use('/health', require('./routes/health'));
@@ -80,51 +88,64 @@ app.get("/metrics", async (req, res) => {
   }
 });
 
-// Routes (wired in as they are implemented)
-app.use('/api/auth', require('./routes/auth'));
-app.use('/api/merchants', require('./routes/merchants'));
-app.use('/api/campaigns', require('./routes/campaigns'));
-app.use('/api/campaigns', require('./routes/campaignAnalytics'));
-app.use('/api/rewards', require('./routes/rewards'));
-app.use('/api/redemptions', require('./routes/redemptions'));
-app.use('/api/transactions', require('./routes/transactions'));
-app.use('/api/trustline', require('./routes/trustline'));
-app.use('/api/users', require('./routes/users'));
-app.use('/api/users', require('./routes/onboarding'));
-app.use('/api/contract-events', require('./routes/contractEvents'));
-app.use('/api/admin/email-logs', require('./routes/emailLogs'));
-app.use('/api/leaderboard', require('./routes/leaderboard'));
-app.use('/api/admin', require('./routes/admin'));
-app.use('/api/drops', require('./routes/drops'));
-app.use('/api/analytics', require('./routes/analytics'));
-app.use('/api/notifications', require('./routes/notifications'));
-app.use("/api/auth", require("./routes/auth"));
-app.use("/api/auth", require("./routes/stellarAuth"));
-app.use("/api/merchants", require("./routes/merchants"));
-app.use("/api/campaigns", require("./routes/campaigns"));
-app.use("/api/rewards", require("./routes/rewards"));
-app.use("/api/redemptions", require("./routes/redemptions"));
-app.use("/api/transactions", require("./routes/transactions"));
-app.use("/api/transactions", require("./routes/stellarTransaction"));
-app.use("/api/fee-estimate", require("./routes/feeEstimate"));
-app.use("/api/trustline", require("./routes/trustline"));
-app.use("/api/users", require("./routes/users"));
-app.use("/api/wallet", require("./routes/wallet"));
-app.use("/api/contract-events", require("./routes/contractEvents"));
-app.use("/api/admin/email-logs", require("./routes/emailLogs"));
-app.use("/api/leaderboard", require("./routes/leaderboard"));
-app.use("/api/admin", require("./routes/admin"));
+function buildApiRouter() {
+  const router = express.Router();
 
-// Bull Board UI (requires admin auth)
-// We will mount it using the serverAdapter from jobs/queues.js
-const { serverAdapter } = require('./jobs/queues');
-const { authenticateUser, requireAdmin } = require('./middleware/authenticateUser');
-app.use('/api/admin/queues', authenticateUser, requireAdmin, serverAdapter.getRouter());
-app.use("/api/drops", require("./routes/drops"));
-app.use("/api/search", require("./routes/search"));
-app.use("/api/webhooks", require("./routes/webhooks"));
-app.use("/api/merchants/:id/api-keys", require("./routes/merchantApiKeys"));
-app.use("/api/governance", require("./routes/governance"));
+  // Routes (wired in as they are implemented)
+  router.use('/auth', require('./routes/auth'));
+  router.use('/merchants', require('./routes/merchants'));
+  router.use('/campaigns', require('./routes/campaigns'));
+  router.use('/campaigns', require('./routes/campaignAnalytics'));
+  router.use('/rewards', require('./routes/rewards'));
+  router.use('/redemptions', require('./routes/redemptions'));
+  router.use('/transactions', require('./routes/transactions'));
+  router.use('/trustline', require('./routes/trustline'));
+  router.use('/users', require('./routes/users'));
+  router.use('/users', require('./routes/onboarding'));
+  router.use('/contract-events', require('./routes/contractEvents'));
+  router.use('/admin/email-logs', require('./routes/emailLogs'));
+  router.use('/leaderboard', require('./routes/leaderboard'));
+  router.use('/admin', require('./routes/admin'));
+  router.use('/drops', require('./routes/drops'));
+  router.use('/analytics', require('./routes/analytics'));
+  router.use('/notifications', require('./routes/notifications'));
+  router.use("/auth", require("./routes/auth"));
+  router.use("/auth", require("./routes/stellarAuth"));
+  router.use("/merchants", require("./routes/merchants"));
+  router.use("/campaigns", require("./routes/campaigns"));
+  router.use("/rewards", require("./routes/rewards"));
+  router.use("/redemptions", require("./routes/redemptions"));
+  router.use("/transactions", require("./routes/transactions"));
+  router.use("/transactions", require("./routes/stellarTransaction"));
+  router.use("/fee-estimate", require("./routes/feeEstimate"));
+  router.use("/trustline", require("./routes/trustline"));
+  router.use("/users", require("./routes/users"));
+  router.use("/wallet", require("./routes/wallet"));
+  router.use("/contract-events", require("./routes/contractEvents"));
+  router.use("/admin/email-logs", require("./routes/emailLogs"));
+  router.use("/leaderboard", require("./routes/leaderboard"));
+  router.use("/admin", require("./routes/admin"));
+
+  // Bull Board UI (requires admin auth)
+  // We will mount it using the serverAdapter from jobs/queues.js
+  const { serverAdapter } = require('./jobs/queues');
+  const { authenticateUser, requireAdmin } = require('./middleware/authenticateUser');
+  router.use('/admin/queues', authenticateUser, requireAdmin, serverAdapter.getRouter());
+  router.use("/drops", require("./routes/drops"));
+  router.use("/search", require("./routes/search"));
+  router.use("/webhooks", require("./routes/webhooks"));
+  router.use("/merchants/:id/api-keys", require("./routes/merchantApiKeys"));
+  router.use("/governance", require("./routes/governance"));
+
+  return router;
+}
+
+app.get('/api/versions', legacyApi, versionsHandler);
+app.get('/api/v1/versions', versionedApi('v1'), versionsHandler);
+app.get('/api/versioning', legacyApi, migrationGuideHandler);
+app.get('/api/v1/versioning', versionedApi('v1'), migrationGuideHandler);
+app.use('/api/v1', versionedApi('v1'), buildApiRouter());
+app.use(/^\/api(?!\/v\d+(?:\/|$))/, legacyApi, buildApiRouter());
 
 // Swagger/OpenAPI docs
 const swaggerUi = require("swagger-ui-express");
@@ -132,6 +153,8 @@ const swaggerSpec = require("./swagger");
 if (process.env.NODE_ENV !== "production") {
   app.use("/api/docs", swaggerUi.serve, swaggerUi.setup(swaggerSpec));
   app.get("/api/docs/openapi.json", (req, res) => res.json(swaggerSpec));
+  app.use("/api/v1/docs", swaggerUi.serve, swaggerUi.setup(swaggerSpec));
+  app.get("/api/v1/docs/openapi.json", (req, res) => res.json(swaggerSpec));
 }
 
 // 404 catch-all (must be after all routes)

--- a/novaRewards/backend/swagger.js
+++ b/novaRewards/backend/swagger.js
@@ -14,8 +14,10 @@ const options = {
       license: { name: 'MIT' },
     },
     servers: [
-      { url: 'http://localhost:3001/api', description: 'Local development' },
-      { url: 'https://api.novarewards.io/api', description: 'Production' },
+      { url: 'http://localhost:3001/api/v1', description: 'Local development (current v1)' },
+      { url: 'https://api.novarewards.io/api/v1', description: 'Production (current v1)' },
+      { url: 'http://localhost:3001/api', description: 'Local development legacy alias for v1' },
+      { url: 'https://api.novarewards.io/api', description: 'Production legacy alias for v1' },
     ],
     components: {
       securitySchemes: {

--- a/novaRewards/backend/tests/apiVersioning.test.js
+++ b/novaRewards/backend/tests/apiVersioning.test.js
@@ -1,0 +1,90 @@
+const express = require('express');
+const request = require('supertest');
+const {
+  legacyApi,
+  migrationGuideHandler,
+  versionedApi,
+  versionsHandler,
+} = require('../middleware/apiVersioning');
+
+function buildApp() {
+  const app = express();
+
+  const router = express.Router();
+  router.get('/health', (req, res) => {
+    res.json({ success: true, data: { version: req.apiVersion } });
+  });
+
+  app.get('/api/versions', legacyApi, versionsHandler);
+  app.get('/api/v1/versions', versionedApi('v1'), versionsHandler);
+  app.get('/api/versioning', legacyApi, migrationGuideHandler);
+  app.get('/api/v1/versioning', versionedApi('v1'), migrationGuideHandler);
+  app.use('/api/v1', versionedApi('v1'), router);
+  app.use(/^\/api(?!\/v\d+(?:\/|$))/, legacyApi, router);
+
+  return app;
+}
+
+describe('API versioning middleware', () => {
+  let app;
+
+  beforeEach(() => {
+    app = buildApp();
+  });
+
+  test('serves v1 routes under /api/v1 with current-version headers', async () => {
+    const res = await request(app).get('/api/v1/health').expect(200);
+
+    expect(res.body.data.version).toBe('v1');
+    expect(res.headers['x-api-version']).toBe('v1');
+    expect(res.headers['x-api-deprecated']).toBe('false');
+    expect(res.headers.deprecation).toBeUndefined();
+    expect(res.headers.sunset).toBeUndefined();
+  });
+
+  test('keeps unversioned /api routes backward compatible as deprecated v1', async () => {
+    const res = await request(app).get('/api/health').expect(200);
+
+    expect(res.body.data.version).toBe('v1');
+    expect(res.headers['x-api-version']).toBe('v1');
+    expect(res.headers['x-api-deprecated']).toBe('true');
+    expect(res.headers.deprecation).toBe('true');
+    expect(res.headers.sunset).toBe('2027-01-01');
+    expect(res.headers.link).toBe('</api/v1>; rel="successor-version"');
+    expect(res.headers['x-api-migration-guide']).toBe('/api/versioning');
+  });
+
+  test('exposes version discovery metadata', async () => {
+    const res = await request(app).get('/api/versions').expect(200);
+
+    expect(res.body.success).toBe(true);
+    expect(res.body.data.current).toBe('v1');
+    expect(res.body.data.supported).toEqual(['v1']);
+    expect(res.body.data.routes.current).toBe('/api/v1');
+    expect(res.body.data.deprecation.legacyApiDeprecated).toBe(true);
+    expect(res.headers['x-api-version']).toBe('v1');
+    expect(res.headers['x-api-deprecated']).toBe('true');
+  });
+
+  test('exposes v1 version discovery without legacy deprecation headers', async () => {
+    const res = await request(app).get('/api/v1/versions').expect(200);
+
+    expect(res.body.data.current).toBe('v1');
+    expect(res.headers['x-api-version']).toBe('v1');
+    expect(res.headers['x-api-deprecated']).toBe('false');
+    expect(res.headers.deprecation).toBeUndefined();
+  });
+
+  test('exposes migration guide examples and sunset policy', async () => {
+    const res = await request(app).get('/api/versioning').expect(200);
+
+    expect(res.body.data.currentBasePath).toBe('/api/v1');
+    expect(res.body.data.sunset).toBe('2027-01-01');
+    expect(res.body.data.examples).toContainEqual({
+      from: 'POST /api/auth/login',
+      to: 'POST /api/v1/auth/login',
+    });
+    expect(res.body.data.policy.length).toBeGreaterThan(0);
+    expect(res.headers['x-api-deprecated']).toBe('true');
+  });
+});


### PR DESCRIPTION
Closes #370

## Summary
- add URL-based API versioning with current `/api/v1` routes
- keep legacy `/api` routes backward compatible while returning deprecation, sunset, version, and migration-guide headers
- expose `/api/versions` and `/api/versioning` discovery/migration endpoints
- update Swagger/OpenAPI server URLs and API versioning docs

## Validation
- `npm ci --cache E:\codex-tools\npm-cache --no-audit --no-fund` completed; the outer shell timed out after dependencies were installed, npm log ended with `exit 0` / `info ok`
- `npx vitest run tests/apiVersioning.test.js --coverage.enabled=false` passed 5 tests
- `node --check middleware/apiVersioning.js server.js swagger.js tests/apiVersioning.test.js` passed
- route smoke verified legacy `/api/*` and current `/api/v1/*` headers
- OpenAPI JSON parsed and docs/YAML contain `/api/v1` and legacy aliases