### PR TITLE
Feat/tokens transfer endpoint

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,8 @@
+# Nova Rewards — Claude Code instructions
+
+## Git commit & PR conventions
+- Do NOT add a `Co-Authored-By: Claude` (or any Claude/Anthropic) line to commit messages.
+- Commit messages: concise, focused on why the change was made, following the existing repo log style.
+- When pushing/opening a PR, always write a clear, substantive PR description (not a placeholder) covering:
+  - Summary of the change and motivation
+  - Test plan / how it was verified

--- a/novaRewards/backend/routes/tokens.js
+++ b/novaRewards/backend/routes/tokens.js
@@ -1,0 +1,84 @@
+const router = require('express').Router();
+const { authenticateUser } = require('../middleware/authenticateUser');
+const tokenTransferService = require('../services/tokenTransferService');
+
+/**
+ * @openapi
+ * /tokens/transfer:
+ *   post:
+ *     tags: [Tokens]
+ *     summary: Transfer NOVA tokens to another wallet
+ *     description: >
+ *       Validates the destination address and amount, checks the sender's
+ *       on-chain NOVA balance, submits a Stellar payment operation, waits
+ *       for ledger confirmation, and records the transfer in the
+ *       transactions table.
+ *     security:
+ *       - bearerAuth: []
+ *     requestBody:
+ *       required: true
+ *       content:
+ *         application/json:
+ *           schema:
+ *             type: object
+ *             required: [destination, amount, signerSecret]
+ *             properties:
+ *               destination:
+ *                 type: string
+ *                 description: Recipient's Stellar public key
+ *               amount:
+ *                 type: string
+ *                 description: Amount of NOVA to transfer (up to 7 decimal places)
+ *               signerSecret:
+ *                 type: string
+ *                 description: Secret key of the sender's linked wallet
+ *               memo:
+ *                 type: string
+ *     responses:
+ *       200:
+ *         description: Transfer submitted and confirmed on-chain.
+ *       400:
+ *         description: Validation error or insufficient balance.
+ *       401:
+ *         description: Unauthorized.
+ *       403:
+ *         description: signerSecret does not match the authenticated user's wallet.
+ */
+router.post('/transfer', authenticateUser, async (req, res, next) => {
+  try {
+    const { destination, amount, signerSecret, memo } = req.body;
+
+    const result = await tokenTransferService.transferTokens({
+      userId: req.user.id,
+      walletAddress: req.user.stellar_public_key,
+      destination,
+      amount,
+      signerSecret,
+      memo,
+    });
+
+    return res.json({
+      success: true,
+      data: {
+        txHash: result.txHash,
+        ledger: result.ledger,
+        status: result.status,
+        amount: result.amount,
+        fromWallet: result.fromWallet,
+        toWallet: result.toWallet,
+        balance: result.balance,
+      },
+    });
+  } catch (err) {
+    if (err.status) {
+      return res.status(err.status).json({
+        success: false,
+        error: err.code || 'transfer_failed',
+        message: err.message,
+      });
+    }
+    next(err);
+  }
+});
+
+module.exports = router;

--- a/novaRewards/backend/server.js
+++ b/novaRewards/backend/server.js
@@ -127,6 +127,7 @@ function buildApiRouter() {
   router.use('/redemptions', require('./routes/redemptions'));
   router.use('/transactions', require('./routes/transactions'));
   router.use('/transactions', require('./routes/stellarTransaction'));
+  router.use('/tokens', require('./routes/tokens'));
   router.use('/trustline', require('./routes/trustline'));
   router.use('/fee-estimate', require('./routes/feeEstimate'));
   router.use('/users', require('./routes/users'));

--- a/novaRewards/backend/services/tokenTransferService.js
+++ b/novaRewards/backend/services/tokenTransferService.js
@@ -1,0 +1,153 @@
+'use strict';
+
+const { Operation, Keypair, StrKey } = require('stellar-sdk');
+const { NOVA, isValidStellarAddress, getNOVABalance } = require('../../blockchain/stellarService');
+const { verifyTrustline } = require('../../blockchain/trustline');
+const stellarTxService = require('./stellarTransactionService');
+
+const AMOUNT_PATTERN = /^\d+(\.\d{1,7})?$/;
+
+// Routed through an overridable object (rather than calling the imported
+// bindings directly) so unit tests can substitute fakes for the Horizon/DB
+// calls without a real network connection.
+const deps = {
+  getNOVABalance,
+  verifyTrustline,
+  submit: (...args) => stellarTxService.submit(...args),
+};
+
+function createError(message, status, code) {
+  const err = new Error(message);
+  err.status = status;
+  err.code = code;
+  return err;
+}
+
+function validateAmount(amount) {
+  if (amount === undefined || amount === null || amount === '') {
+    throw createError('amount is required', 400, 'validation_error');
+  }
+  if (!AMOUNT_PATTERN.test(String(amount))) {
+    throw createError('amount must be a positive number with up to 7 decimal places', 400, 'validation_error');
+  }
+  if (Number(amount) <= 0) {
+    throw createError('amount must be greater than zero', 400, 'validation_error');
+  }
+  return String(amount);
+}
+
+/**
+ * Maps a Horizon submission failure to a specific, user-facing error code.
+ * `stellarTransactionService.submit` already surfaces these as 400s with the
+ * raw Horizon result codes joined into the message — this re-maps the common
+ * payment-operation failures to codes callers can branch on directly.
+ */
+function mapStellarSubmissionError(err) {
+  const message = err?.message || '';
+  if (message.includes('op_underfunded')) {
+    return createError('Sender has insufficient NOVA balance for this transfer', 400, 'insufficient_balance');
+  }
+  if (message.includes('op_no_destination')) {
+    return createError('Destination account does not exist on the Stellar network', 400, 'destination_not_found');
+  }
+  if (message.includes('op_no_trust')) {
+    return createError('Destination account does not have a NOVA trustline', 400, 'destination_no_trustline');
+  }
+  if (message.includes('op_line_full')) {
+    return createError("Destination account's NOVA trustline limit would be exceeded", 400, 'destination_trustline_full');
+  }
+  return err;
+}
+
+/**
+ * Transfers NOVA tokens from an authenticated user's linked wallet to another
+ * Stellar account. Builds and submits a payment operation, waits for ledger
+ * confirmation, and records the transfer in the transactions table.
+ *
+ * @param {object} params
+ * @param {number} params.userId - Authenticated user's DB id
+ * @param {string} params.walletAddress - Authenticated user's linked Stellar public key
+ * @param {string} params.destination - Recipient's Stellar public key
+ * @param {string|number} params.amount - Amount of NOVA to transfer
+ * @param {string} params.signerSecret - Secret key of the sending wallet
+ * @param {string} [params.memo] - Optional memo text
+ * @returns {Promise<{ txHash: string, ledger: number, status: string, amount: string, fromWallet: string, toWallet: string, balance: string }>}
+ */
+async function transferTokens({ userId, walletAddress, destination, amount, signerSecret, memo }) {
+  if (!walletAddress) {
+    throw createError('Authenticated user has no linked Stellar wallet', 400, 'no_wallet_linked');
+  }
+
+  if (!destination || !isValidStellarAddress(destination)) {
+    throw createError('destination must be a valid Stellar public key', 400, 'validation_error');
+  }
+
+  if (destination === walletAddress) {
+    throw createError("destination cannot be the sender's own wallet", 400, 'validation_error');
+  }
+
+  const validAmount = validateAmount(amount);
+
+  if (!signerSecret || !StrKey.isValidEd25519SecretSeed(signerSecret)) {
+    throw createError('signerSecret must be a valid Stellar secret key', 400, 'validation_error');
+  }
+
+  const signerKeypair = Keypair.fromSecret(signerSecret);
+  if (signerKeypair.publicKey() !== walletAddress) {
+    throw createError("signerSecret does not match the authenticated user's linked wallet", 403, 'forbidden');
+  }
+
+  const currentBalance = await deps.getNOVABalance(walletAddress);
+  if (Number(currentBalance) < Number(validAmount)) {
+    throw createError('Insufficient NOVA balance for this transfer', 400, 'insufficient_balance');
+  }
+
+  const { exists: destinationHasTrustline } = await deps.verifyTrustline(destination);
+  if (!destinationHasTrustline) {
+    throw createError('Destination account does not have a NOVA trustline', 400, 'destination_no_trustline');
+  }
+
+  const paymentOp = Operation.payment({
+    destination,
+    asset: NOVA,
+    amount: validAmount,
+  });
+
+  let result;
+  try {
+    result = await deps.submit({
+      sourceAddress: walletAddress,
+      operations: [paymentOp],
+      signers: [signerKeypair],
+      options: {
+        memo,
+        txType: 'transfer',
+        amount: validAmount,
+        fromWallet: walletAddress,
+        toWallet: destination,
+        userId,
+      },
+    });
+  } catch (err) {
+    throw mapStellarSubmissionError(err);
+  }
+
+  const updatedBalance = await deps.getNOVABalance(walletAddress).catch(() => currentBalance);
+
+  return {
+    txHash: result.txHash,
+    ledger: result.ledger,
+    status: result.status,
+    amount: validAmount,
+    fromWallet: walletAddress,
+    toWallet: destination,
+    balance: updatedBalance,
+  };
+}
+
+module.exports = {
+  transferTokens,
+  validateAmount,
+  mapStellarSubmissionError,
+  _deps: deps,
+};

--- a/novaRewards/backend/tests/tokenTransferRoutes.test.js
+++ b/novaRewards/backend/tests/tokenTransferRoutes.test.js
@@ -1,0 +1,119 @@
+'use strict';
+
+/**
+ * Route tests for POST /api/tokens/transfer.
+ * Closes #863
+ *
+ * tokenTransferService is stubbed directly (not via jest.mock/vi.mock —
+ * see the note in tokenTransferService.test.js for why module mocking
+ * doesn't intercept this codebase's CommonJS require() chains under the
+ * current Vitest setup). Since routes/tokens.js accesses
+ * `tokenTransferService.transferTokens` through the module object rather
+ * than a destructured binding, swapping the property on the cached module
+ * before each test is enough to control its behavior.
+ */
+
+import { describe, it, expect, beforeEach, vi } from 'vitest';
+const request = require('supertest');
+const express = require('express');
+
+// routes/tokens.js destructures `{ authenticateUser }` at require time, so
+// the real middleware must be replaced before the route module is required.
+const authModule = require('../middleware/authenticateUser');
+authModule.authenticateUser = (req, res, next) => {
+  req.user = { id: 1, stellar_public_key: 'GSENDER1234567890ABCDEFGHIJKLMNOPQRSTUVWXYZ1234567890AB' };
+  next();
+};
+
+const tokenTransferService = require('../services/tokenTransferService');
+const tokensRoutes = require('../routes/tokens');
+
+const app = express();
+app.use(express.json());
+app.use('/api/tokens', tokensRoutes);
+
+describe('POST /api/tokens/transfer', () => {
+  beforeEach(() => {
+    tokenTransferService.transferTokens = vi.fn();
+  });
+
+  it('returns the transfer result on success', async () => {
+    tokenTransferService.transferTokens.mockResolvedValue({
+      txHash: 'abctxhash',
+      ledger: 12345,
+      status: 'submitted',
+      amount: '10.5',
+      fromWallet: 'GSENDER1234567890ABCDEFGHIJKLMNOPQRSTUVWXYZ1234567890AB',
+      toWallet: 'GDEST1234567890ABCDEFGHIJKLMNOPQRSTUVWXYZ1234567890ABCDE',
+      balance: '89.5000000',
+    });
+
+    const res = await request(app)
+      .post('/api/tokens/transfer')
+      .send({ destination: 'GDEST1234567890ABCDEFGHIJKLMNOPQRSTUVWXYZ1234567890ABCDE', amount: '10.5', signerSecret: 'SSECRET' })
+      .expect(200);
+
+    expect(res.body.success).toBe(true);
+    expect(res.body.data.txHash).toBe('abctxhash');
+    expect(res.body.data.balance).toBe('89.5000000');
+    expect(tokenTransferService.transferTokens).toHaveBeenCalledWith({
+      userId: 1,
+      walletAddress: 'GSENDER1234567890ABCDEFGHIJKLMNOPQRSTUVWXYZ1234567890AB',
+      destination: 'GDEST1234567890ABCDEFGHIJKLMNOPQRSTUVWXYZ1234567890ABCDE',
+      amount: '10.5',
+      signerSecret: 'SSECRET',
+      memo: undefined,
+    });
+  });
+
+  it('returns the mapped status/code when the service rejects', async () => {
+    tokenTransferService.transferTokens.mockRejectedValue(
+      Object.assign(new Error('Insufficient NOVA balance for this transfer'), { status: 400, code: 'insufficient_balance' })
+    );
+
+    const res = await request(app)
+      .post('/api/tokens/transfer')
+      .send({ destination: 'GDEST1234567890ABCDEFGHIJKLMNOPQRSTUVWXYZ1234567890ABCDE', amount: '10.5', signerSecret: 'SSECRET' })
+      .expect(400);
+
+    expect(res.body).toEqual({
+      success: false,
+      error: 'insufficient_balance',
+      message: 'Insufficient NOVA balance for this transfer',
+    });
+  });
+
+  it('returns 403 when the service reports a wallet mismatch', async () => {
+    tokenTransferService.transferTokens.mockRejectedValue(
+      Object.assign(new Error("signerSecret does not match the authenticated user's linked wallet"), { status: 403, code: 'forbidden' })
+    );
+
+    const res = await request(app)
+      .post('/api/tokens/transfer')
+      .send({ destination: 'GDEST1234567890ABCDEFGHIJKLMNOPQRSTUVWXYZ1234567890ABCDE', amount: '10.5', signerSecret: 'SSECRET' })
+      .expect(403);
+
+    expect(res.body.error).toBe('forbidden');
+  });
+
+  it('forwards unrecognized errors to the error-handling middleware', async () => {
+    tokenTransferService.transferTokens.mockRejectedValue(new Error('boom'));
+
+    let caughtErr = null;
+    const appWithHandler = express();
+    appWithHandler.use(express.json());
+    appWithHandler.use('/api/tokens', tokensRoutes);
+    appWithHandler.use((err, req, res, next) => {
+      caughtErr = err;
+      res.status(500).json({ success: false, error: 'server_error' });
+    });
+
+    const res = await request(appWithHandler)
+      .post('/api/tokens/transfer')
+      .send({ destination: 'GDEST1234567890ABCDEFGHIJKLMNOPQRSTUVWXYZ1234567890ABCDE', amount: '10.5', signerSecret: 'SSECRET' })
+      .expect(500);
+
+    expect(res.body.error).toBe('server_error');
+    expect(caughtErr.message).toBe('boom');
+  });
+});

--- a/novaRewards/backend/tests/tokenTransferService.test.js
+++ b/novaRewards/backend/tests/tokenTransferService.test.js
@@ -1,0 +1,192 @@
+'use strict';
+
+/**
+ * Unit tests for tokenTransferService.js — POST /api/tokens/transfer business logic.
+ * Closes #863
+ *
+ * Horizon/DB calls are faked out via the service's `_deps` seam rather than
+ * jest/vi module mocking: this codebase's Vitest setup does not intercept
+ * require() calls made from inside a CommonJS module under test (only
+ * mocks registered against the test file's own ESM import graph apply), so
+ * jest.mock()/vi.mock() on '../../blockchain/stellarService' etc. silently
+ * fall through to the real network here. `_deps` avoids that entirely.
+ */
+
+import { describe, it, expect, beforeEach, vi } from 'vitest';
+const { Keypair } = require('stellar-sdk');
+
+const tokenTransferService = require('../services/tokenTransferService');
+const { transferTokens, _deps } = tokenTransferService;
+
+const SENDER_KEYPAIR = Keypair.random();
+const SENDER_ADDRESS = SENDER_KEYPAIR.publicKey();
+const VALID_SECRET = SENDER_KEYPAIR.secret();
+const VALID_DESTINATION = Keypair.random().publicKey();
+
+function baseParams(overrides = {}) {
+  return {
+    userId: 1,
+    walletAddress: SENDER_ADDRESS,
+    destination: VALID_DESTINATION,
+    amount: '10.5',
+    signerSecret: VALID_SECRET,
+    ...overrides,
+  };
+}
+
+describe('transferTokens', () => {
+  beforeEach(() => {
+    _deps.getNOVABalance = vi.fn().mockResolvedValue('100.0000000');
+    _deps.verifyTrustline = vi.fn().mockResolvedValue({ exists: true });
+    _deps.submit = vi.fn().mockResolvedValue({
+      txHash: 'abctxhash',
+      ledger: 12345,
+      status: 'submitted',
+      resultXdr: 'xdr',
+    });
+  });
+
+  it('successfully transfers and returns tx hash + updated balance', async () => {
+    _deps.getNOVABalance
+      .mockResolvedValueOnce('100.0000000') // pre-check
+      .mockResolvedValueOnce('89.5000000'); // post-submit
+
+    const result = await transferTokens(baseParams());
+
+    expect(result).toMatchObject({
+      txHash: 'abctxhash',
+      ledger: 12345,
+      status: 'submitted',
+      amount: '10.5',
+      fromWallet: SENDER_ADDRESS,
+      toWallet: VALID_DESTINATION,
+      balance: '89.5000000',
+    });
+
+    expect(_deps.submit).toHaveBeenCalledWith(
+      expect.objectContaining({
+        sourceAddress: SENDER_ADDRESS,
+        options: expect.objectContaining({
+          txType: 'transfer',
+          amount: '10.5',
+          fromWallet: SENDER_ADDRESS,
+          toWallet: VALID_DESTINATION,
+          userId: 1,
+        }),
+      })
+    );
+  });
+
+  it('throws 400 when the user has no linked wallet', async () => {
+    await expect(transferTokens(baseParams({ walletAddress: undefined })))
+      .rejects.toMatchObject({ status: 400, code: 'no_wallet_linked' });
+  });
+
+  it('throws 400 for a missing destination', async () => {
+    await expect(transferTokens(baseParams({ destination: undefined })))
+      .rejects.toMatchObject({ status: 400, code: 'validation_error' });
+  });
+
+  it('throws 400 for an invalid destination address', async () => {
+    await expect(transferTokens(baseParams({ destination: 'not-an-address' })))
+      .rejects.toMatchObject({ status: 400, code: 'validation_error' });
+  });
+
+  it('throws 400 when destination equals the sender wallet', async () => {
+    await expect(transferTokens(baseParams({ destination: SENDER_ADDRESS })))
+      .rejects.toMatchObject({ status: 400, code: 'validation_error' });
+  });
+
+  it('throws 400 when amount is missing', async () => {
+    await expect(transferTokens(baseParams({ amount: undefined })))
+      .rejects.toMatchObject({ status: 400, code: 'validation_error' });
+  });
+
+  it('throws 400 when amount is zero', async () => {
+    await expect(transferTokens(baseParams({ amount: '0' })))
+      .rejects.toMatchObject({ status: 400, code: 'validation_error' });
+  });
+
+  it('throws 400 when amount is negative', async () => {
+    await expect(transferTokens(baseParams({ amount: '-5' })))
+      .rejects.toMatchObject({ status: 400, code: 'validation_error' });
+  });
+
+  it('throws 400 when amount has too many decimal places', async () => {
+    await expect(transferTokens(baseParams({ amount: '1.12345678' })))
+      .rejects.toMatchObject({ status: 400, code: 'validation_error' });
+  });
+
+  it('throws 400 for a malformed signerSecret', async () => {
+    await expect(transferTokens(baseParams({ signerSecret: 'not-a-secret' })))
+      .rejects.toMatchObject({ status: 400, code: 'validation_error' });
+  });
+
+  it('throws 403 when signerSecret does not match the linked wallet', async () => {
+    const otherKeypair = Keypair.random();
+    await expect(transferTokens(baseParams({ signerSecret: otherKeypair.secret() })))
+      .rejects.toMatchObject({ status: 403, code: 'forbidden' });
+  });
+
+  it('throws 400 when the sender has insufficient balance', async () => {
+    _deps.getNOVABalance.mockResolvedValueOnce('5.0000000');
+    await expect(transferTokens(baseParams({ amount: '10' })))
+      .rejects.toMatchObject({ status: 400, code: 'insufficient_balance' });
+  });
+
+  it('throws 400 when the destination has no NOVA trustline', async () => {
+    _deps.verifyTrustline.mockResolvedValue({ exists: false });
+    await expect(transferTokens(baseParams()))
+      .rejects.toMatchObject({ status: 400, code: 'destination_no_trustline' });
+    expect(_deps.submit).not.toHaveBeenCalled();
+  });
+
+  it('maps a Horizon op_underfunded submission failure to insufficient_balance', async () => {
+    _deps.submit.mockRejectedValue(
+      Object.assign(new Error('Transaction submission failed: op_underfunded'), { status: 400, code: 'tx_submission_failed' })
+    );
+    await expect(transferTokens(baseParams()))
+      .rejects.toMatchObject({ status: 400, code: 'insufficient_balance' });
+  });
+
+  it('maps a Horizon op_no_destination submission failure to destination_not_found', async () => {
+    _deps.submit.mockRejectedValue(
+      Object.assign(new Error('Transaction submission failed: op_no_destination'), { status: 400, code: 'tx_submission_failed' })
+    );
+    await expect(transferTokens(baseParams()))
+      .rejects.toMatchObject({ status: 400, code: 'destination_not_found' });
+  });
+
+  it('maps a Horizon op_no_trust submission failure to destination_no_trustline', async () => {
+    _deps.submit.mockRejectedValue(
+      Object.assign(new Error('Transaction submission failed: op_no_trust'), { status: 400, code: 'tx_submission_failed' })
+    );
+    await expect(transferTokens(baseParams()))
+      .rejects.toMatchObject({ status: 400, code: 'destination_no_trustline' });
+  });
+
+  it('maps a Horizon op_line_full submission failure to destination_trustline_full', async () => {
+    _deps.submit.mockRejectedValue(
+      Object.assign(new Error('Transaction submission failed: op_line_full'), { status: 400, code: 'tx_submission_failed' })
+    );
+    await expect(transferTokens(baseParams()))
+      .rejects.toMatchObject({ status: 400, code: 'destination_trustline_full' });
+  });
+
+  it('propagates unrecognized submission errors unchanged', async () => {
+    _deps.submit.mockRejectedValue(
+      Object.assign(new Error('Horizon error'), { status: 503, code: 'horizon_error' })
+    );
+    await expect(transferTokens(baseParams()))
+      .rejects.toMatchObject({ status: 503, code: 'horizon_error' });
+  });
+
+  it('falls back to the pre-submission balance if the post-submit balance fetch fails', async () => {
+    _deps.getNOVABalance
+      .mockResolvedValueOnce('100.0000000')
+      .mockRejectedValueOnce(new Error('Horizon down'));
+
+    const result = await transferTokens(baseParams());
+    expect(result.balance).toBe('100.0000000');
+  });
+});


### PR DESCRIPTION
## Summary
   - Adds `POST /api/tokens/transfer` for user-to-user NOVA transfers, closing #863.
   - Validates the destination address format and transfer amount, checks the sender's on-chain NOVA balance (400 `insufficient_balance`
   on shortfall), and verifies the destination holds a NOVA trustline before touching the network.
   - Builds and submits a Stellar payment operation through the existing `stellarTransactionService.submit()` (fee-bump retry, waits for
   ledger confirmation, records the transfer in `transactions`).
   - Maps Horizon-specific payment failures (`op_underfunded`, `op_no_destination`, `op_no_trust`, `op_line_full`) to distinct,
   branchable error codes instead of one generic failure.
   - Since users' wallets are non-custodial (no secrets stored server-side), the sender proves ownership by supplying `signerSecret`,
   which is checked against the authenticated user's linked `stellar_public_key` — same pattern already used by the existing
   `/transactions/submit` route.
   - Also adds `CLAUDE.md` documenting this repo's git conventions (no Claude co-author trailer, PRs need a real description).

   ## Test plan
   - `services/tokenTransferService.js`: 19 unit tests covering validation, balance/trustline checks, success path, and Horizon
   error-code mapping — all passing, no network calls (see note below).
   - `routes/tokens.js`: 4 route-level tests covering the success response shape, error status/code mapping, and unhandled-error
   passthrough — all passing.
   - Verified both new modules load cleanly under plain `node` (matches production `node server.js` execution) and `node -c`
   syntax-checks pass.
closes #863