### PR TITLE
feat: implement JWT auth middleware with specific error codes

### DIFF
--- a/novaRewards/backend/middleware/authenticateUser.js
+++ b/novaRewards/backend/middleware/authenticateUser.js
@@ -1,4 +1,5 @@
-const logger = require('./lib/logger');
+const jwt = require('jsonwebtoken');
+const logger = require('../lib/logger');
 const { query } = require('../db/index');
 const { verifyToken, isRevoked } = require('../services/tokenService');
 const AuditService = require('../services/auditService');
@@ -7,7 +8,8 @@ const SecurityAlertService = require('../services/securityAlertService');
 /**
  * Middleware: validates RS256 JWT from Authorization header.
  * Checks Redis blocklist before accepting the token.
- * Attaches the user record to req.user on success.
+ * Attaches { userId, role, walletAddress } (plus full DB row) to req.user on success.
+ * Issue #857 — JWT authentication middleware.
  * Issue #648 — JWT RS256 hardening.
  */
 async function authenticateUser(req, res, next) {
@@ -16,7 +18,7 @@ async function authenticateUser(req, res, next) {
   if (!authHeader || !authHeader.startsWith('Bearer ')) {
     return res.status(401).json({
       success: false,
-      error: 'unauthorized',
+      code: 'TOKEN_MISSING',
       message: 'Bearer token is required in Authorization header',
     });
   }
@@ -26,21 +28,21 @@ async function authenticateUser(req, res, next) {
   try {
     const decoded = verifyToken(token);
 
-    // Reject if jti is in the Redis blocklist
-    if (decoded.jti && await isRevoked(decoded.jti)) {
-      return res.status(401).json({
-        success: false,
-        error: 'unauthorized',
-        message: 'Token has been revoked',
-      });
-    }
-
     // sub = wallet_address (RS256 payload uses sub, not userId)
     if (!decoded || !decoded.sub) {
       return res.status(401).json({
         success: false,
-        error: 'unauthorized',
-        message: 'Invalid token',
+        code: 'TOKEN_INVALID',
+        message: 'Invalid token payload',
+      });
+    }
+
+    // Reject if jti is in the Redis blocklist
+    if (decoded.jti && await isRevoked(decoded.jti)) {
+      return res.status(401).json({
+        success: false,
+        code: 'TOKEN_INVALID',
+        message: 'Token has been revoked',
       });
     }
 
@@ -55,19 +57,31 @@ async function authenticateUser(req, res, next) {
     if (!result.rows[0]) {
       return res.status(401).json({
         success: false,
-        error: 'unauthorized',
+        code: 'TOKEN_INVALID',
         message: 'User not found or account deleted',
       });
     }
 
-    req.user = result.rows[0];
+    const dbUser = result.rows[0];
+    req.user = {
+      ...dbUser,
+      userId: dbUser.id,
+      walletAddress: dbUser.wallet_address,
+    };
     next();
   } catch (err) {
+    if (err instanceof jwt.TokenExpiredError) {
+      return res.status(401).json({
+        success: false,
+        code: 'TOKEN_EXPIRED',
+        message: 'Token has expired',
+      });
+    }
     logger.error('Authentication error:', err);
     return res.status(401).json({
       success: false,
-      error: 'unauthorized',
-      message: 'Invalid or expired token',
+      code: 'TOKEN_INVALID',
+      message: 'Invalid or malformed token',
     });
   }
 }

--- a/novaRewards/backend/tests/authenticateUser.test.js
+++ b/novaRewards/backend/tests/authenticateUser.test.js
@@ -2,10 +2,15 @@
 jest.mock('../db/index', () => ({ query: jest.fn() }));
 jest.mock('../services/tokenService', () => ({
   verifyToken: jest.fn(),
+  isRevoked: jest.fn().mockResolvedValue(false),
 }));
+jest.mock('../lib/logger', () => ({ error: jest.fn(), info: jest.fn() }));
+jest.mock('../services/auditService', () => ({ log: jest.fn().mockResolvedValue(undefined) }));
+jest.mock('../services/securityAlertService', () => ({ send: jest.fn().mockResolvedValue(undefined) }));
 
+const jwt = require('jsonwebtoken');
 const { query } = require('../db/index');
-const { verifyToken } = require('../services/tokenService');
+const { verifyToken, isRevoked } = require('../services/tokenService');
 const { authenticateUser, requireAdmin, requireOwnershipOrAdmin } = require('../middleware/authenticateUser');
 
 function mockReqRes(headers = {}, params = {}, method = 'GET') {
@@ -21,52 +26,98 @@ function mockReqRes(headers = {}, params = {}, method = 'GET') {
 beforeEach(() => jest.clearAllMocks());
 
 describe('authenticateUser', () => {
-  test('returns 401 when no Authorization header', async () => {
+  test('returns 401 with TOKEN_MISSING when no Authorization header', async () => {
     const { req, res, next } = mockReqRes();
     await authenticateUser(req, res, next);
     expect(res.status).toHaveBeenCalledWith(401);
+    expect(res.json).toHaveBeenCalledWith(expect.objectContaining({ code: 'TOKEN_MISSING' }));
     expect(next).not.toHaveBeenCalled();
   });
 
-  test('returns 401 when token verification throws (malformed token)', async () => {
-    verifyToken.mockImplementation(() => { throw new Error('invalid token'); });
+  test('returns 401 with TOKEN_MISSING when Authorization header lacks Bearer prefix', async () => {
+    const { req, res, next } = mockReqRes({ authorization: 'Token abc123' });
+    await authenticateUser(req, res, next);
+    expect(res.status).toHaveBeenCalledWith(401);
+    expect(res.json).toHaveBeenCalledWith(expect.objectContaining({ code: 'TOKEN_MISSING' }));
+  });
+
+  test('returns 401 with TOKEN_EXPIRED when token is expired', async () => {
+    verifyToken.mockImplementation(() => {
+      throw new jwt.TokenExpiredError('jwt expired', new Date());
+    });
+    const { req, res, next } = mockReqRes({ authorization: 'Bearer expired.token.here' });
+    await authenticateUser(req, res, next);
+    expect(res.status).toHaveBeenCalledWith(401);
+    expect(res.json).toHaveBeenCalledWith(expect.objectContaining({ code: 'TOKEN_EXPIRED' }));
+    expect(next).not.toHaveBeenCalled();
+  });
+
+  test('returns 401 with TOKEN_INVALID when token is malformed', async () => {
+    verifyToken.mockImplementation(() => { throw new Error('invalid signature'); });
     const { req, res, next } = mockReqRes({ authorization: 'Bearer bad.token.here' });
     await authenticateUser(req, res, next);
     expect(res.status).toHaveBeenCalledWith(401);
+    expect(res.json).toHaveBeenCalledWith(expect.objectContaining({ code: 'TOKEN_INVALID' }));
+    expect(next).not.toHaveBeenCalled();
   });
 
-  test('returns 401 when user not found in DB', async () => {
-    verifyToken.mockReturnValue({ userId: 999 });
+  test('returns 401 with TOKEN_INVALID when decoded payload has no sub', async () => {
+    verifyToken.mockReturnValue({ role: 'user' }); // missing sub
     const { req, res, next } = mockReqRes({ authorization: 'Bearer valid.token.here' });
-    query.mockResolvedValue({ rows: [] });
     await authenticateUser(req, res, next);
     expect(res.status).toHaveBeenCalledWith(401);
+    expect(res.json).toHaveBeenCalledWith(expect.objectContaining({ code: 'TOKEN_INVALID' }));
   });
 
-  test('attaches user to req and calls next on success', async () => {
-    const user = { id: 1, role: 'user' };
-    verifyToken.mockReturnValue({ userId: 1 });
+  test('returns 401 with TOKEN_INVALID when user not found in DB', async () => {
+    verifyToken.mockReturnValue({ sub: 'WALLET_XYZ' });
+    query.mockResolvedValue({ rows: [] });
     const { req, res, next } = mockReqRes({ authorization: 'Bearer valid.token.here' });
-    query.mockResolvedValue({ rows: [user] });
     await authenticateUser(req, res, next);
-    expect(req.user).toEqual(user);
+    expect(res.status).toHaveBeenCalledWith(401);
+    expect(res.json).toHaveBeenCalledWith(expect.objectContaining({ code: 'TOKEN_INVALID' }));
+  });
+
+  test('returns 401 with TOKEN_INVALID when token jti is revoked', async () => {
+    verifyToken.mockReturnValue({ sub: 'WALLET_XYZ', jti: 'some-jti' });
+    isRevoked.mockResolvedValue(true);
+    const { req, res, next } = mockReqRes({ authorization: 'Bearer revoked.token.here' });
+    await authenticateUser(req, res, next);
+    expect(res.status).toHaveBeenCalledWith(401);
+    expect(res.json).toHaveBeenCalledWith(expect.objectContaining({ code: 'TOKEN_INVALID' }));
+    expect(next).not.toHaveBeenCalled();
+  });
+
+  test('attaches user with userId, role, walletAddress and calls next on success', async () => {
+    const dbUser = { id: 1, role: 'user', wallet_address: 'WALLET_ABC', email: 'a@b.com' };
+    verifyToken.mockReturnValue({ sub: 'WALLET_ABC' });
+    query.mockResolvedValue({ rows: [dbUser] });
+    const { req, res, next } = mockReqRes({ authorization: 'Bearer valid.token.here' });
+    await authenticateUser(req, res, next);
+    expect(req.user).toMatchObject({
+      id: 1,
+      role: 'user',
+      wallet_address: 'WALLET_ABC',
+      userId: 1,
+      walletAddress: 'WALLET_ABC',
+    });
     expect(next).toHaveBeenCalled();
   });
 });
 
 describe('requireAdmin', () => {
-  test('returns 403 for non-admin', () => {
+  test('returns 403 for non-admin', async () => {
     const { req, res, next } = mockReqRes();
-    req.user = { role: 'user' };
-    requireAdmin(req, res, next);
+    req.user = { role: 'user', id: 1 };
+    await requireAdmin(req, res, next);
     expect(res.status).toHaveBeenCalledWith(403);
     expect(next).not.toHaveBeenCalled();
   });
 
-  test('calls next for admin', () => {
+  test('calls next for admin', async () => {
     const { req, res, next } = mockReqRes();
-    req.user = { role: 'admin' };
-    requireAdmin(req, res, next);
+    req.user = { role: 'admin', id: 1 };
+    await requireAdmin(req, res, next);
     expect(next).toHaveBeenCalled();
   });
 });


### PR DESCRIPTION
## Summary

Closes #857

- **TOKEN_MISSING**: returned when the `Authorization` header is absent or doesn't start with `Bearer `
- **TOKEN_EXPIRED**: returned specifically when `jwt.TokenExpiredError` is caught, distinguishing expiry from other failures
- **TOKEN_INVALID**: returned for malformed/bad-signature tokens, missing `sub` in payload, revoked JTIs, or unknown users
- On success, `req.user` now carries `userId` and `walletAddress` camelCase aliases alongside the full DB row, preserving backward compatibility with routes that already access `req.user.id` / `req.user.wallet_address`
- Fixed a pre-existing logger import path bug (`./lib/logger` → `../lib/logger`)

## Test plan

- [ ] `TOKEN_MISSING` test: no header and non-Bearer header both return 401 with correct code
- [ ] `TOKEN_EXPIRED` test: mocked `jwt.TokenExpiredError` thrown by `verifyToken` returns 401 `TOKEN_EXPIRED`
- [ ] `TOKEN_INVALID` test: generic error, missing `sub`, revoked JTI, user not found all return 401 `TOKEN_INVALID`
- [ ] Success test: `req.user` contains `userId`, `role`, `walletAddress` and `next()` is called
- [ ] Existing `requireAdmin` and `requireOwnershipOrAdmin` tests still pass