### PR TITLE
docs: add How to Use This Document section to ROADMAP.md

### DIFF
--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -2,6 +2,16 @@
 
 **Last Updated:** `date`
 
+## How to Use This Document
+
+| Step | Action | Description |
+|------|--------|-------------|
+| 1 | **Prioritize** | Review issues and prioritize based on the project roadmap |
+| 2 | **Assign** | Assign issues to team members based on expertise |
+| 3 | **Track** | Use GitHub Issues to track progress with labels per category |
+| 4 | **Update** | Update as issues are completed or new ones are identified |
+| 5 | **Collaborate** | Use as a reference for team discussions and sprint planning |
+
 ## Prioritization
 Issues prioritized by project roadmap (README.md): Smart contracts first (foundational), then backend/frontend.
 


### PR DESCRIPTION
Adds a 'How to Use This Document' section at the top of ROADMAP.md that explains the workflow for using GitHub Issues: prioritize, assign, track, update, and collaborate.

Closes #312 
