### PR TITLE
feat: Redis-backed rate limiting for login and token refresh endpoints

### DIFF
--- a/novaRewards/backend/config/constants.js
+++ b/novaRewards/backend/config/constants.js
@@ -30,6 +30,9 @@ const MS_PER_DAY = 24 * MS_PER_HOUR;
 /** Standard sliding-window size used by most rate limiters (60 seconds). */
 const RATE_LIMIT_WINDOW_MS = MS_PER_MINUTE;
 
+/** Longer sliding-window for authentication endpoints (15 minutes). */
+const RL_AUTH_WINDOW_MS = 15 * MS_PER_MINUTE;
+
 // ---------------------------------------------------------------------------
 // Rate-limit max requests (requests per window)
 // ---------------------------------------------------------------------------
@@ -39,6 +42,12 @@ const RL_GLOBAL_MAX = 100;
 
 /** Auth endpoint cap per window (login, forgot-password). */
 const RL_AUTH_MAX = 5;
+
+/** Login endpoint cap per 15-minute window per IP. */
+const RL_LOGIN_MAX = 10;
+
+/** Token refresh endpoint cap per 15-minute window per IP. */
+const RL_REFRESH_MAX = 30;
 
 /** Authenticated-user cap per window. */
 const RL_USER_MAX = 200;
@@ -95,8 +104,11 @@ module.exports = {
   MS_PER_DAY,
   // rate limits
   RATE_LIMIT_WINDOW_MS,
+  RL_AUTH_WINDOW_MS,
   RL_GLOBAL_MAX,
   RL_AUTH_MAX,
+  RL_LOGIN_MAX,
+  RL_REFRESH_MAX,
   RL_USER_MAX,
   RL_SEARCH_MAX,
   RL_WEBHOOK_MAX,

--- a/novaRewards/backend/middleware/rateLimiter.js
+++ b/novaRewards/backend/middleware/rateLimiter.js
@@ -21,9 +21,12 @@ const { client: redisClient } = require('../lib/redis');
 const { slidingRateLimiter } = require('./slidingRateLimiter');
 const {
   RATE_LIMIT_WINDOW_MS,
+  RL_AUTH_WINDOW_MS,
   RATE_LIMIT_RETRY_AFTER_SECS,
   RL_GLOBAL_MAX,
   RL_AUTH_MAX,
+  RL_LOGIN_MAX,
+  RL_REFRESH_MAX,
   RL_USER_MAX,
   RL_SEARCH_MAX,
   RL_WEBHOOK_MAX,
@@ -154,6 +157,28 @@ const slidingAdmin = slidingRateLimiter({
   keyBy:    'user',
 });
 
+// ---------------------------------------------------------------------------
+// Auth-specific sliding-window limiters (15-minute window) — Issue #861
+// ---------------------------------------------------------------------------
+
+/** Login endpoint: 10 attempts per 15 minutes per IP. */
+const loginLimiter = slidingRateLimiter({
+  prefix:   'sw:login',
+  windowMs: RL_AUTH_WINDOW_MS,
+  max:      parseInt(process.env.RL_LOGIN_MAX) || RL_LOGIN_MAX,
+  keyBy:    'ip',
+  message:  `Too many login attempts. Retry after ${Math.ceil(RL_AUTH_WINDOW_MS / 1000)} seconds.`,
+});
+
+/** Token refresh endpoint: 30 attempts per 15 minutes per IP. */
+const refreshLimiter = slidingRateLimiter({
+  prefix:   'sw:refresh',
+  windowMs: RL_AUTH_WINDOW_MS,
+  max:      parseInt(process.env.RL_REFRESH_MAX) || RL_REFRESH_MAX,
+  keyBy:    'ip',
+  message:  `Too many token refresh attempts. Retry after ${Math.ceil(RL_AUTH_WINDOW_MS / 1000)} seconds.`,
+});
+
 module.exports = {
   // fixed-window (legacy)
   globalLimiter,
@@ -167,4 +192,7 @@ module.exports = {
   webhookApiKeyLimiter,
   slidingRewards,
   slidingAdmin,
+  // auth-specific (15-minute window)
+  loginLimiter,
+  refreshLimiter,
 };

--- a/novaRewards/backend/server.js
+++ b/novaRewards/backend/server.js
@@ -15,7 +15,7 @@ const {
 } = require("./jobs/leaderboardCacheWarmer");
 const { startDailyLoginBonusJob } = require("./jobs/dailyLoginBonus");
 const { startWebhookRetryJob } = require("./jobs/webhookRetry");
-const { globalLimiter, authLimiter } = require("./middleware/rateLimiter");
+const { globalLimiter, authLimiter, loginLimiter, refreshLimiter } = require("./middleware/rateLimiter");
 const {
   metricsMiddleware,
   registry,
@@ -72,11 +72,15 @@ app.use(require('./middleware/auditMiddleware').auditMiddleware);
 
 // JSON parse errors are handled by globalErrorHandler below
 
-// Rate limiting — fixed-window global baseline
+// Rate limiting — fixed-window global baseline (100 req/min per IP)
 app.use(globalLimiter);
-app.use("/api/auth/login", authLimiter);
+
+// Auth-specific sliding-window limiters (15-minute window, Redis-backed)
+app.use("/api/auth/login",           loginLimiter);   // 10 req/15min per IP
+app.use("/api/v1/auth/login",        loginLimiter);
+app.use("/api/auth/refresh",         refreshLimiter); // 30 req/15min per IP
+app.use("/api/v1/auth/refresh",      refreshLimiter);
 app.use("/api/auth/forgot-password", authLimiter);
-app.use("/api/v1/auth/login", authLimiter);
 app.use("/api/v1/auth/forgot-password", authLimiter);
 
 // Health / readiness checks — /health, /health/detailed, /ready

--- a/novaRewards/backend/tests/rateLimiter.test.js
+++ b/novaRewards/backend/tests/rateLimiter.test.js
@@ -1,6 +1,6 @@
 // Feature: Rate Limiter middleware
-// Validates: Requirements #187
-// Asserts 429 + Retry-After on (n+1)th request for both global and auth limiters.
+// Validates: Requirements #187, Issue #861
+// Asserts 429 + Retry-After on (n+1)th request for all limiters.
 
 const request = require('supertest');
 const express = require('express');
@@ -10,7 +10,7 @@ const express = require('express');
 // We override the store with the in-memory default by NOT passing a store,
 // which is what express-rate-limit uses when no store is provided.
 // ---------------------------------------------------------------------------
-function buildApp({ globalMax, authMax }) {
+function buildApp({ globalMax, authMax, loginMax, refreshMax }) {
   const rateLimit = require('express-rate-limit');
 
   const globalLimiter = rateLimit({
@@ -35,14 +35,39 @@ function buildApp({ globalMax, authMax }) {
     },
   });
 
+  const loginLimiterInstance = loginMax != null ? rateLimit({
+    windowMs: 900_000, // 15 minutes
+    max: loginMax,
+    standardHeaders: true,
+    legacyHeaders: false,
+    handler: (req, res) => {
+      res.setHeader('Retry-After', '900');
+      res.status(429).json({ success: false, error: 'too_many_requests' });
+    },
+  }) : null;
+
+  const refreshLimiterInstance = refreshMax != null ? rateLimit({
+    windowMs: 900_000, // 15 minutes
+    max: refreshMax,
+    standardHeaders: true,
+    legacyHeaders: false,
+    handler: (req, res) => {
+      res.setHeader('Retry-After', '900');
+      res.status(429).json({ success: false, error: 'too_many_requests' });
+    },
+  }) : null;
+
   const app = express();
   app.use(globalLimiter);
+  if (loginLimiterInstance) app.use('/api/auth/login', loginLimiterInstance);
+  if (refreshLimiterInstance) app.use('/api/auth/refresh', refreshLimiterInstance);
   app.use('/api/auth/login', authLimiter);
   app.use('/api/auth/forgot-password', authLimiter);
 
   app.get('/api/health', (req, res) => res.json({ ok: true }));
   app.post('/api/auth/login', (req, res) => res.json({ ok: true }));
   app.post('/api/auth/forgot-password', (req, res) => res.json({ ok: true }));
+  app.post('/api/auth/refresh', (req, res) => res.json({ ok: true }));
 
   return app;
 }
@@ -144,6 +169,106 @@ describe('Auth rate limiter (5 req / 60 s)', () => {
       await request(app).post('/api/auth/login');
     }
     // Non-auth route should still be reachable (global limit not hit)
+    const res = await request(app).get('/api/health');
+    expect(res.status).toBe(200);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Login limiter — 10 req / 15 min per IP (Issue #861)
+// ---------------------------------------------------------------------------
+describe('Login rate limiter (10 req / 15 min per IP)', () => {
+  const LOGIN_MAX = 3; // small cap for speed
+  let app;
+
+  beforeEach(() => {
+    jest.resetModules();
+    app = buildApp({ globalMax: 100, authMax: 100, loginMax: LOGIN_MAX });
+  });
+
+  test('allows exactly LOGIN_MAX requests to /api/auth/login', async () => {
+    for (let i = 0; i < LOGIN_MAX; i++) {
+      const res = await request(app).post('/api/auth/login');
+      expect(res.status).toBe(200);
+    }
+  });
+
+  test('returns 429 on (LOGIN_MAX+1)th request to /api/auth/login', async () => {
+    for (let i = 0; i < LOGIN_MAX; i++) {
+      await request(app).post('/api/auth/login');
+    }
+    const res = await request(app).post('/api/auth/login');
+    expect(res.status).toBe(429);
+    expect(res.body.error).toBe('too_many_requests');
+    expect(res.body.success).toBe(false);
+  });
+
+  test('login 429 includes Retry-After header set to 15-minute window', async () => {
+    for (let i = 0; i <= LOGIN_MAX; i++) {
+      await request(app).post('/api/auth/login');
+    }
+    const res = await request(app).post('/api/auth/login');
+    expect(res.headers['retry-after']).toBe('900');
+  });
+
+  test('login limiter does not affect /api/auth/refresh', async () => {
+    for (let i = 0; i < LOGIN_MAX + 2; i++) {
+      await request(app).post('/api/auth/login');
+    }
+    const res = await request(app).post('/api/auth/refresh');
+    expect(res.status).toBe(200);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Refresh limiter — 30 req / 15 min per IP (Issue #861)
+// ---------------------------------------------------------------------------
+describe('Token refresh rate limiter (30 req / 15 min per IP)', () => {
+  const REFRESH_MAX = 3; // small cap for speed
+  let app;
+
+  beforeEach(() => {
+    jest.resetModules();
+    app = buildApp({ globalMax: 100, authMax: 100, refreshMax: REFRESH_MAX });
+  });
+
+  test('allows exactly REFRESH_MAX requests to /api/auth/refresh', async () => {
+    for (let i = 0; i < REFRESH_MAX; i++) {
+      const res = await request(app).post('/api/auth/refresh');
+      expect(res.status).toBe(200);
+    }
+  });
+
+  test('returns 429 on (REFRESH_MAX+1)th request to /api/auth/refresh', async () => {
+    for (let i = 0; i < REFRESH_MAX; i++) {
+      await request(app).post('/api/auth/refresh');
+    }
+    const res = await request(app).post('/api/auth/refresh');
+    expect(res.status).toBe(429);
+    expect(res.body.error).toBe('too_many_requests');
+    expect(res.body.success).toBe(false);
+  });
+
+  test('refresh 429 includes Retry-After header set to 15-minute window', async () => {
+    for (let i = 0; i <= REFRESH_MAX; i++) {
+      await request(app).post('/api/auth/refresh');
+    }
+    const res = await request(app).post('/api/auth/refresh');
+    expect(res.headers['retry-after']).toBe('900');
+  });
+
+  test('refresh limiter does not affect /api/auth/login', async () => {
+    for (let i = 0; i < REFRESH_MAX + 2; i++) {
+      await request(app).post('/api/auth/refresh');
+    }
+    const res = await request(app).post('/api/auth/login');
+    expect(res.status).toBe(200);
+  });
+
+  test('refresh limiter does not affect non-auth routes', async () => {
+    for (let i = 0; i < REFRESH_MAX + 2; i++) {
+      await request(app).post('/api/auth/refresh');
+    }
     const res = await request(app).get('/api/health');
     expect(res.status).toBe(200);
   });


### PR DESCRIPTION
## Summary

Closes #861

- **Login endpoint** (`POST /api/auth/login`, `/api/v1/auth/login`): 10 requests per 15 minutes per IP — enforced by a new `loginLimiter` using the existing sliding-window Redis infrastructure
- **Token refresh endpoint** (`POST /api/auth/refresh`, `/api/v1/auth/refresh`): 30 requests per 15 minutes per IP — enforced by a new `refreshLimiter`
- **429 responses** include a `Retry-After: 900` header (15-minute window in seconds)
- **Redis-backed counters** (sorted-set per IP key) survive server restarts; falls back to fail-open if Redis is unavailable so legitimate traffic is never blocked by infrastructure issues
- **General API** (100 req/min per IP) remains handled by the existing `globalLimiter`

## Changes

| File | What changed |
|------|-------------|
| `config/constants.js` | Added `RL_AUTH_WINDOW_MS` (900,000 ms), `RL_LOGIN_MAX` (10), `RL_REFRESH_MAX` (30) |
| `middleware/rateLimiter.js` | Added `loginLimiter` and `refreshLimiter` sliding-window instances; exported both |
| `server.js` | Wired `loginLimiter` and `refreshLimiter` before route handlers for both `/api` and `/api/v1` prefixes |
| `tests/rateLimiter.test.js` | Added describe blocks for login and refresh limiters: allow-up-to-max, block-on-exceed, Retry-After value, endpoint isolation |

## Test plan

- [ ] Login allows exactly 10 requests per window, 11th gets 429
- [ ] Refresh allows exactly 30 requests per window, 31st gets 429
- [ ] Both 429 responses include `Retry-After: 900`
- [ ] Exhausting login limit does not affect `/auth/refresh` and vice versa
- [ ] Exhausting either auth limit does not affect `/health` or other non-auth routes
- [ ] Rate limit counters persist in Redis across server restarts