### PR TITLE
feat: implement webhook delivery for campaign events

### DIFF
--- a/apps/api/src/webhooks/tests/webhook.service.spec.ts
+++ b/apps/api/src/webhooks/tests/webhook.service.spec.ts
@@ -1,0 +1,86 @@
+import { Test, TestingModule } from '@nestjs/testing';
+import { WebhookService } from '../webhook.service';
+import { getRepositoryToken } from '@nestjs/typeorm';
+import { Webhook } from '../webhook.entity';
+import { WebhookDelivery } from '../webhook-delivery.entity';
+
+describe('WebhookService', () => {
+  let service: WebhookService;
+
+  const mockWebhookRepository = {
+    create: jest.fn(),
+    save: jest.fn(),
+    find: jest.fn(),
+    findOne: jest.fn(),
+    count: jest.fn(),
+    update: jest.fn(),
+  };
+
+  const mockDeliveryRepository = {
+    create: jest.fn(),
+    save: jest.fn(),
+    find: jest.fn(),
+  };
+
+  beforeEach(async () => {
+    const module: TestingModule = await Test.createTestingModule({
+      providers: [
+        WebhookService,
+        {
+          provide: getRepositoryToken(Webhook),
+          useValue: mockWebhookRepository,
+        },
+        {
+          provide: getRepositoryToken(WebhookDelivery),
+          useValue: mockDeliveryRepository,
+        },
+      ],
+    }).compile();
+
+    service = module.get<WebhookService>(WebhookService);
+  });
+
+  it('should be defined', () => {
+    expect(service).toBeDefined();
+  });
+
+  describe('registerWebhook', () => {
+    it('should register a new webhook', async () => {
+      const mockWebhook = {
+        id: '123',
+        merchantId: 'merchant123',
+        url: 'https://example.com/webhook',
+        secret: 'secret123',
+        isActive: true,
+      };
+
+      mockWebhookRepository.count.mockResolvedValue(0);
+      mockWebhookRepository.create.mockReturnValue(mockWebhook);
+      mockWebhookRepository.save.mockResolvedValue(mockWebhook);
+
+      const result = await service.registerWebhook(
+        'merchant123',
+        'https://example.com/webhook',
+      );
+
+      expect(result).toEqual(mockWebhook);
+      expect(mockWebhookRepository.count).toHaveBeenCalled();
+    });
+
+    it('should throw error if more than 5 webhooks', async () => {
+      mockWebhookRepository.count.mockResolvedValue(5);
+
+      await expect(
+        service.registerWebhook('merchant123', 'https://example.com/webhook'),
+      ).rejects.toThrow('Maximum of 5 webhook URLs allowed');
+    });
+
+    it('should throw error for invalid URL', async () => {
+      mockWebhookRepository.count.mockResolvedValue(0);
+
+      await expect(
+        service.registerWebhook('merchant123', 'invalid-url'),
+      ).rejects.toThrow('Invalid URL format');
+    });
+  });
+});

--- a/apps/api/src/webhooks/webhook-delivery.entity.ts
+++ b/apps/api/src/webhooks/webhook-delivery.entity.ts
@@ -1,0 +1,42 @@
+import { Entity, Column, PrimaryGeneratedColumn, CreateDateColumn, ManyToOne, JoinColumn } from 'typeorm';
+import { Webhook } from './webhook.entity';
+
+@Entity('webhook_deliveries')
+export class WebhookDelivery {
+  @PrimaryGeneratedColumn('uuid')
+  id: string;
+
+  @Column()
+  webhookId: string;
+
+  @ManyToOne(() => Webhook)
+  @JoinColumn({ name: 'webhookId' })
+  webhook: Webhook;
+
+  @Column()
+  eventType: string; // 'distribution.completed', 'campaign.cap_reached', etc.
+
+  @Column({ type: 'jsonb' })
+  payload: Record<string, any>;
+
+  @Column({ nullable: true })
+  responseStatus: number;
+
+  @Column({ nullable: true, type: 'text' })
+  responseBody: string;
+
+  @Column({ nullable: true })
+  responseTimeMs: number;
+
+  @Column({ default: 0 })
+  attemptCount: number;
+
+  @Column({ default: false })
+  success: boolean;
+
+  @Column({ nullable: true })
+  errorMessage: string;
+
+  @CreateDateColumn()
+  createdAt: Date;
+}

--- a/apps/api/src/webhooks/webhook.controller.ts
+++ b/apps/api/src/webhooks/webhook.controller.ts
@@ -1,0 +1,126 @@
+import { Controller, Post, Get, Body, Param, Delete, UseGuards, Request, Query } from '@nestjs/common';
+import { ApiTags, ApiOperation, ApiResponse, ApiBearerAuth } from '@nestjs/swagger';
+import { WebhookService } from './webhook.service';
+import { JwtAuthGuard } from '../auth/guards/jwt-auth.guard';
+import { IsUrl, IsOptional, IsNumber } from 'class-validator';
+
+class RegisterWebhookDto {
+  @IsUrl()
+  url: string;
+}
+
+class GetDeliveriesDto {
+  @IsOptional()
+  @IsNumber()
+  limit?: number;
+}
+
+@ApiTags('webhooks')
+@Controller('webhooks')
+@UseGuards(JwtAuthGuard)
+@ApiBearerAuth('JWT-auth')
+export class WebhookController {
+  constructor(private readonly webhookService: WebhookService) {}
+
+  @Post()
+  @ApiOperation({ summary: 'Register a new webhook URL' })
+  @ApiResponse({
+    status: 201,
+    description: 'Webhook registered successfully',
+  })
+  @ApiResponse({
+    status: 400,
+    description: 'Invalid URL or too many webhooks',
+  })
+  async registerWebhook(
+    @Request() req: any,
+    @Body() body: RegisterWebhookDto,
+  ) {
+    const merchantId = req.user.merchantId;
+    const webhook = await this.webhookService.registerWebhook(
+      merchantId,
+      body.url,
+    );
+
+    return {
+      success: true,
+      message: 'Webhook registered successfully',
+      webhook: {
+        id: webhook.id,
+        url: webhook.url,
+        secret: webhook.secret,
+        isActive: webhook.isActive,
+        createdAt: webhook.createdAt,
+      },
+    };
+  }
+
+  @Get()
+  @ApiOperation({ summary: 'Get all webhooks for merchant' })
+  @ApiResponse({
+    status: 200,
+    description: 'Webhooks retrieved successfully',
+  })
+  async getWebhooks(@Request() req: any) {
+    const merchantId = req.user.merchantId;
+    const webhooks = await this.webhookService.getMerchantWebhooks(merchantId);
+
+    return {
+      success: true,
+      webhooks,
+    };
+  }
+
+  @Delete(':id')
+  @ApiOperation({ summary: 'Delete a webhook' })
+  @ApiResponse({
+    status: 200,
+    description: 'Webhook deleted successfully',
+  })
+  @ApiResponse({
+    status: 404,
+    description: 'Webhook not found',
+  })
+  async deleteWebhook(
+    @Param('id') webhookId: string,
+    @Request() req: any,
+  ) {
+    const merchantId = req.user.merchantId;
+    await this.webhookService.deleteWebhook(webhookId, merchantId);
+
+    return {
+      success: true,
+      message: 'Webhook deleted successfully',
+    };
+  }
+
+  @Get(':id/deliveries')
+  @ApiOperation({ summary: 'Get delivery history for a webhook' })
+  @ApiResponse({
+    status: 200,
+    description: 'Delivery history retrieved successfully',
+  })
+  @ApiResponse({
+    status: 404,
+    description: 'Webhook not found',
+  })
+  async getDeliveryHistory(
+    @Param('id') webhookId: string,
+    @Request() req: any,
+    @Query() query: GetDeliveriesDto,
+  ) {
+    const merchantId = req.user.merchantId;
+    const limit = query.limit || 50;
+    const deliveries = await this.webhookService.getDeliveryHistory(
+      webhookId,
+      merchantId,
+      limit,
+    );
+
+    return {
+      success: true,
+      deliveries,
+      count: deliveries.length,
+    };
+  }
+}

--- a/apps/api/src/webhooks/webhook.entity.ts
+++ b/apps/api/src/webhooks/webhook.entity.ts
@@ -1,0 +1,39 @@
+import { Entity, Column, PrimaryGeneratedColumn, CreateDateColumn, UpdateDateColumn, ManyToOne, JoinColumn } from 'typeorm';
+import { Merchant } from '../merchants/merchant.entity';
+
+@Entity('webhooks')
+export class Webhook {
+  @PrimaryGeneratedColumn('uuid')
+  id: string;
+
+  @Column()
+  merchantId: string;
+
+  @ManyToOne(() => Merchant)
+  @JoinColumn({ name: 'merchantId' })
+  merchant: Merchant;
+
+  @Column()
+  url: string;
+
+  @Column({ default: true })
+  isActive: boolean;
+
+  @Column({ nullable: true })
+  secret: string;
+
+  @Column({ default: 0 })
+  failureCount: number;
+
+  @Column({ nullable: true })
+  lastDeliveryAt: Date;
+
+  @Column({ nullable: true })
+  lastDeliveryStatus: number;
+
+  @CreateDateColumn()
+  createdAt: Date;
+
+  @UpdateDateColumn()
+  updatedAt: Date;
+}

--- a/apps/api/src/webhooks/webhook.module.ts
+++ b/apps/api/src/webhooks/webhook.module.ts
@@ -1,0 +1,14 @@
+import { Module } from '@nestjs/common';
+import { TypeOrmModule } from '@nestjs/typeorm';
+import { Webhook } from './webhook.entity';
+import { WebhookDelivery } from './webhook-delivery.entity';
+import { WebhookService } from './webhook.service';
+import { WebhookController } from './webhook.controller';
+
+@Module({
+  imports: [TypeOrmModule.forFeature([Webhook, WebhookDelivery])],
+  providers: [WebhookService],
+  controllers: [WebhookController],
+  exports: [WebhookService],
+})
+export class WebhookModule {}

--- a/apps/api/src/webhooks/webhook.service.ts
+++ b/apps/api/src/webhooks/webhook.service.ts
@@ -1,0 +1,275 @@
+import { Injectable, Logger, BadRequestException, NotFoundException } from '@nestjs/common';
+import { InjectRepository } from '@nestjs/typeorm';
+import { Repository } from 'typeorm';
+import { Webhook } from './webhook.entity';
+import { WebhookDelivery } from './webhook-delivery.entity';
+import * as crypto from 'crypto';
+import axios from 'axios';
+
+@Injectable()
+export class WebhookService {
+  private readonly logger = new Logger(WebhookService.name);
+
+  constructor(
+    @InjectRepository(Webhook)
+    private webhookRepository: Repository<Webhook>,
+    @InjectRepository(WebhookDelivery)
+    private deliveryRepository: Repository<WebhookDelivery>,
+  ) {}
+
+  /**
+   * Register a new webhook URL for a merchant
+   */
+  async registerWebhook(
+    merchantId: string,
+    url: string,
+  ): Promise<Webhook> {
+    // Check if merchant already has 5 webhooks
+    const existingWebhooks = await this.webhookRepository.count({
+      where: { merchantId, isActive: true },
+    });
+
+    if (existingWebhooks >= 5) {
+      throw new BadRequestException(
+        'Maximum of 5 webhook URLs allowed per merchant',
+      );
+    }
+
+    // Validate URL format
+    try {
+      new URL(url);
+    } catch {
+      throw new BadRequestException('Invalid URL format');
+    }
+
+    // Generate a unique secret for this webhook
+    const secret = crypto.randomBytes(32).toString('hex');
+
+    const webhook = this.webhookRepository.create({
+      merchantId,
+      url,
+      secret,
+      isActive: true,
+    });
+
+    return this.webhookRepository.save(webhook);
+  }
+
+  /**
+   * Get all webhooks for a merchant
+   */
+  async getMerchantWebhooks(merchantId: string): Promise<Webhook[]> {
+    return this.webhookRepository.find({
+      where: { merchantId, isActive: true },
+    });
+  }
+
+  /**
+   * Delete a webhook (soft delete by setting isActive: false)
+   */
+  async deleteWebhook(webhookId: string, merchantId: string): Promise<void> {
+    const webhook = await this.webhookRepository.findOne({
+      where: { id: webhookId, merchantId },
+    });
+
+    if (!webhook) {
+      throw new NotFoundException('Webhook not found');
+    }
+
+    webhook.isActive = false;
+    await this.webhookRepository.save(webhook);
+  }
+
+  /**
+   * Deliver an event to all active webhooks for a merchant
+   */
+  async deliverEvent(
+    merchantId: string,
+    eventType: string,
+    payload: Record<string, any>,
+  ): Promise<void> {
+    const webhooks = await this.webhookRepository.find({
+      where: { merchantId, isActive: true },
+    });
+
+    if (webhooks.length === 0) {
+      this.logger.debug(`No active webhooks for merchant ${merchantId}`);
+      return;
+    }
+
+    const deliveryPromises = webhooks.map((webhook) =>
+      this.sendWebhook(webhook, eventType, payload),
+    );
+
+    await Promise.allSettled(deliveryPromises);
+  }
+
+  /**
+   * Send a webhook with retry logic
+   */
+  private async sendWebhook(
+    webhook: Webhook,
+    eventType: string,
+    payload: Record<string, any>,
+  ): Promise<void> {
+    const startTime = Date.now();
+    let attemptCount = 0;
+    let success = false;
+    let lastError: Error | null = null;
+
+    // Retry up to 5 times with exponential backoff
+    while (attemptCount < 5 && !success) {
+      attemptCount++;
+      try {
+        const delivery = await this.sendSingleWebhook(
+          webhook,
+          eventType,
+          payload,
+          attemptCount,
+        );
+        success = delivery.success;
+        lastError = null;
+        break;
+      } catch (error) {
+        lastError = error;
+        this.logger.error(
+          `Webhook delivery failed for ${webhook.url} (attempt ${attemptCount}/5): ${error.message}`,
+        );
+
+        // Exponential backoff: 2^attempt * 1000ms (1s, 2s, 4s, 8s, 16s)
+        if (attemptCount < 5) {
+          const backoffMs = Math.pow(2, attemptCount) * 1000;
+          await this.sleep(backoffMs);
+        }
+      }
+    }
+
+    // Update webhook with last delivery info
+    await this.webhookRepository.update(webhook.id, {
+      lastDeliveryAt: new Date(),
+      lastDeliveryStatus: success ? 200 : 500,
+      failureCount: success ? 0 : webhook.failureCount + 1,
+    });
+
+    if (!success) {
+      this.logger.error(
+        `Webhook ${webhook.url} failed after 5 attempts: ${lastError?.message}`,
+      );
+    }
+  }
+
+  /**
+   * Send a single webhook delivery
+   */
+  private async sendSingleWebhook(
+    webhook: Webhook,
+    eventType: string,
+    payload: Record<string, any>,
+    attemptNumber: number,
+  ): Promise<WebhookDelivery> {
+    const startTime = Date.now();
+
+    // Create the payload to send
+    const deliveryPayload = {
+      event: eventType,
+      timestamp: new Date().toISOString(),
+      data: payload,
+    };
+
+    // Sign the payload
+    const signature = this.signPayload(
+      JSON.stringify(deliveryPayload),
+      webhook.secret,
+    );
+
+    try {
+      const response = await axios.post(webhook.url, deliveryPayload, {
+        headers: {
+          'Content-Type': 'application/json',
+          'X-Webhook-Signature': signature,
+          'X-Webhook-Id': webhook.id,
+          'X-Webhook-Attempt': attemptNumber,
+        },
+        timeout: 10000, // 10 second timeout
+      });
+
+      const responseTimeMs = Date.now() - startTime;
+
+      // Log successful delivery
+      const delivery = await this.deliveryRepository.create({
+        webhookId: webhook.id,
+        eventType,
+        payload,
+        responseStatus: response.status,
+        responseBody: JSON.stringify(response.data),
+        responseTimeMs,
+        attemptCount: attemptNumber,
+        success: true,
+      });
+
+      await this.deliveryRepository.save(delivery);
+      this.logger.debug(`Webhook delivered to ${webhook.url} in ${responseTimeMs}ms`);
+
+      return delivery;
+    } catch (error) {
+      const responseTimeMs = Date.now() - startTime;
+
+      // Log failed delivery
+      const delivery = await this.deliveryRepository.create({
+        webhookId: webhook.id,
+        eventType,
+        payload,
+        responseStatus: error.response?.status || 500,
+        responseBody: error.response?.data || error.message,
+        responseTimeMs,
+        attemptCount: attemptNumber,
+        success: false,
+        errorMessage: error.message,
+      });
+
+      await this.deliveryRepository.save(delivery);
+      throw error;
+    }
+  }
+
+  /**
+   * Sign payload with HMAC-SHA256
+   */
+  private signPayload(payload: string, secret: string): string {
+    return crypto
+      .createHmac('sha256', secret)
+      .update(payload)
+      .digest('hex');
+  }
+
+  /**
+   * Get delivery history for a webhook
+   */
+  async getDeliveryHistory(
+    webhookId: string,
+    merchantId: string,
+    limit: number = 50,
+  ): Promise<WebhookDelivery[]> {
+    // Verify webhook belongs to merchant
+    const webhook = await this.webhookRepository.findOne({
+      where: { id: webhookId, merchantId },
+    });
+
+    if (!webhook) {
+      throw new NotFoundException('Webhook not found');
+    }
+
+    return this.deliveryRepository.find({
+      where: { webhookId },
+      order: { createdAt: 'DESC' },
+      take: limit,
+    });
+  }
+
+  /**
+   * Helper function to sleep
+   */
+  private sleep(ms: number): Promise<void> {
+    return new Promise((resolve) => setTimeout(resolve, ms));
+  }
+}


### PR DESCRIPTION
## Description
This PR implements a webhook delivery system for campaign events.

## Changes
- Merchants can register up to 5 webhook URLs
- Payloads signed with HMAC-SHA256
- Failed deliveries retried 5 times with exponential backoff
- Delivery attempts logged with status and response time
- Delivery history endpoint
- Unit tests

## Acceptance Criteria Met
- [x] Merchants can register up to 5 webhook URLs
- [x] Payloads signed with HMAC-SHA256
- [x] Failed deliveries retried 5 times with exponential backoff
- [x] Delivery attempts logged with status and response time
- [x] Merchants can view delivery history

Closes #870