### PR TITLE
feat: GET /api/transactions with cursor-based pagination

### DIFF
--- a/novaRewards/backend/db/transactionRepository.js
+++ b/novaRewards/backend/db/transactionRepository.js
@@ -495,6 +495,74 @@ async function getTransactionReport(filters = {}) {
 }
 
 /**
+ * Cursor-paginated transaction history scoped to an authenticated user's wallet.
+ * Issue #866 — GET /api/transactions
+ *
+ * Cursor is a base64-encoded JSON string: { createdAt, id }
+ *
+ * @param {string} walletAddress
+ * @param {{ limit?: number, cursor?: string, direction?: 'asc'|'desc' }} opts
+ * @returns {Promise<{ data: object[], nextCursor: string|null, hasMore: boolean }>}
+ */
+async function getUserTransactionsCursor(walletAddress, { limit = 25, cursor, direction = 'desc' } = {}) {
+  const safeLimit = Math.min(Math.max(1, parseInt(limit, 10) || 25), 100);
+  const isAsc = direction === 'asc';
+  const params = [walletAddress];
+  let cursorClause = '';
+
+  if (cursor) {
+    try {
+      const decoded = JSON.parse(Buffer.from(cursor, 'base64').toString('utf8'));
+      const { createdAt, id } = decoded;
+      if (createdAt && id) {
+        params.push(createdAt, parseInt(id, 10));
+        cursorClause = isAsc
+          ? `AND (t.created_at, t.id) > ($${params.length - 1}::timestamptz, $${params.length})`
+          : `AND (t.created_at, t.id) < ($${params.length - 1}::timestamptz, $${params.length})`;
+      }
+    } catch (_) {
+      // invalid cursor — start from beginning
+    }
+  }
+
+  const orderDir = isAsc ? 'ASC' : 'DESC';
+
+  const result = await query(
+    `SELECT t.id,
+            t.tx_hash,
+            t.tx_type,
+            t.amount,
+            t.from_wallet,
+            t.to_wallet,
+            t.status,
+            t.created_at,
+            t.updated_at,
+            c.name AS campaign_name,
+            c.id   AS campaign_id
+     FROM transactions t
+     LEFT JOIN campaigns c ON t.campaign_id = c.id
+     WHERE (t.from_wallet = $1 OR t.to_wallet = $1)
+       ${cursorClause}
+     ORDER BY t.created_at ${orderDir}, t.id ${orderDir}
+     LIMIT $${params.length + 1}`,
+    [...params, safeLimit + 1]
+  );
+
+  const rows = result.rows;
+  const hasMore = rows.length > safeLimit;
+  const data = hasMore ? rows.slice(0, safeLimit) : rows;
+
+  const nextCursor = hasMore
+    ? Buffer.from(JSON.stringify({
+        createdAt: data[data.length - 1].created_at,
+        id: data[data.length - 1].id,
+      })).toString('base64')
+    : null;
+
+  return { data, nextCursor, hasMore };
+}
+
+/**
  * Cursor-based rewards history for a user.
  * Cursor is the base64-encoded `created_at::id` of the last seen row.
  *
@@ -555,6 +623,7 @@ module.exports = {
   getTransactionsByUser,
   getTransactionHistory,
   getRewardsHistoryCursor,
+  getUserTransactionsCursor,
   updateTransaction,
   processRefund,
   reconcileTransactions,

--- a/novaRewards/backend/routes/transactions.js
+++ b/novaRewards/backend/routes/transactions.js
@@ -1,7 +1,8 @@
-const logger = require('./lib/logger');
+const logger = require('../lib/logger');
 const router = require('express').Router();
 const { authenticateMerchant } = require('../middleware/authenticateMerchant');
-const { getMerchantTotals } = require('../db/transactionRepository');
+const { authenticateUser } = require('../middleware/authenticateUser');
+const { getMerchantTotals, getUserTransactionsCursor } = require('../db/transactionRepository');
 const {
   recordTransaction,
   getWalletHistory,
@@ -183,6 +184,64 @@ router.get('/user/history', async (req, res, next) => {
     const result = await getUserHistory(req.query);
     res.json({ success: true, data: result.data, total: result.total, page: result.page, limit: result.limit });
   } catch (err) { next(err); }
+});
+
+/**
+ * @openapi
+ * /transactions:
+ *   get:
+ *     tags: [Transactions]
+ *     summary: Get cursor-paginated transaction history for the authenticated user
+ *     security:
+ *       - bearerAuth: []
+ *     parameters:
+ *       - name: cursor
+ *         in: query
+ *         schema: { type: string }
+ *         description: Opaque base64 cursor from a previous response
+ *       - name: limit
+ *         in: query
+ *         schema: { type: integer, default: 25, maximum: 100 }
+ *       - name: direction
+ *         in: query
+ *         schema: { type: string, enum: [asc, desc], default: desc }
+ *     responses:
+ *       200:
+ *         description: Paginated transactions
+ *         content:
+ *           application/json:
+ *             schema:
+ *               type: object
+ *               properties:
+ *                 success: { type: boolean }
+ *                 data: { type: array, items: { $ref: '#/components/schemas/Transaction' } }
+ *                 nextCursor: { type: string, nullable: true }
+ *                 hasMore: { type: boolean }
+ *       401:
+ *         description: Unauthorized
+ */
+router.get('/', authenticateUser, async (req, res, next) => {
+  try {
+    const { cursor, direction = 'desc' } = req.query;
+    const limit = Math.min(Math.max(1, parseInt(req.query.limit) || 25), 100);
+
+    if (direction !== 'asc' && direction !== 'desc') {
+      return res.status(400).json({
+        success: false,
+        error: 'validation_error',
+        message: "direction must be 'asc' or 'desc'",
+      });
+    }
+
+    const { data, nextCursor, hasMore } = await getUserTransactionsCursor(
+      req.user.wallet_address,
+      { limit, cursor, direction }
+    );
+
+    return res.json({ success: true, data, nextCursor, hasMore });
+  } catch (err) {
+    next(err);
+  }
 });
 
 router.get('/:walletAddress', async (req, res, next) => {

--- a/novaRewards/backend/tests/userTransactionsCursor.test.js
+++ b/novaRewards/backend/tests/userTransactionsCursor.test.js
@@ -1,0 +1,227 @@
+/**
+ * Tests for GET /api/transactions — cursor-paginated transaction history.
+ * Issue #866
+ *
+ * Covers:
+ *  - getUserTransactionsCursor repository function
+ *  - GET / route (auth, params, response shape)
+ */
+
+// ---------------------------------------------------------------------------
+// Repository unit tests
+// ---------------------------------------------------------------------------
+jest.mock('../db/index', () => ({ query: jest.fn() }));
+jest.mock('../lib/redis', () => ({ client: { del: jest.fn(), isOpen: false } }));
+jest.mock('../lib/logger', () => ({ error: jest.fn(), warn: jest.fn(), info: jest.fn() }));
+
+const { query } = require('../db/index');
+const { getUserTransactionsCursor } = require('../db/transactionRepository');
+
+function makeRows(n, startId = 1) {
+  return Array.from({ length: n }, (_, i) => ({
+    id: startId + i,
+    tx_hash: `hash${startId + i}`,
+    tx_type: 'distribution',
+    amount: '10',
+    from_wallet: 'WALLET_A',
+    to_wallet: null,
+    status: 'completed',
+    created_at: new Date(`2024-01-${String(startId + i).padStart(2, '0')}T00:00:00Z`),
+    updated_at: new Date(),
+    campaign_name: null,
+    campaign_id: null,
+  }));
+}
+
+function encodeCursor(createdAt, id) {
+  return Buffer.from(JSON.stringify({ createdAt, id })).toString('base64');
+}
+
+beforeEach(() => jest.clearAllMocks());
+
+describe('getUserTransactionsCursor', () => {
+  test('returns empty data and hasMore=false when no transactions exist', async () => {
+    query.mockResolvedValue({ rows: [] });
+    const result = await getUserTransactionsCursor('WALLET_A', { limit: 10 });
+    expect(result.data).toEqual([]);
+    expect(result.nextCursor).toBeNull();
+    expect(result.hasMore).toBe(false);
+  });
+
+  test('returns data with hasMore=false when results fit within limit', async () => {
+    query.mockResolvedValue({ rows: makeRows(3) });
+    const result = await getUserTransactionsCursor('WALLET_A', { limit: 5 });
+    expect(result.data).toHaveLength(3);
+    expect(result.hasMore).toBe(false);
+    expect(result.nextCursor).toBeNull();
+  });
+
+  test('sets hasMore=true and nextCursor when more results exist', async () => {
+    // limit=3 → fetch limit+1=4 rows → indicates more pages
+    query.mockResolvedValue({ rows: makeRows(4) });
+    const result = await getUserTransactionsCursor('WALLET_A', { limit: 3 });
+    expect(result.data).toHaveLength(3);
+    expect(result.hasMore).toBe(true);
+    expect(result.nextCursor).not.toBeNull();
+  });
+
+  test('nextCursor decodes to { createdAt, id } of the last returned row', async () => {
+    const rows = makeRows(4);
+    query.mockResolvedValue({ rows });
+    const result = await getUserTransactionsCursor('WALLET_A', { limit: 3 });
+    const decoded = JSON.parse(Buffer.from(result.nextCursor, 'base64').toString('utf8'));
+    expect(decoded).toHaveProperty('createdAt');
+    expect(decoded).toHaveProperty('id');
+    expect(decoded.id).toBe(rows[2].id); // 3rd row (index 2) is the last returned
+  });
+
+  test('applies cursor for desc direction (get older items)', async () => {
+    const cursor = encodeCursor('2024-01-05T00:00:00.000Z', 5);
+    query.mockResolvedValue({ rows: makeRows(2, 3) });
+    await getUserTransactionsCursor('WALLET_A', { limit: 5, cursor, direction: 'desc' });
+    const callArgs = query.mock.calls[0];
+    expect(callArgs[0]).toContain('< (');
+    expect(callArgs[1]).toContain('2024-01-05T00:00:00.000Z');
+  });
+
+  test('applies cursor for asc direction (get newer items)', async () => {
+    const cursor = encodeCursor('2024-01-01T00:00:00.000Z', 1);
+    query.mockResolvedValue({ rows: makeRows(2, 2) });
+    await getUserTransactionsCursor('WALLET_A', { limit: 5, cursor, direction: 'asc' });
+    const callArgs = query.mock.calls[0];
+    expect(callArgs[0]).toContain('> (');
+  });
+
+  test('ignores an invalid cursor and starts from beginning', async () => {
+    query.mockResolvedValue({ rows: makeRows(2) });
+    const result = await getUserTransactionsCursor('WALLET_A', { limit: 5, cursor: 'not-valid-base64!!' });
+    expect(result.data).toHaveLength(2);
+    const callArgs = query.mock.calls[0];
+    expect(callArgs[0]).not.toContain('AND (t.created_at');
+  });
+
+  test('caps limit at 100', async () => {
+    query.mockResolvedValue({ rows: [] });
+    await getUserTransactionsCursor('WALLET_A', { limit: 9999 });
+    const callArgs = query.mock.calls[0];
+    // safeLimit+1 = 101 is the last param
+    expect(callArgs[1][callArgs[1].length - 1]).toBe(101);
+  });
+
+  test('scopes query by wallet address via from_wallet OR to_wallet', async () => {
+    query.mockResolvedValue({ rows: [] });
+    await getUserTransactionsCursor('WALLET_XYZ', { limit: 10 });
+    const callArgs = query.mock.calls[0];
+    expect(callArgs[0]).toContain('from_wallet = $1 OR t.to_wallet = $1');
+    expect(callArgs[1][0]).toBe('WALLET_XYZ');
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Route integration tests
+// ---------------------------------------------------------------------------
+jest.mock('../middleware/authenticateUser', () => ({
+  authenticateUser: (req, _res, next) => {
+    req.user = { id: 1, wallet_address: 'WALLET_A', role: 'user' };
+    next();
+  },
+  requireAdmin: (_req, _res, next) => next(),
+  requireOwnershipOrAdmin: (_req, _res, next) => next(),
+}));
+
+jest.mock('../middleware/authenticateMerchant', () => ({
+  authenticateMerchant: (req, _res, next) => { req.merchant = { id: 1 }; next(); },
+}));
+
+jest.mock('../db/transactionRepository', () => ({
+  getMerchantTotals: jest.fn(),
+  getUserTransactionsCursor: jest.fn(),
+  recordTransaction: jest.fn(),
+  getTransactionsByUser: jest.fn(),
+  getTransactionsByMerchant: jest.fn(),
+}));
+
+jest.mock('../services/transactionService', () => ({
+  recordTransaction: jest.fn(),
+  getWalletHistory: jest.fn(),
+  getUserHistory: jest.fn(),
+  getMerchantHistory: jest.fn(),
+  refundTransaction: jest.fn(),
+  reconcileMerchantTransactions: jest.fn(),
+  getMerchantTransactionReport: jest.fn(),
+}));
+
+jest.mock('../middleware/validateEnv', () => ({ validateEnv: jest.fn() }));
+
+const request = require('supertest');
+const express = require('express');
+const { getUserTransactionsCursor: mockGetCursor } = require('../db/transactionRepository');
+
+function buildApp() {
+  const app = express();
+  app.use(express.json());
+  app.use('/api/transactions', require('../routes/transactions'));
+  app.use((err, _req, res, _next) => res.status(err.status || 500).json({ error: err.message }));
+  return app;
+}
+
+describe('GET /api/transactions', () => {
+  let app;
+
+  beforeAll(() => { app = buildApp(); });
+  beforeEach(() => jest.clearAllMocks());
+
+  test('returns 200 with { data, nextCursor, hasMore }', async () => {
+    mockGetCursor.mockResolvedValue({ data: [], nextCursor: null, hasMore: false });
+    const res = await request(app).get('/api/transactions');
+    expect(res.status).toBe(200);
+    expect(res.body.success).toBe(true);
+    expect(res.body).toHaveProperty('data');
+    expect(res.body).toHaveProperty('nextCursor');
+    expect(res.body).toHaveProperty('hasMore');
+  });
+
+  test('returns empty array (not 404) when no transactions exist', async () => {
+    mockGetCursor.mockResolvedValue({ data: [], nextCursor: null, hasMore: false });
+    const res = await request(app).get('/api/transactions');
+    expect(res.status).toBe(200);
+    expect(res.body.data).toEqual([]);
+    expect(res.body.hasMore).toBe(false);
+  });
+
+  test('passes cursor and limit to repository', async () => {
+    mockGetCursor.mockResolvedValue({ data: [], nextCursor: null, hasMore: false });
+    const cursor = Buffer.from(JSON.stringify({ createdAt: '2024-01-01', id: 1 })).toString('base64');
+    await request(app).get(`/api/transactions?cursor=${cursor}&limit=10`);
+    expect(mockGetCursor).toHaveBeenCalledWith('WALLET_A', expect.objectContaining({
+      limit: 10,
+      cursor,
+    }));
+  });
+
+  test('passes direction=asc to repository', async () => {
+    mockGetCursor.mockResolvedValue({ data: [], nextCursor: null, hasMore: false });
+    await request(app).get('/api/transactions?direction=asc');
+    expect(mockGetCursor).toHaveBeenCalledWith('WALLET_A', expect.objectContaining({ direction: 'asc' }));
+  });
+
+  test('returns 400 for invalid direction', async () => {
+    const res = await request(app).get('/api/transactions?direction=sideways');
+    expect(res.status).toBe(400);
+    expect(res.body.error).toBe('validation_error');
+  });
+
+  test('caps limit at 100', async () => {
+    mockGetCursor.mockResolvedValue({ data: [], nextCursor: null, hasMore: false });
+    await request(app).get('/api/transactions?limit=9999');
+    expect(mockGetCursor).toHaveBeenCalledWith('WALLET_A', expect.objectContaining({ limit: 100 }));
+  });
+
+  test('returns nextCursor and hasMore=true when more pages exist', async () => {
+    const nextCursor = Buffer.from(JSON.stringify({ createdAt: '2024-01-01', id: 5 })).toString('base64');
+    mockGetCursor.mockResolvedValue({ data: [{ id: 5 }], nextCursor, hasMore: true });
+    const res = await request(app).get('/api/transactions?limit=1');
+    expect(res.body.hasMore).toBe(true);
+    expect(res.body.nextCursor).toBe(nextCursor);
+  });
+});


### PR DESCRIPTION
## Summary

Closes #866

- New `GET /api/transactions` endpoint (protected by `authenticateUser`) returns the authenticated user's transaction history using cursor-based pagination
- Results are scoped to `req.user.wallet_address` via `from_wallet OR to_wallet` matching
- Returns `{ success, data, nextCursor, hasMore }` — empty array (not 404) when no transactions exist

## Pagination design

| Query param | Default | Notes |
|---|---|---|
| `cursor` | — | Opaque base64 JSON `{ createdAt, id }` from prior `nextCursor` |
| `limit` | 25 | Clamped to [1, 100] |
| `direction` | `desc` | `desc` = newest-first; `asc` = oldest-first |

The composite `(created_at, id)` cursor avoids offset drift on concurrent inserts. Invalid cursors are silently treated as start-of-list.

## Files changed

| File | Change |
|---|---|
| `db/transactionRepository.js` | New `getUserTransactionsCursor(walletAddress, opts)` function |
| `routes/transactions.js` | New `GET /` handler with auth; fixed logger import path |
| `tests/userTransactionsCursor.test.js` | New test file — repository logic + route behaviour |

## Test plan

- [ ] `GET /api/transactions` without auth → 401
- [ ] `GET /api/transactions` with valid token, no transactions → 200, `data: []`, `hasMore: false`
- [ ] `GET /api/transactions?limit=2` with 3 records → 200, `hasMore: true`, `nextCursor` present
- [ ] Pass `nextCursor` as `cursor` → returns next page
- [ ] `direction=asc` → oldest first
- [ ] `direction=sideways` → 400 `validation_error`
- [ ] `limit=9999` → capped to 100
- [ ] Invalid/garbage `cursor` value → ignored, returns from start