### PR TITLE
chore: add Next Steps tracking and label sync workflow

### DIFF
--- a/.github/workflows/sync-labels.yml
+++ b/.github/workflows/sync-labels.yml
@@ -1,0 +1,24 @@
+name: Sync Labels
+
+on:
+  push:
+    branches: [main]
+    paths:
+      - '.github/labels.yml'
+  workflow_dispatch:
+
+jobs:
+  sync-labels:
+    runs-on: ubuntu-latest
+    permissions:
+      issues: write
+      contents: read
+
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Sync labels
+        uses: micnncim/action-label-syncer@v1
+        with:
+          manifest: .github/labels.yml
+          token: ${{ secrets.GITHUB_TOKEN }}

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -2,6 +2,25 @@
 
 **Last Updated:** `date`
 
+## How to Use This Document
+
+| Step | Action | Description |
+|------|--------|-------------|
+| 1 | **Prioritize** | Review issues and prioritize based on the project roadmap |
+| 2 | **Assign** | Assign issues to team members based on expertise |
+| 3 | **Track** | Use GitHub Issues to track progress with labels per category |
+| 4 | **Update** | Update as issues are completed or new ones are identified |
+| 5 | **Collaborate** | Use as a reference for team discussions and sprint planning |
+
+## Next Steps
+
+- [x] Create issue category labels (`.github/labels.yml`) — `frontend`, `backend`, `smart-contract`, `testing`, `devops`, `docs`, `ui-ux`
+- [x] Add label sync workflow (`.github/workflows/sync-labels.yml`) to keep labels in sync with repo
+- [ ] Import tasks from `docs/TASK_BREAKDOWN.md` into GitHub Issues using the appropriate labels
+- [ ] Set up a [GitHub project board](https://docs.github.com/en/issues/planning-and-tracking-with-projects) for tracking work across categories
+- [ ] Assign issues to team members based on expertise
+- [ ] Begin implementation following the prioritized roadmap below
+
 ## Prioritization
 Issues prioritized by project roadmap (README.md): Smart contracts first (foundational), then backend/frontend.
 


### PR DESCRIPTION
Adds:
- .github/workflows/sync-labels.yml — automated label sync on push to main
- ROADMAP.md — Next Steps section with actionable checklist for setting up GitHub Issues infrastructure (labels, project board, issue import, assignments)

Closes #313




