### PR TITLE
feat: background job queue for campaign reward distribution

### DIFF
--- a/novaRewards/backend/jobs/queues.js
+++ b/novaRewards/backend/jobs/queues.js
@@ -36,6 +36,18 @@ const webhookDeliveryQueue = new Queue('webhook-delivery', {
   },
 });
 
+// Campaign-level bulk distribution — one job per distribute request.
+// removeOnComplete/removeOnFailed use count-based retention so GET /api/jobs/:jobId
+// can query results after the job finishes.
+const rewardDistributionQueue = new Queue('reward-distribution', {
+  connection: redisConfig,
+  defaultJobOptions: {
+    attempts: 1,
+    removeOnComplete: { count: 500 },
+    removeOnFailed: { count: 500 },
+  },
+});
+
 // Setup Bull Board
 const serverAdapter = new ExpressAdapter();
 serverAdapter.setBasePath('/api/admin/queues');
@@ -45,6 +57,7 @@ createBullBoard({
     new BullMQAdapter(rewardIssuanceQueue),
     new BullMQAdapter(transactionSubmissionQueue),
     new BullMQAdapter(webhookDeliveryQueue),
+    new BullMQAdapter(rewardDistributionQueue),
   ],
   serverAdapter: serverAdapter,
 });
@@ -53,5 +66,6 @@ module.exports = {
   rewardIssuanceQueue,
   transactionSubmissionQueue,
   webhookDeliveryQueue,
+  rewardDistributionQueue,
   serverAdapter,
 };

--- a/novaRewards/backend/jobs/rewardDistributionWorker.js
+++ b/novaRewards/backend/jobs/rewardDistributionWorker.js
@@ -1,0 +1,52 @@
+'use strict';
+
+const { Worker } = require('bullmq');
+const { processCampaignDistribution } = require('../services/campaignDistributionService');
+const logger = require('../lib/logger');
+
+const connection = {
+  host: process.env.REDIS_HOST || 'localhost',
+  port: parseInt(process.env.REDIS_PORT) || 6379,
+};
+
+const worker = new Worker(
+  'reward-distribution',
+  async (job) => {
+    const { campaignId, recipients, defaultAmount } = job.data;
+
+    logger.info('[DistributionWorker] starting job', {
+      jobId: job.id,
+      campaignId,
+      recipientCount: recipients.length,
+    });
+
+    const result = await processCampaignDistribution({ campaignId, recipients, defaultAmount });
+
+    logger.info('[DistributionWorker] job finished', {
+      jobId: job.id,
+      campaignId,
+      succeeded: result.succeeded.length,
+      failed: result.failed.length,
+    });
+
+    return result;
+  },
+  {
+    connection,
+    concurrency: parseInt(process.env.DISTRIBUTION_WORKER_CONCURRENCY) || 2,
+  },
+);
+
+worker.on('failed', (job, err) => {
+  logger.error('[DistributionWorker] job failed', {
+    jobId: job?.id,
+    campaignId: job?.data?.campaignId,
+    error: err.message,
+  });
+});
+
+worker.on('error', (err) => {
+  logger.error('[DistributionWorker] worker error', { error: err.message });
+});
+
+module.exports = { worker };

--- a/novaRewards/backend/routes/campaigns.js
+++ b/novaRewards/backend/routes/campaigns.js
@@ -18,6 +18,7 @@ const { authenticateMerchant } = require('../middleware/authenticateMerchant');
 const { getNOVABalance } = require('../../blockchain/stellarService');
 const { getRedisClient } = require('../cache/redisClient');
 const { metrics } = require('../middleware/metricsMiddleware');
+const { rewardDistributionQueue } = require('../jobs/queues');
 const {
   validateCreateCampaign,
   validateUpdateCampaign,
@@ -265,6 +266,54 @@ router.get('/', authenticateMerchant, async (req, res, next) => {
     await cacheSet(cacheKey, campaigns);
 
     res.json({ success: true, data: campaigns, cached: false });
+  } catch (err) {
+    next(err);
+  }
+});
+
+// ---------------------------------------------------------------------------
+// POST /campaigns/:id/distribute — enqueue bulk reward distribution job
+// ---------------------------------------------------------------------------
+router.post('/:id/distribute', authenticateMerchant, async (req, res, next) => {
+  try {
+    const id = parseInt(req.params.id, 10);
+    if (isNaN(id) || id <= 0) {
+      return res.status(400).json({ success: false, error: 'validation_error', message: 'id must be a positive integer' });
+    }
+
+    const campaign = await getCampaignById(id);
+    if (!campaign) {
+      return res.status(404).json({ success: false, error: 'not_found', message: 'Campaign not found' });
+    }
+    if (campaign.merchant_id !== req.merchant.id) {
+      return res.status(403).json({ success: false, error: 'forbidden', message: 'Access denied' });
+    }
+
+    const { recipients, amount } = req.body;
+
+    if (!Array.isArray(recipients) || recipients.length === 0) {
+      return res.status(400).json({ success: false, error: 'validation_error', message: 'recipients must be a non-empty array' });
+    }
+
+    for (const r of recipients) {
+      if (typeof r.walletAddress !== 'string' || !r.walletAddress.trim()) {
+        return res.status(400).json({ success: false, error: 'validation_error', message: 'each recipient must have a walletAddress string' });
+      }
+    }
+
+    const defaultAmount = amount ?? campaign.reward_per_action ?? campaign.reward_rate;
+    if (!defaultAmount) {
+      return res.status(400).json({ success: false, error: 'validation_error', message: 'amount is required when the campaign has no default reward_per_action' });
+    }
+
+    const job = await rewardDistributionQueue.add('distribute', {
+      campaignId: id,
+      merchantId: req.merchant.id,
+      recipients,
+      defaultAmount: String(defaultAmount),
+    });
+
+    return res.status(202).json({ success: true, data: { jobId: job.id } });
   } catch (err) {
     next(err);
   }

--- a/novaRewards/backend/routes/jobs.js
+++ b/novaRewards/backend/routes/jobs.js
@@ -1,0 +1,75 @@
+'use strict';
+
+const router = require('express').Router();
+const { rewardDistributionQueue } = require('../jobs/queues');
+const { authenticateMerchant } = require('../middleware/authenticateMerchant');
+
+/**
+ * @openapi
+ * /jobs/{jobId}:
+ *   get:
+ *     tags: [Jobs]
+ *     summary: Get distribution job status
+ *     description: >
+ *       Returns the current state and result of a reward distribution job
+ *       that was enqueued via POST /api/campaigns/:id/distribute.
+ *     security:
+ *       - apiKey: []
+ *     parameters:
+ *       - in: path
+ *         name: jobId
+ *         required: true
+ *         schema:
+ *           type: string
+ *     responses:
+ *       200:
+ *         description: Job status returned.
+ *       404:
+ *         description: Job not found.
+ */
+router.get('/:jobId', authenticateMerchant, async (req, res, next) => {
+  try {
+    const { jobId } = req.params;
+
+    const job = await rewardDistributionQueue.getJob(jobId);
+    if (!job) {
+      return res.status(404).json({ success: false, error: 'not_found', message: 'Job not found' });
+    }
+
+    // Merchants may only query their own distribution jobs
+    if (job.data.merchantId !== req.merchant.id) {
+      return res.status(403).json({ success: false, error: 'forbidden', message: 'Access denied' });
+    }
+
+    const state = await job.getState();
+    const returnValue = job.returnvalue;
+    const failedReason = job.failedReason;
+
+    return res.json({
+      success: true,
+      data: {
+        jobId: job.id,
+        state,
+        campaignId: job.data.campaignId,
+        recipientCount: job.data.recipients?.length ?? 0,
+        ...(returnValue && {
+          succeeded: returnValue.succeeded,
+          failed: returnValue.failed,
+          summary: {
+            total: (returnValue.succeeded?.length ?? 0) + (returnValue.failed?.length ?? 0),
+            succeeded: returnValue.succeeded?.length ?? 0,
+            failed: returnValue.failed?.length ?? 0,
+          },
+        }),
+        ...(failedReason && { failedReason }),
+        createdAt: new Date(job.timestamp).toISOString(),
+        processedAt: job.processedOn ? new Date(job.processedOn).toISOString() : null,
+        finishedAt: job.finishedOn ? new Date(job.finishedOn).toISOString() : null,
+      },
+    });
+  } catch (err) {
+    next(err);
+  }
+});
+
+module.exports = router;

--- a/novaRewards/backend/server.js
+++ b/novaRewards/backend/server.js
@@ -170,6 +170,7 @@ function buildApiRouter() {
   router.use("/webhooks", require("./routes/webhooks"));
   router.use("/merchants/:id/api-keys", require("./routes/merchantApiKeys"));
   router.use("/governance", require("./routes/governance"));
+  router.use("/jobs", require("./routes/jobs"));
 
   return router;
 }
@@ -210,6 +211,8 @@ if (require.main === module) {
     require("./jobs/webhookHandler");
     // Initialize Reward Issuance Worker
     require("./jobs/rewardIssuanceWorker");
+    // Initialize Reward Distribution Worker (bulk campaign distribution)
+    require("./jobs/rewardDistributionWorker");
     logger.info(`NovaRewards backend running on port ${PORT}`);
     console.log(`✅ Health check: http://localhost:${PORT}/health`);
     console.log(`✅ Detailed health: http://localhost:${PORT}/health/detailed`);

--- a/novaRewards/backend/services/campaignDistributionService.js
+++ b/novaRewards/backend/services/campaignDistributionService.js
@@ -1,0 +1,90 @@
+'use strict';
+
+const { distributeRewards } = require('../../blockchain/sendRewards');
+const logger = require('../lib/logger');
+
+const BATCH_SIZE = 50;
+const MAX_RECIPIENT_RETRIES = 3;
+
+/**
+ * Attempts a single transfer, retrying up to MAX_RECIPIENT_RETRIES times on failure.
+ * Returns { walletAddress, txHash } on success or throws the last error.
+ */
+async function transferWithRetry(walletAddress, amount, campaignId) {
+  let lastErr;
+  for (let attempt = 1; attempt <= MAX_RECIPIENT_RETRIES; attempt++) {
+    try {
+      const { txHash } = await distributeRewards({ toWallet: walletAddress, amount: String(amount), campaignId });
+      return { walletAddress, txHash };
+    } catch (err) {
+      lastErr = err;
+      logger.warn('[Distribution] transfer attempt failed', {
+        walletAddress,
+        campaignId,
+        attempt,
+        maxAttempts: MAX_RECIPIENT_RETRIES,
+        error: err.message,
+      });
+    }
+  }
+  throw lastErr;
+}
+
+/**
+ * Processes all recipients for a campaign distribution job.
+ *
+ * Recipients are processed in batches of BATCH_SIZE (50) to stay within
+ * Stellar's rate limits. Each recipient is retried up to MAX_RECIPIENT_RETRIES (3)
+ * times before being counted as permanently failed.
+ *
+ * @param {object} params
+ * @param {number|string} params.campaignId
+ * @param {Array<{walletAddress: string, amount: string}>} params.recipients
+ * @param {string} [params.defaultAmount] - Used when a recipient has no per-recipient amount
+ * @returns {Promise<{succeeded: Array, failed: Array}>}
+ */
+async function processCampaignDistribution({ campaignId, recipients, defaultAmount }) {
+  const succeeded = [];
+  const failed = [];
+
+  for (let batchStart = 0; batchStart < recipients.length; batchStart += BATCH_SIZE) {
+    const batch = recipients.slice(batchStart, batchStart + BATCH_SIZE);
+    const batchIndex = Math.floor(batchStart / BATCH_SIZE) + 1;
+    const totalBatches = Math.ceil(recipients.length / BATCH_SIZE);
+
+    logger.info('[Distribution] processing batch', {
+      campaignId,
+      batchIndex,
+      totalBatches,
+      batchSize: batch.length,
+    });
+
+    await Promise.all(
+      batch.map(async (recipient) => {
+        const amount = recipient.amount ?? defaultAmount;
+        try {
+          const result = await transferWithRetry(recipient.walletAddress, amount, campaignId);
+          succeeded.push(result);
+        } catch (err) {
+          logger.error('[Distribution] recipient permanently failed', {
+            campaignId,
+            walletAddress: recipient.walletAddress,
+            error: err.message,
+          });
+          failed.push({ walletAddress: recipient.walletAddress, error: err.message });
+        }
+      }),
+    );
+  }
+
+  logger.info('[Distribution] job complete', {
+    campaignId,
+    total: recipients.length,
+    succeeded: succeeded.length,
+    failed: failed.length,
+  });
+
+  return { succeeded, failed };
+}
+
+module.exports = { processCampaignDistribution, BATCH_SIZE, MAX_RECIPIENT_RETRIES };


### PR DESCRIPTION
Closes #859

## Summary

- **`POST /api/campaigns/:id/distribute`** — validates campaign ownership, enqueues a BullMQ job, and returns `202 { jobId }` immediately (no more synchronous timeouts for large campaigns)
- **`GET /api/jobs/:jobId`** — merchant-scoped status endpoint; returns job state, per-recipient succeeded/failed arrays, and a summary once complete
- **`rewardDistributionQueue`** (BullMQ) — count-based job retention (500) so results survive worker completion and remain queryable
- **`campaignDistributionService`** — processes recipients in parallel batches of 50 (Stellar rate-limit safe); each recipient retried up to 3× inline before being marked permanently failed; full structured logging on every batch and on completion
- **`rewardDistributionWorker`** — BullMQ worker with configurable concurrency (`DISTRIBUTION_WORKER_CONCURRENCY` env var, default 2); auto-started alongside existing workers in `server.js`
- New queue registered in Bull Board admin UI

## How it works

```
POST /api/campaigns/42/distribute
  { "recipients": [{"walletAddress": "G...", "amount": "10"}], "amount": "10" }

→ 202 { "data": { "jobId": "abc123" } }

GET /api/jobs/abc123
→ 200 { "data": { "state": "completed", "summary": { "total": 1, "succeeded": 1, "failed": 0 }, ... } }
```

## Test plan

- [ ] `POST /api/campaigns/:id/distribute` returns `202` with a `jobId`
- [ ] Missing/empty `recipients` returns `400`
- [ ] Campaign belonging to a different merchant returns `403`
- [ ] `GET /api/jobs/:jobId` for a queued/active/completed job returns correct `state`
- [ ] `GET /api/jobs/:jobId` for a job owned by another merchant returns `403`
- [ ] Worker processes recipients in batches and retries failures (unit: `campaignDistributionService`)
- [ ] Existing campaign CRUD endpoints unaffected