### PR TITLE
Fix upgraded-event tuple arity in upgrade test (issue #379 review)

### DIFF
--- a/contracts/nova-rewards/tests/upgrade.rs
+++ b/contracts/nova-rewards/tests/upgrade.rs
@@ -83,10 +83,13 @@ fn test_upgrade_v1_to_v2_migrate_and_verify() {
     });
     assert!(upgraded_event.is_some(), "upgraded event not emitted");
 
-    // Verify event data contains the correct hash and migration version
+    // Verify event data contains the correct hash and migration version.
+    // Payload is (schema_version, wasm_hash, migration_version) — see
+    // events::emit_upgraded and the schema table in utils/events.rs.
     let (_, _, data) = upgraded_event.unwrap();
-    let (emitted_hash, emitted_version): (BytesN<32>, u32) =
+    let (emitted_schema_version, emitted_hash, emitted_version): (u32, BytesN<32>, u32) =
         data.into_val(&env);
+    assert_eq!(emitted_schema_version, 1u32);
     assert_eq!(emitted_hash, v2_hash);
     assert_eq!(emitted_version, 1u32);
 }

--- a/docs/upgrade-guide.md
+++ b/docs/upgrade-guide.md
@@ -122,7 +122,7 @@ soroban contract invoke --network testnet --id <CONTRACT_ID> -- get_migrated_ver
 
 Confirm the `upgraded` event appears in the transaction record on the Stellar explorer.
 
-1. Invoke `get_migrated_version` and confirm it matches `CONTRACT_VERSION` in [`contracts/nova-rewards/src/lib.rs`](../contracts/nova-rewards/src/lib.rs).
+1. Invoke `get_migrated_version` and confirm it matches `get_migration_version` (both counters equal means the migration for this upgrade completed).
 2. Query representative balances with `get_balance` to confirm state survived the code swap.
 3. Re-run [`contracts/nova-rewards/tests/upgrade.rs`](../contracts/nova-rewards/tests/upgrade.rs).
 4. If the release touched swaps or staking, also run the swap and staking test suites.


### PR DESCRIPTION
## Summary
While reviewing #379 ("[Smart Contract] Feature: Upgradability Pattern"), found the feature is already fully implemented in `contracts/nova-rewards`:
- `upgrade(new_wasm_hash)` — admin-only, calls `env.deployer().update_current_contract_wasm(...)`.
- `migration_version` / `migrated_version` counters in instance storage, with `migrate()` gated on `migrated_version < migration_version`.
- `upgraded` event emitted with the WASM hash and migration version.
- V1-to-V2 upgrade+migrate test and `docs/upgrade-guide.md` already exist.

Found and fixed two bugs along the way:
- `test_upgrade_v1_to_v2_migrate_and_verify` decoded the `upgraded` event data as `(BytesN<32>, u32)`, but `events::emit_upgraded` publishes `(schema_version, wasm_hash, migration_version)` -- a 3-tuple, matching every other event in this contract's schema. The arity mismatch would panic on `into_val()`, so the test as written could not pass.
- `docs/upgrade-guide.md` told operators to verify against a `CONTRACT_VERSION` constant in `lib.rs` that doesn't exist; corrected it to reference the actual `migration_version`/`migrated_version` counters.

## Test plan
- No Rust toolchain available in this environment to run `cargo test`, so this was verified by careful manual review: cross-checked `emit_upgraded`'s publish call against every sibling `emit_*` function in `utils/events.rs` (all publish `(EVENT_SCHEMA_VERSION, ...)` as the first tuple element), confirming the 3-tuple decode now matches the actual event shape.
- Recommend running `cargo test -p nova-rewards --test upgrade` in CI to confirm the fixed assertion passes.

closes #379 