### PR TITLE
feat(jobs): BullMQ DLQ consumer, Prometheus alerts, and safe reproces…

### DIFF
--- a/novaRewards/backend/jobs/queues.js
+++ b/novaRewards/backend/jobs/queues.js
@@ -2,11 +2,20 @@ const { Queue } = require('bullmq');
 const { createBullBoard } = require('@bull-board/api');
 const { BullMQAdapter } = require('@bull-board/api/bullMQAdapter');
 const { ExpressAdapter } = require('@bull-board/express');
+const rewardIssuanceFailureRepository = require('../repositories/rewardIssuanceFailureRepository');
+const metricsMiddleware = require('../middleware/metricsMiddleware');
 
 const redisConfig = {
   host: process.env.REDIS_HOST || 'localhost',
   port: process.env.REDIS_PORT || 6379,
 };
+
+// ── Prometheus Counter ──────────────────────────────────────────────
+const novaRewardDlqTotal = metricsMiddleware.createCounter(
+  'nova_reward_dlq_total',
+  'Total number of reward issuance jobs moved to DLQ after max retries',
+  ['reason']
+);
 
 // Define queues with specific retry logic
 const rewardIssuanceQueue = new Queue('reward-issuance', {
@@ -15,7 +24,45 @@ const rewardIssuanceQueue = new Queue('reward-issuance', {
     attempts: 3,
     backoff: { type: 'exponential', delay: 1000 },
     removeOnComplete: true,
+    removeOnFail: false, // Keep failed jobs so the DLQ handler can process them
   },
+});
+
+// ── DLQ Event Handler ─────────────────────────────────────────────
+// Persist permanently failed jobs to DB + Prometheus before removing from Redis
+rewardIssuanceQueue.on('failed', async (job, err) => {
+  const maxAttempts = job.opts?.attempts ?? 3;
+  if (job.attemptsMade < maxAttempts) {
+    return; // Will be retried, not DLQ yet
+  }
+
+  const reason = err?.name || err?.message || 'unknown';
+  novaRewardDlqTotal.inc({ reason });
+
+  try {
+    await rewardIssuanceFailureRepository.recordFailure({
+      jobId: job.id,
+      payload: job.data,
+      error: err,
+      attempts: job.attemptsMade,
+    });
+
+    // Remove from Redis to prevent bloat; failure is now in DB
+    await job.remove();
+
+    logger.error('[RewardWorker] job permanently failed — moved to DLQ', {
+      jobId: job.id,
+      attempts: job.attemptsMade,
+      error: err.message,
+    });
+  } catch (dlqErr) {
+    // Critical: DLQ persistence itself failed. Alert immediately.
+    logger.error('[RewardWorker] DLQ-CRITICAL: failed to persist DLQ entry', {
+      jobId: job.id,
+      dlqError: dlqErr.message,
+    });
+    // Do NOT remove job from queue so it doesn't disappear silently
+  }
 });
 
 const transactionSubmissionQueue = new Queue('transaction-submission', {
@@ -68,4 +115,5 @@ module.exports = {
   webhookDeliveryQueue,
   rewardDistributionQueue,
   serverAdapter,
+  novaRewardDlqTotal,
 };

--- a/novaRewards/backend/jobs/rewardIssuanceWorker.js
+++ b/novaRewards/backend/jobs/rewardIssuanceWorker.js
@@ -5,6 +5,7 @@
 
 const { Worker, Queue } = require('bullmq');
 const { processRewardIssuance } = require('../services/rewardIssuanceService');
+const rewardIssuanceRepository = require('../repositories/rewardIssuanceRepository');
 const logger = require('../lib/logger');
 
 const connection = {
@@ -17,7 +18,19 @@ const rewardDLQ = new Queue('reward-issuance-dlq', { connection });
 
 const worker = new Worker(
   'reward-issuance',
-  async (job) => processRewardIssuance(job),
+  async (job) => {
+    // ── Idempotency guard ───────────────────────────────────────
+    const { rewardId } = job.data;
+    if (rewardId) {
+      const existing = await rewardIssuanceRepository.getByRewardId(rewardId);
+      if (existing?.status === 'completed') {
+        logger.info('[RewardWorker] Reward already issued; skipping', { rewardId, jobId: job.id });
+        return { status: 'skipped', rewardId };
+      }
+    }
+
+    return processRewardIssuance(job);
+  },
   {
     connection,
     concurrency: parseInt(process.env.REWARD_WORKER_CONCURRENCY) || 5,
@@ -39,6 +52,14 @@ worker.on('completed', (job) => {
 
 worker.on('error', (err) => {
   logger.error('[RewardWorker] worker error', { error: err.message });
+});
+
+// Graceful shutdown
+process.on('SIGTERM', async () => {
+  logger.info('[RewardWorker] SIGTERM received, closing...');
+  await worker.close();
+  await rewardDLQ.close();
+  process.exit(0);
 });
 
 module.exports = { worker, rewardDLQ };

--- a/novaRewards/backend/migrations/20260717000001_create_reward_issuance_failures.js
+++ b/novaRewards/backend/migrations/20260717000001_create_reward_issuance_failures.js
@@ -1,0 +1,27 @@
+/**
+ * @param { import("knex").Knex } knex
+ * @returns { Promise<void> }
+ */
+exports.up = async function(knex) {
+  await knex.schema.createTable('reward_issuance_failures', (table) => {
+    table.increments('id').primary();
+    table.string('job_id', 64).notNullable().unique().index();
+    table.jsonb('payload').notNullable();
+    table.text('error');
+    table.integer('attempts').notNullable().defaultTo(0);
+    table.timestamp('created_at', { useTz: true }).notNullable().defaultTo(knex.fn.now());
+    table.timestamp('reprocessed_at', { useTz: true });
+    table.string('reprocess_job_id', 64);
+    
+    // Index for querying un-reprocessed failures
+    table.index(['created_at', 'reprocessed_at'], 'idx_failures_pending');
+  });
+};
+
+/**
+ * @param { import("knex").Knex } knex
+ * @returns { Promise<void> }
+ */
+exports.down = async function(knex) {
+  await knex.schema.dropTableIfExists('reward_issuance_failures');
+};

--- a/novaRewards/backend/repositories/rewardIssuanceFailureRepository.js
+++ b/novaRewards/backend/repositories/rewardIssuanceFailureRepository.js
@@ -1,0 +1,74 @@
+const knex = require('../db/knex');
+const { v4: uuidv4 } = require('uuid');
+
+class RewardIssuanceFailureRepository {
+  /**
+   * Persist a failed job to the DLQ table.
+   */
+  async recordFailure({ jobId, payload, error, attempts }) {
+    const existing = await knex('reward_issuance_failures')
+      .where('job_id', jobId)
+      .first();
+    
+    if (existing) {
+      // Idempotent update if already recorded (e.g., duplicate event)
+      return existing;
+    }
+
+    const [record] = await knex('reward_issuance_failures')
+      .insert({
+        job_id: jobId,
+        payload: JSON.stringify(payload),
+        error: error?.message || String(error),
+        attempts,
+        created_at: new Date().toISOString(),
+      })
+      .returning('*');
+
+    return record;
+  }
+
+  /**
+   * Check if a job has already been successfully reprocessed (idempotency).
+   */
+  async isReprocessed(jobId) {
+    const record = await knex('reward_issuance_failures')
+      .where('job_id', jobId)
+      .first();
+    
+    return record?.reprocessed_at != null;
+  }
+
+  /**
+   * Mark a failure as reprocessed.
+   */
+  async markReprocessed(jobId, reprocessJobId) {
+    await knex('reward_issuance_failures')
+      .where('job_id', jobId)
+      .update({
+        reprocessed_at: new Date().toISOString(),
+        reprocess_job_id: reprocessJobId,
+      });
+  }
+
+  /**
+   * Get a single failure by job ID.
+   */
+  async getByJobId(jobId) {
+    return knex('reward_issuance_failures')
+      .where('job_id', jobId)
+      .first();
+  }
+
+  /**
+   * List pending failures (not yet reprocessed), oldest first.
+   */
+  async listPending({ limit = 100 } = {}) {
+    return knex('reward_issuance_failures')
+      .whereNull('reprocessed_at')
+      .orderBy('created_at', 'asc')
+      .limit(limit);
+  }
+}
+
+module.exports = new RewardIssuanceFailureRepository();

--- a/novaRewards/backend/tests/rewardIssuanceWorker.test.js
+++ b/novaRewards/backend/tests/rewardIssuanceWorker.test.js
@@ -1,22 +1,8 @@
-'use strict';
-
-/**
- * Reward Issuance Worker — unit test suite (Vitest)
- *
- * Covers:
- *  - Worker instantiation with correct queue name and processor
- *  - 'failed' event: routes permanently-failed jobs to DLQ
- *  - 'failed' event: does NOT route to DLQ when retries remain
- *  - 'completed' event: logs correctly
- *  - 'error' event: logs worker errors
- *
- * All external dependencies (BullMQ, Redis) are mocked.
- */
-
 import { describe, it, expect, vi, beforeEach } from 'vitest';
 
 // ── Mock BullMQ before requiring the worker module ─────────────────────────
 const mockQueueAdd = vi.fn().mockResolvedValue(true);
+const mockQueueOn = vi.fn();
 const mockWorkerOn = vi.fn();
 const mockWorkerConstructor = vi.fn();
 
@@ -28,12 +14,49 @@ vi.mock('bullmq', () => ({
       opts,
       on: mockWorkerOn,
     };
-    // Simulate event registration by the module
     return worker;
   }),
-  Queue: vi.fn().mockImplementation(() => ({
+  Queue: vi.fn().mockImplementation((queueName, opts) => ({
     add: mockQueueAdd,
+    on: mockQueueOn,
+    name: queueName,
+    opts,
   })),
+}));
+
+// ── Mock repository and metrics ────────────────────────────────────────────
+const mockRecordFailure = vi.fn().mockResolvedValue({ id: 1 });
+const mockIsReprocessed = vi.fn().mockResolvedValue(false);
+const mockMarkReprocessed = vi.fn().mockResolvedValue(true);
+const mockGetByJobId = vi.fn();
+const mockListPending = vi.fn();
+
+vi.mock('../repositories/rewardIssuanceFailureRepository', () => ({
+  default: {
+    recordFailure: mockRecordFailure,
+    isReprocessed: mockIsReprocessed,
+    markReprocessed: mockMarkReprocessed,
+    getByJobId: mockGetByJobId,
+    listPending: mockListPending,
+  },
+}));
+
+const mockCounterInc = vi.fn();
+const mockCreateCounter = vi.fn().mockReturnValue({ inc: mockCounterInc });
+
+vi.mock('../middleware/metricsMiddleware', () => ({
+  default: {
+    createCounter: mockCreateCounter,
+  },
+}));
+
+// ── Mock logger ─────────────────────────────────────────────────────────────
+vi.mock('../lib/logger', () => ({
+  default: {
+    info: vi.fn(),
+    error: vi.fn(),
+    warn: vi.fn(),
+  },
 }));
 
 // ── Imports ─────────────────────────────────────────────────────────────────
@@ -43,13 +66,14 @@ beforeEach(() => {
   vi.clearAllMocks();
 });
 
-// ============================================================================
-// Helper: load the worker module fresh and capture registered handlers
-// ============================================================================
 function loadWorkerModule() {
   vi.resetModules();
-  // Re-require to trigger constructor and event registration
   return import('../jobs/rewardIssuanceWorker.js');
+}
+
+function loadQueuesModule() {
+  vi.resetModules();
+  return import('../jobs/queues.js');
 }
 
 describe('rewardIssuanceWorker', () => {
@@ -89,7 +113,6 @@ describe('rewardIssuanceWorker', () => {
   it('routes permanently-failed job to DLQ after max attempts exhausted', async () => {
     await loadWorkerModule();
 
-    // Extract the failed handler registered by the module
     const failedHandler = mockWorkerOn.mock.calls.find((c) => c[0] === 'failed')?.[1];
     expect(failedHandler).toBeDefined();
 
@@ -194,7 +217,6 @@ describe('rewardIssuanceWorker', () => {
     expect(completedHandler).toBeDefined();
 
     const job = { id: 'job-46' };
-    // Should not throw
     expect(() => completedHandler(job)).not.toThrow();
   });
 
@@ -205,21 +227,105 @@ describe('rewardIssuanceWorker', () => {
     expect(errorHandler).toBeDefined();
 
     const err = new Error('Worker connection lost');
-    // Should not throw
     expect(() => errorHandler(err)).not.toThrow();
   });
 
   it('processor function delegates to processRewardIssuance', async () => {
-    // We can verify the processor exists and is a function by checking constructor args
     await loadWorkerModule();
 
     const processor = mockWorkerConstructor.mock.calls[0][1];
     expect(typeof processor).toBe('function');
-
-    // The processor should be async and accept a job argument
-    // We can't easily test the internal import without mocking the service,
-    // but we verify the signature
-    expect(processor.length).toBe(1); // one argument: job
+    expect(processor.length).toBe(1);
   });
 });
 
+describe('queues.js DLQ persistence', () => {
+  it('creates nova_reward_dlq_total counter on module load', async () => {
+    await loadQueuesModule();
+    expect(mockCreateCounter).toHaveBeenCalledWith(
+      'nova_reward_dlq_total',
+      'Total number of reward issuance jobs moved to DLQ after max retries',
+      ['reason']
+    );
+  });
+
+  it('registers a failed event listener on rewardIssuanceQueue', async () => {
+    await loadQueuesModule();
+    const queueCalls = Queue.mock.results;
+    // The first Queue instantiation is reward-issuance
+    expect(mockQueueOn).toHaveBeenCalledWith('failed', expect.any(Function));
+  });
+
+  it('persists permanently failed job to DB and increments counter', async () => {
+    await loadQueuesModule();
+
+    const failedHandler = mockQueueOn.mock.calls.find((c) => c[0] === 'failed')?.[1];
+    expect(failedHandler).toBeDefined();
+
+    const job = {
+      id: 'job-dlq-99',
+      attemptsMade: 3,
+      opts: { attempts: 3 },
+      data: { rewardId: 'r-99', amount: '500' },
+      remove: vi.fn().mockResolvedValue(true),
+    };
+    const err = new Error('Stellar timeout');
+
+    await failedHandler(job, err);
+
+    expect(mockCounterInc).toHaveBeenCalledWith({ reason: 'Stellar timeout' });
+    expect(mockRecordFailure).toHaveBeenCalledWith({
+      jobId: 'job-dlq-99',
+      payload: { rewardId: 'r-99', amount: '500' },
+      error: err,
+      attempts: 3,
+    });
+    expect(job.remove).toHaveBeenCalled();
+  });
+
+  it('does NOT persist when retries remain', async () => {
+    await loadQueuesModule();
+
+    const failedHandler = mockQueueOn.mock.calls.find((c) => c[0] === 'failed')?.[1];
+    expect(failedHandler).toBeDefined();
+
+    const job = {
+      id: 'job-dlq-98',
+      attemptsMade: 1,
+      opts: { attempts: 3 },
+      data: { rewardId: 'r-98' },
+      remove: vi.fn().mockResolvedValue(true),
+    };
+    const err = new Error('Temporary');
+
+    await failedHandler(job, err);
+
+    expect(mockCounterInc).not.toHaveBeenCalled();
+    expect(mockRecordFailure).not.toHaveBeenCalled();
+    expect(job.remove).not.toHaveBeenCalled();
+  });
+
+  it('does NOT remove job when DB persistence fails', async () => {
+    await loadQueuesModule();
+
+    const failedHandler = mockQueueOn.mock.calls.find((c) => c[0] === 'failed')?.[1];
+    expect(failedHandler).toBeDefined();
+
+    mockRecordFailure.mockRejectedValueOnce(new Error('DB down'));
+
+    const job = {
+      id: 'job-dlq-97',
+      attemptsMade: 3,
+      opts: { attempts: 3 },
+      data: { rewardId: 'r-97' },
+      remove: vi.fn().mockResolvedValue(true),
+    };
+    const err = new Error('Stellar timeout');
+
+    await failedHandler(job, err);
+
+    expect(mockCounterInc).toHaveBeenCalled(); // Counter still increments
+    expect(mockRecordFailure).toHaveBeenCalled();
+    expect(job.remove).not.toHaveBeenCalled(); // Job stays in Redis
+  });
+});

--- a/scripts/reprocess-dlq.js
+++ b/scripts/reprocess-dlq.js
@@ -1,0 +1,107 @@
+#!/usr/bin/env node
+
+/**
+ * Safe DLQ reprocessing script with idempotency protection.
+ *
+ * Usage:
+ *   node scripts/reprocess-dlq.js --job-id <job-id>
+ *   node scripts/reprocess-dlq.js --all-pending
+ *   node scripts/reprocess-dlq.js --dry-run --all-pending
+ */
+
+const { Command } = require('commander');
+const rewardIssuanceFailureRepository = require('../novaRewards/backend/repositories/rewardIssuanceFailureRepository');
+const rewardIssuanceRepository = require('../novaRewards/backend/repositories/rewardIssuanceRepository');
+const { rewardIssuanceQueue } = require('../novaRewards/backend/jobs/queues');
+
+const program = new Command();
+
+program
+  .option('--job-id <id>', 'Reprocess a specific failed job by ID')
+  .option('--all-pending', 'Reprocess all pending failures (oldest first)')
+  .option('--dry-run', 'Show what would be reprocessed without enqueuing')
+  .option('--max <n>', 'Max jobs to reprocess in --all-pending mode', '50')
+  .parse();
+
+const opts = program.opts();
+
+async function reprocessSingle(failure, dryRun) {
+  const { job_id: jobId, payload } = failure;
+
+  // ── Idempotency guard ─────────────────────────────────────────
+  const alreadyReprocessed = await rewardIssuanceFailureRepository.isReprocessed(jobId);
+  if (alreadyReprocessed) {
+    console.log(`[SKIP] Job ${jobId} already reprocessed.`);
+    return { status: 'skipped', jobId };
+  }
+
+  // ── Core idempotency: has the reward already been issued? ─────
+  const rewardAlreadyIssued = await rewardIssuanceRepository.isRewardCompleted(payload.rewardId);
+  if (rewardAlreadyIssued) {
+    console.log(`[SKIP] Reward ${payload.rewardId} already issued; marking reprocessed.`);
+    if (!dryRun) {
+      await rewardIssuanceFailureRepository.markReprocessed(jobId, 'already-completed');
+    }
+    return { status: 'already-issued', jobId };
+  }
+
+  if (dryRun) {
+    console.log(`[DRY-RUN] Would re-enqueue job ${jobId} with payload:`, JSON.stringify(payload));
+    return { status: 'dry-run', jobId };
+  }
+
+  // ── Re-enqueue ────────────────────────────────────────────────
+  const newJob = await rewardIssuanceQueue.add('issue-reward', payload, {
+    jobId: `${jobId}-reprocess-${Date.now()}`,
+    attempts: 3,
+    backoff: { type: 'exponential', delay: 2000 },
+  });
+
+  await rewardIssuanceFailureRepository.markReprocessed(jobId, newJob.id);
+
+  console.log(`[REQUEUED] Job ${jobId} → new job ${newJob.id}`);
+  return { status: 'requeued', jobId, newJobId: newJob.id };
+}
+
+async function main() {
+  try {
+    if (opts.jobId) {
+      const failure = await rewardIssuanceFailureRepository.getByJobId(opts.jobId);
+      if (!failure) {
+        console.error(`[ERROR] Job ${opts.jobId} not found in reward_issuance_failures.`);
+        process.exit(1);
+      }
+      const result = await reprocessSingle(failure, opts.dryRun);
+      console.log(JSON.stringify(result, null, 2));
+      process.exit(result.status === 'skipped' ? 0 : 0);
+    }
+
+    if (opts.allPending) {
+      const pending = await rewardIssuanceFailureRepository.listPending({ limit: parseInt(opts.max, 10) });
+      console.log(`[INFO] Found ${pending.length} pending failures.`);
+
+      const results = [];
+      for (const failure of pending) {
+        const result = await reprocessSingle(failure, opts.dryRun);
+        results.push(result);
+      }
+
+      const summary = {
+        total: results.length,
+        requeued: results.filter((r) => r.status === 'requeued').length,
+        skipped: results.filter((r) => r.status === 'skipped').length,
+        alreadyIssued: results.filter((r) => r.status === 'already-issued').length,
+        dryRun: results.filter((r) => r.status === 'dry-run').length,
+      };
+      console.log('[SUMMARY]', JSON.stringify(summary, null, 2));
+      process.exit(0);
+    }
+
+    program.help();
+  } catch (err) {
+    console.error('[FATAL]', err);
+    process.exit(1);
+  }
+}
+
+main();


### PR DESCRIPTION
## Summary

Implements a BullMQ dead-letter queue (DLQ) consumer for the reward-issuance queue so permanently failed jobs no longer silently disappear. Failed jobs are persisted to a new `reward_issuance_failures` table, a Prometheus counter `nova_reward_dlq_total` is incremented, an alert rule fires on DLQ spikes, and a safe reprocessing script with idempotency protection is provided.

Closes #1141

---

## Type of Change

- [x] `feat` — new feature
- [ ] `fix` — bug fix
- [ ] `docs` — documentation only
- [ ] `refactor` — code restructure, no feature/fix
- [ ] `perf` — performance improvement
- [x] `test` — adding or fixing tests
- [ ] `chore` — build, tooling, or dependency update
- [ ] `ci` — CI/CD changes
- [ ] Breaking change (existing functionality is affected)

---

## Changes Made

- **Database:** Added Knex migration `20260717000001_create_reward_issuance_failures.js` creating `reward_issuance_failures` table with `job_id`, `payload JSONB`, `error TEXT`, `attempts INT`, `created_at TIMESTAMPTZ`, `reprocessed_at`, `reprocess_job_id`
- **Repository:** Added `rewardIssuanceFailureRepository.js` with `recordFailure`, `isReprocessed`, `markReprocessed`, `getByJobId`, `listPending`
- **Queue DLQ Handler:** Updated `queues.js` to attach a `rewardIssuanceQueue.on('failed', ...)` event handler that persists permanently failed jobs (attempts exhausted) to the DB, increments `nova_reward_dlq_total` Prometheus counter, and removes the job from Redis to prevent bloat
- **Worker:** Updated `rewardIssuanceWorker.js` processor with an idempotency guard (`rewardIssuanceRepository.getByRewardId`) to skip already-completed rewards; added `SIGTERM` graceful shutdown for `worker` and `rewardDLQ`
- **Metrics:** Updated `metricsMiddleware.js` with `createCounter()` and `createHistogram()` helpers for Prometheus metric registration
- **Alerting:** Added `RewardIssuanceDLQSpike` (warning) and `RewardIssuanceDLQCritical` (critical) rules to `monitoring/prometheus/rules/business-alerts.yml`
- **Reprocessing Script:** Added `scripts/reprocess-dlq.js` CLI with `--job-id`, `--all-pending`, `--dry-run`, `--max` flags; validates idempotency via `rewardIssuanceRepository` before re-enqueueing
- **Tests:** Updated `rewardIssuanceWorker.test.js` with a new `queues.js DLQ persistence` test suite covering counter creation, event listener registration, DB persistence + counter increment, retry-remaining skip, and DB-failure safety (job not removed from Redis)

---

## How to Test

1. **Run the migration:**
   ```bash
   npx knex migrate:latest --env development