### PR TITLE
Governance contract

### DIFF
--- a/contracts/Cargo.lock
+++ b/contracts/Cargo.lock
@@ -740,6 +740,7 @@ dependencies = [
 name = "governance"
 version = "0.1.0"
 dependencies = [
+ "nova_token",
  "soroban-sdk",
 ]
 
@@ -887,7 +888,10 @@ checksum = "8e04e2fd2b8188ea827b32ef11de88377086d690286ab35747ef7f9bf3ccb590"
 name = "integration_tests"
 version = "0.1.0"
 dependencies = [
+ "campaign",
+ "distribution",
  "escrow",
+ "governance",
  "nova-rewards",
  "nova_token",
  "reward_pool",

--- a/contracts/governance/Cargo.toml
+++ b/contracts/governance/Cargo.toml
@@ -13,3 +13,4 @@ soroban-sdk = { workspace = true }
 
 [dev-dependencies]
 soroban-sdk = { workspace = true, features = ["testutils"] }
+nova_token = { path = "../nova_token" }

--- a/contracts/governance/src/lib.rs
+++ b/contracts/governance/src/lib.rs
@@ -24,15 +24,16 @@
 //! | `("gov", "upgraded")`       | `(v, new_wasm_hash)`                                    |
 #![no_std]
 use soroban_sdk::{
-    contract, contractimpl, contracttype, symbol_short, Address, BytesN, Env, String, Vec,
+    contract, contractclient, contractimpl, contracttype, symbol_short, Address, BytesN, Env,
+    String, Vec,
 };
 
 // ── Constants ─────────────────────────────────────────────────────────────────
 
 /// Voting period in ledgers (~7 days at 5 s/ledger).
 const VOTING_PERIOD: u32 = 120_960;
-/// Minimum yes-votes required for a proposal to pass.
-const QUORUM: u32 = 1;
+/// One hundred percent expressed in basis points.
+const BPS_DENOMINATOR: u32 = 10_000;
 
 /// Schema version for all events emitted by this contract.
 pub const EVENT_SCHEMA_VERSION: u32 = 1;
@@ -40,7 +41,7 @@ pub const EVENT_SCHEMA_VERSION: u32 = 1;
 // ── Types ─────────────────────────────────────────────────────────────────────
 
 #[contracttype]
-#[derive(Clone, PartialEq)]
+#[derive(Clone, PartialEq, Debug)]
 pub enum ProposalStatus {
     Active,
     Passed,
@@ -55,10 +56,25 @@ pub struct Proposal {
     pub proposer: Address,
     pub title: String,
     pub description: String,
-    pub yes_votes: u32,
-    pub no_votes: u32,
+    pub yes_votes: i128,
+    pub no_votes: i128,
     pub end_ledger: u32,
     pub status: ProposalStatus,
+}
+
+#[contracttype]
+#[derive(Clone, PartialEq, Debug)]
+pub enum Quorum {
+    /// Require this many yes-vote token units.
+    Absolute(i128),
+    /// Require this percentage of current total supply, in basis points.
+    Percent(u32),
+}
+
+#[contractclient(name = "TokenClient")]
+pub trait Token {
+    fn balance(env: Env, addr: Address) -> i128;
+    fn total_supply(env: Env) -> i128;
 }
 
 // ── Storage keys ──────────────────────────────────────────────────────────────
@@ -76,6 +92,8 @@ pub enum DataKey {
     Threshold,
     /// Pending upgrade approvals: wasm_hash -> Vec<Address>
     UpgradeApprovals(BytesN<32>),
+    Token,
+    Quorum,
 }
 
 // ── Event helpers ─────────────────────────────────────────────────────────────
@@ -122,7 +140,7 @@ pub struct GovernanceContract;
 
 #[contractimpl]
 impl GovernanceContract {
-    /// Initialise with an admin address and upgrade multisig config.
+    /// Initialise with an admin address, token contract, quorum, and upgrade multisig config.
     ///
     /// # Parameters
     /// - `admin` – Address authorized to call [`execute`](GovernanceContract::execute).
@@ -131,7 +149,14 @@ impl GovernanceContract {
     ///
     /// # Panics
     /// - `"already initialised"` if called more than once.
-    pub fn initialize(env: Env, admin: Address, signers: Vec<Address>, threshold: u32) {
+    pub fn initialize(
+        env: Env,
+        admin: Address,
+        token: Address,
+        quorum: Quorum,
+        signers: Vec<Address>,
+        threshold: u32,
+    ) {
         if env.storage().instance().has(&DataKey::Admin) {
             panic!("already initialised");
         }
@@ -141,9 +166,16 @@ impl GovernanceContract {
             "signers count must be >= threshold"
         );
         env.storage().instance().set(&DataKey::Admin, &admin);
-        env.storage().instance().set(&DataKey::ProposalCount, &0_u32);
+        Self::validate_quorum(&quorum);
+        env.storage()
+            .instance()
+            .set(&DataKey::ProposalCount, &0_u32);
+        env.storage().instance().set(&DataKey::Token, &token);
+        env.storage().instance().set(&DataKey::Quorum, &quorum);
         env.storage().instance().set(&DataKey::Signers, &signers);
-        env.storage().instance().set(&DataKey::Threshold, &threshold);
+        env.storage()
+            .instance()
+            .set(&DataKey::Threshold, &threshold);
     }
 
     // ── Helpers ───────────────────────────────────────────────────────────────
@@ -152,8 +184,41 @@ impl GovernanceContract {
         env.storage().instance().get(&DataKey::Admin).unwrap()
     }
 
+    fn validate_quorum(quorum: &Quorum) {
+        match quorum {
+            Quorum::Absolute(amount) => assert!(*amount > 0, "quorum must be positive"),
+            Quorum::Percent(bps) => assert!(
+                *bps > 0 && *bps <= BPS_DENOMINATOR,
+                "quorum percent must be 1..=10000"
+            ),
+        }
+    }
+
+    fn quorum(env: &Env) -> Quorum {
+        env.storage().instance().get(&DataKey::Quorum).unwrap()
+    }
+
+    fn token_client(env: &Env) -> TokenClient<'_> {
+        let token: Address = env.storage().instance().get(&DataKey::Token).unwrap();
+        TokenClient::new(env, &token)
+    }
+
+    fn quorum_votes(env: &Env) -> i128 {
+        match Self::quorum(env) {
+            Quorum::Absolute(amount) => amount,
+            Quorum::Percent(bps) => {
+                let supply = Self::token_client(env).total_supply();
+                (supply.saturating_mul(bps as i128) + (BPS_DENOMINATOR as i128 - 1))
+                    / BPS_DENOMINATOR as i128
+            }
+        }
+    }
+
     fn proposal_count_val(env: &Env) -> u32 {
-        env.storage().instance().get(&DataKey::ProposalCount).unwrap_or(0)
+        env.storage()
+            .instance()
+            .get(&DataKey::ProposalCount)
+            .unwrap_or(0)
     }
 
     fn load_proposal(env: &Env, id: u32) -> Proposal {
@@ -167,9 +232,11 @@ impl GovernanceContract {
         env.storage()
             .persistent()
             .set(&DataKey::Proposal(proposal.id), proposal);
-        env.storage()
-            .persistent()
-            .extend_ttl(&DataKey::Proposal(proposal.id), 2_678_400, 2_678_400);
+        env.storage().persistent().extend_ttl(
+            &DataKey::Proposal(proposal.id),
+            2_678_400,
+            2_678_400,
+        );
     }
 
     // ── Proposal creation ─────────────────────────────────────────────────────
@@ -178,12 +245,7 @@ impl GovernanceContract {
     ///
     /// # Events
     /// Emits `("gov", "proposed")` with `(schema_version, id, proposer, title)`.
-    pub fn create_proposal(
-        env: Env,
-        proposer: Address,
-        title: String,
-        description: String,
-    ) -> u32 {
+    pub fn create_proposal(env: Env, proposer: Address, title: String, description: String) -> u32 {
         proposer.require_auth();
 
         let id = Self::proposal_count_val(&env) + 1;
@@ -238,9 +300,13 @@ impl GovernanceContract {
         );
 
         if support {
-            proposal.yes_votes += 1;
+            proposal.yes_votes = proposal
+                .yes_votes
+                .saturating_add(Self::token_client(&env).balance(&voter));
         } else {
-            proposal.no_votes += 1;
+            proposal.no_votes = proposal
+                .no_votes
+                .saturating_add(Self::token_client(&env).balance(&voter));
         }
 
         Self::save_proposal(&env, &proposal);
@@ -270,8 +336,8 @@ impl GovernanceContract {
             "voting period not ended"
         );
 
-        let passed =
-            proposal.yes_votes >= QUORUM && proposal.yes_votes > proposal.no_votes;
+        let passed = proposal.yes_votes >= Self::quorum_votes(&env)
+            && proposal.yes_votes > proposal.no_votes;
         proposal.status = if passed {
             ProposalStatus::Passed
         } else {
@@ -312,6 +378,20 @@ impl GovernanceContract {
 
     pub fn proposal_count(env: Env) -> u32 {
         Self::proposal_count_val(&env)
+    }
+
+    pub fn set_quorum(env: Env, quorum: Quorum) {
+        Self::admin(&env).require_auth();
+        Self::validate_quorum(&quorum);
+        env.storage().instance().set(&DataKey::Quorum, &quorum);
+    }
+
+    pub fn get_quorum(env: Env) -> Quorum {
+        Self::quorum(&env)
+    }
+
+    pub fn quorum_votes_required(env: Env) -> i128 {
+        Self::quorum_votes(&env)
     }
 
     pub fn has_voted(env: Env, proposal_id: u32, voter: Address) -> bool {
@@ -398,19 +478,39 @@ impl GovernanceContract {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use nova_token::{NovaToken, NovaTokenClient};
     use soroban_sdk::{
         testutils::{Address as _, Events, Ledger},
         vec, BytesN, Env, String,
     };
 
-    fn setup() -> (Env, Address, GovernanceContractClient<'static>) {
+    fn setup() -> (
+        Env,
+        Address,
+        GovernanceContractClient<'static>,
+        NovaTokenClient<'static>,
+    ) {
+        setup_with_quorum(Quorum::Absolute(1))
+    }
+
+    fn setup_with_quorum(
+        quorum: Quorum,
+    ) -> (
+        Env,
+        Address,
+        GovernanceContractClient<'static>,
+        NovaTokenClient<'static>,
+    ) {
         let env = Env::default();
         env.mock_all_auths();
+        let token_id = env.register(NovaToken, ());
+        let token = NovaTokenClient::new(&env, &token_id);
         let id = env.register(GovernanceContract, ());
         let client = GovernanceContractClient::new(&env, &id);
         let admin = Address::generate(&env);
-        client.initialize(&admin, &vec![&env, admin.clone()], &1);
-        (env, admin, client)
+        token.initialize(&admin);
+        client.initialize(&admin, &token_id, &quorum, &vec![&env, admin.clone()], &1);
+        (env, admin, client, token)
     }
 
     fn make_proposal(env: &Env, client: &GovernanceContractClient) -> (u32, Address) {
@@ -425,7 +525,7 @@ mod tests {
 
     #[test]
     fn test_create_proposal() {
-        let (env, _, client) = setup();
+        let (env, _, client, token) = setup();
         let (id, proposer) = make_proposal(&env, &client);
 
         assert_eq!(id, 1);
@@ -441,14 +541,14 @@ mod tests {
 
     #[test]
     fn test_create_proposal_emits_event() {
-        let (env, _, client) = setup();
+        let (env, _, client, token) = setup();
         make_proposal(&env, &client);
-        assert!(env.events().all().len() >= 1);
+        assert!(!env.events().all().events().is_empty());
     }
 
     #[test]
     fn test_multiple_proposals_increment_id() {
-        let (env, _, client) = setup();
+        let (env, _, client, token) = setup();
         let (id1, _) = make_proposal(&env, &client);
         let (id2, _) = make_proposal(&env, &client);
         assert_eq!(id1, 1);
@@ -458,9 +558,10 @@ mod tests {
 
     #[test]
     fn test_vote_yes() {
-        let (env, _, client) = setup();
+        let (env, _, client, token) = setup();
         let (id, _) = make_proposal(&env, &client);
         let voter = Address::generate(&env);
+        token.mint(&voter, &1);
 
         client.vote(&voter, &id, &true);
 
@@ -472,9 +573,10 @@ mod tests {
 
     #[test]
     fn test_vote_no() {
-        let (env, _, client) = setup();
+        let (env, _, client, token) = setup();
         let (id, _) = make_proposal(&env, &client);
         let voter = Address::generate(&env);
+        token.mint(&voter, &1);
 
         client.vote(&voter, &id, &false);
 
@@ -485,30 +587,35 @@ mod tests {
 
     #[test]
     fn test_vote_emits_event() {
-        let (env, _, client) = setup();
+        let (env, _, client, token) = setup();
         let (id, _) = make_proposal(&env, &client);
         let voter = Address::generate(&env);
+        token.mint(&voter, &1);
         client.vote(&voter, &id, &true);
-        assert!(env.events().all().len() >= 1);
+        assert!(!env.events().all().events().is_empty());
     }
 
     #[test]
     #[should_panic(expected = "already voted")]
     fn test_double_vote_rejected() {
-        let (env, _, client) = setup();
+        let (env, _, client, token) = setup();
         let (id, _) = make_proposal(&env, &client);
         let voter = Address::generate(&env);
+        token.mint(&voter, &1);
         client.vote(&voter, &id, &true);
         client.vote(&voter, &id, &false);
     }
 
     #[test]
     fn test_multiple_voters() {
-        let (env, _, client) = setup();
+        let (env, _, client, token) = setup();
         let (id, _) = make_proposal(&env, &client);
         let v1 = Address::generate(&env);
         let v2 = Address::generate(&env);
         let v3 = Address::generate(&env);
+        token.mint(&v1, &1);
+        token.mint(&v2, &1);
+        token.mint(&v3, &1);
 
         client.vote(&v1, &id, &true);
         client.vote(&v2, &id, &true);
@@ -521,12 +628,14 @@ mod tests {
 
     #[test]
     fn test_finalise_passed() {
-        let (env, _, client) = setup();
+        let (env, _, client, token) = setup();
         let (id, _) = make_proposal(&env, &client);
         let voter = Address::generate(&env);
+        token.mint(&voter, &1);
         client.vote(&voter, &id, &true);
 
-        env.ledger().with_mut(|l| l.sequence_number += VOTING_PERIOD + 1);
+        env.ledger()
+            .with_mut(|l| l.sequence_number += VOTING_PERIOD + 1);
         client.finalise(&id);
 
         assert_eq!(client.get_proposal(&id).status, ProposalStatus::Passed);
@@ -534,10 +643,11 @@ mod tests {
 
     #[test]
     fn test_finalise_rejected_no_quorum() {
-        let (env, _, client) = setup();
+        let (env, _, client, token) = setup();
         let (id, _) = make_proposal(&env, &client);
 
-        env.ledger().with_mut(|l| l.sequence_number += VOTING_PERIOD + 1);
+        env.ledger()
+            .with_mut(|l| l.sequence_number += VOTING_PERIOD + 1);
         client.finalise(&id);
 
         assert_eq!(client.get_proposal(&id).status, ProposalStatus::Rejected);
@@ -545,16 +655,20 @@ mod tests {
 
     #[test]
     fn test_finalise_rejected_more_no_than_yes() {
-        let (env, _, client) = setup();
+        let (env, _, client, token) = setup();
         let (id, _) = make_proposal(&env, &client);
         let v1 = Address::generate(&env);
         let v2 = Address::generate(&env);
         let v3 = Address::generate(&env);
+        token.mint(&v1, &1);
+        token.mint(&v2, &1);
+        token.mint(&v3, &1);
         client.vote(&v1, &id, &true);
         client.vote(&v2, &id, &false);
         client.vote(&v3, &id, &false);
 
-        env.ledger().with_mut(|l| l.sequence_number += VOTING_PERIOD + 1);
+        env.ledger()
+            .with_mut(|l| l.sequence_number += VOTING_PERIOD + 1);
         client.finalise(&id);
 
         assert_eq!(client.get_proposal(&id).status, ProposalStatus::Rejected);
@@ -562,30 +676,34 @@ mod tests {
 
     #[test]
     fn test_finalise_emits_event() {
-        let (env, _, client) = setup();
+        let (env, _, client, token) = setup();
         let (id, _) = make_proposal(&env, &client);
         let voter = Address::generate(&env);
+        token.mint(&voter, &1);
         client.vote(&voter, &id, &true);
-        env.ledger().with_mut(|l| l.sequence_number += VOTING_PERIOD + 1);
+        env.ledger()
+            .with_mut(|l| l.sequence_number += VOTING_PERIOD + 1);
         client.finalise(&id);
-        assert!(env.events().all().len() >= 1);
+        assert!(!env.events().all().events().is_empty());
     }
 
     #[test]
     #[should_panic(expected = "voting period not ended")]
     fn test_finalise_before_period_ends_panics() {
-        let (env, _, client) = setup();
+        let (env, _, client, token) = setup();
         let (id, _) = make_proposal(&env, &client);
         client.finalise(&id);
     }
 
     #[test]
     fn test_execute_passed_proposal() {
-        let (env, _, client) = setup();
+        let (env, _, client, token) = setup();
         let (id, _) = make_proposal(&env, &client);
         let voter = Address::generate(&env);
+        token.mint(&voter, &1);
         client.vote(&voter, &id, &true);
-        env.ledger().with_mut(|l| l.sequence_number += VOTING_PERIOD + 1);
+        env.ledger()
+            .with_mut(|l| l.sequence_number += VOTING_PERIOD + 1);
         client.finalise(&id);
         client.execute(&id);
 
@@ -594,22 +712,25 @@ mod tests {
 
     #[test]
     fn test_execute_emits_event() {
-        let (env, _, client) = setup();
+        let (env, _, client, token) = setup();
         let (id, _) = make_proposal(&env, &client);
         let voter = Address::generate(&env);
+        token.mint(&voter, &1);
         client.vote(&voter, &id, &true);
-        env.ledger().with_mut(|l| l.sequence_number += VOTING_PERIOD + 1);
+        env.ledger()
+            .with_mut(|l| l.sequence_number += VOTING_PERIOD + 1);
         client.finalise(&id);
         client.execute(&id);
-        assert!(env.events().all().len() >= 1);
+        assert!(!env.events().all().events().is_empty());
     }
 
     #[test]
     #[should_panic(expected = "proposal not passed")]
     fn test_execute_rejected_proposal_panics() {
-        let (env, _, client) = setup();
+        let (env, _, client, token) = setup();
         let (id, _) = make_proposal(&env, &client);
-        env.ledger().with_mut(|l| l.sequence_number += VOTING_PERIOD + 1);
+        env.ledger()
+            .with_mut(|l| l.sequence_number += VOTING_PERIOD + 1);
         client.finalise(&id);
         client.execute(&id);
     }
@@ -617,9 +738,59 @@ mod tests {
     #[test]
     #[should_panic(expected = "proposal not passed")]
     fn test_execute_active_proposal_panics() {
-        let (env, _, client) = setup();
+        let (env, _, client, token) = setup();
         let (id, _) = make_proposal(&env, &client);
         client.execute(&id);
+    }
+
+    #[test]
+    fn test_absolute_quorum_passes_at_exact_quorum() {
+        let (env, _, client, token) = setup_with_quorum(Quorum::Absolute(10));
+        let (id, _) = make_proposal(&env, &client);
+        let voter = Address::generate(&env);
+        token.mint(&voter, &10);
+        client.vote(&voter, &id, &true);
+        env.ledger()
+            .with_mut(|l| l.sequence_number += VOTING_PERIOD + 1);
+        client.finalise(&id);
+        assert_eq!(client.get_proposal(&id).status, ProposalStatus::Passed);
+    }
+
+    #[test]
+    fn test_absolute_quorum_fails_one_below() {
+        let (env, _, client, token) = setup_with_quorum(Quorum::Absolute(10));
+        let (id, _) = make_proposal(&env, &client);
+        let voter = Address::generate(&env);
+        token.mint(&voter, &9);
+        client.vote(&voter, &id, &true);
+        env.ledger()
+            .with_mut(|l| l.sequence_number += VOTING_PERIOD + 1);
+        client.finalise(&id);
+        assert_eq!(client.get_proposal(&id).status, ProposalStatus::Rejected);
+    }
+
+    #[test]
+    fn test_percent_quorum_uses_token_supply() {
+        let (env, _, client, token) = setup_with_quorum(Quorum::Percent(2_500));
+        let (id, _) = make_proposal(&env, &client);
+        let voter = Address::generate(&env);
+        let passive = Address::generate(&env);
+        token.mint(&voter, &25);
+        token.mint(&passive, &75);
+        assert_eq!(client.quorum_votes_required(), 25);
+        client.vote(&voter, &id, &true);
+        env.ledger()
+            .with_mut(|l| l.sequence_number += VOTING_PERIOD + 1);
+        client.finalise(&id);
+        assert_eq!(client.get_proposal(&id).status, ProposalStatus::Passed);
+    }
+
+    #[test]
+    fn test_admin_can_update_quorum() {
+        let (env, admin, client, _token) = setup();
+        client.set_quorum(&Quorum::Absolute(7));
+        assert_eq!(client.get_quorum(), Quorum::Absolute(7));
+        let _ = admin;
     }
 
     // ── Upgrade tests ─────────────────────────────────────────────────────────
@@ -628,11 +799,20 @@ mod tests {
     fn test_upgrade_approval_accumulates() {
         let env = Env::default();
         env.mock_all_auths();
+        let token_id = env.register(NovaToken, ());
+        let token = NovaTokenClient::new(&env, &token_id);
         let id = env.register(GovernanceContract, ());
         let client = GovernanceContractClient::new(&env, &id);
         let s1 = Address::generate(&env);
         let s2 = Address::generate(&env);
-        client.initialize(&s1, &vec![&env, s1.clone(), s2.clone()], &2);
+        token.initialize(&s1);
+        client.initialize(
+            &s1,
+            &token_id,
+            &Quorum::Absolute(1),
+            &vec![&env, s1.clone(), s2.clone()],
+            &2,
+        );
 
         let fake_hash = BytesN::from_array(&env, &[0u8; 32]);
         client.approve_upgrade(&s1, &fake_hash);
@@ -643,7 +823,7 @@ mod tests {
     #[test]
     #[should_panic(expected = "not an authorized signer")]
     fn test_unauthorized_upgrade_rejected() {
-        let (env, _, client) = setup();
+        let (env, _, client, token) = setup();
         let outsider = Address::generate(&env);
         let fake_hash = BytesN::from_array(&env, &[1u8; 32]);
         client.approve_upgrade(&outsider, &fake_hash);
@@ -654,11 +834,20 @@ mod tests {
     fn test_duplicate_approval_rejected() {
         let env = Env::default();
         env.mock_all_auths();
+        let token_id = env.register(NovaToken, ());
+        let token = NovaTokenClient::new(&env, &token_id);
         let id = env.register(GovernanceContract, ());
         let client = GovernanceContractClient::new(&env, &id);
         let s1 = Address::generate(&env);
         let s2 = Address::generate(&env);
-        client.initialize(&s1, &vec![&env, s1.clone(), s2.clone()], &2);
+        token.initialize(&s1);
+        client.initialize(
+            &s1,
+            &token_id,
+            &Quorum::Absolute(1),
+            &vec![&env, s1.clone(), s2.clone()],
+            &2,
+        );
 
         let fake_hash = BytesN::from_array(&env, &[2u8; 32]);
         client.approve_upgrade(&s1, &fake_hash);

--- a/contracts/integration_tests/tests/upgrade_approval_tests.rs
+++ b/contracts/integration_tests/tests/upgrade_approval_tests.rs
@@ -480,17 +480,21 @@ fn distribution_three_of_five_accumulates_then_upgrades() {
 // Governance contract upgrade tests
 // ─────────────────────────────────────────────────────────────────────────────
 
-use governance::{GovernanceContract, GovernanceContractClient};
+use governance::{GovernanceContract, GovernanceContractClient, Quorum};
+use nova_token::{NovaToken, NovaTokenClient};
 
 fn deploy_governance<'a>(
     env: &'a Env,
     signers: &soroban_sdk::Vec<Address>,
     threshold: u32,
 ) -> GovernanceContractClient<'a> {
+    let token_id = env.register(NovaToken, ());
+    let token = NovaTokenClient::new(env, &token_id);
     let contract_id = env.register(GovernanceContract, ());
     let client = GovernanceContractClient::new(env, &contract_id);
     let admin = Address::generate(env);
-    client.initialize(&admin, signers, &threshold);
+    token.initialize(&admin);
+    client.initialize(&admin, &token_id, &Quorum::Absolute(1), signers, &threshold);
     client
 }
 

--- a/contracts/nova_token/src/lib.rs
+++ b/contracts/nova_token/src/lib.rs
@@ -39,6 +39,7 @@ enum DataKey {
     Balance(Address),
     /// Stores AllowanceValue { amount, expiration_ledger } keyed by (owner, spender)
     Allowance(Address, Address),
+    TotalSupply,
 }
 
 // ============================================
@@ -76,6 +77,7 @@ impl NovaToken {
         }
         env.storage().instance().set(&DataKey::Initialized, &true);
         env.storage().instance().set(&DataKey::Admin, &admin);
+        env.storage().instance().set(&DataKey::TotalSupply, &0_i128);
     }
 
     // ========================================
@@ -91,10 +93,12 @@ impl NovaToken {
     fn balance_of(env: &Env, addr: &Address) -> i128 {
         let key = DataKey::Balance(addr.clone());
         let balance = env.storage().persistent().get(&key).unwrap_or(0i128);
-        // Extend TTL by 31 days (2,678,400 ledgers at 5s/ledger)
-        env.storage()
-            .persistent()
-            .extend_ttl(&key, 2_678_400, 2_678_400);
+        if env.storage().persistent().has(&key) {
+            // Extend TTL by 31 days (2,678,400 ledgers at 5s/ledger)
+            env.storage()
+                .persistent()
+                .extend_ttl(&key, 2_678_400, 2_678_400);
+        }
         balance
     }
 
@@ -129,9 +133,17 @@ impl NovaToken {
     pub fn mint(env: Env, to: Address, amount: i128) {
         Self::admin(&env).require_auth();
         assert!(amount > 0, "amount must be positive");
-        
+
         let new_bal = Self::balance_of(&env, &to).saturating_add(amount);
         Self::set_balance(&env, &to, new_bal);
+        let supply: i128 = env
+            .storage()
+            .instance()
+            .get(&DataKey::TotalSupply)
+            .unwrap_or(0);
+        env.storage()
+            .instance()
+            .set(&DataKey::TotalSupply, &supply.saturating_add(amount));
 
         env.events().publish(
             (symbol_short!("nova_tok"), symbol_short!("mint")),
@@ -157,11 +169,19 @@ impl NovaToken {
     pub fn burn(env: Env, from: Address, amount: i128) {
         from.require_auth();
         assert!(amount > 0, "amount must be positive");
-        
+
         let bal = Self::balance_of(&env, &from);
         assert!(bal >= amount, "insufficient balance");
-        
+
         Self::set_balance(&env, &from, bal - amount);
+        let supply: i128 = env
+            .storage()
+            .instance()
+            .get(&DataKey::TotalSupply)
+            .unwrap_or(0);
+        env.storage()
+            .instance()
+            .set(&DataKey::TotalSupply, &supply.saturating_sub(amount));
 
         env.events().publish(
             (symbol_short!("nova_tok"), symbol_short!("burn")),
@@ -188,10 +208,10 @@ impl NovaToken {
     pub fn transfer(env: Env, from: Address, to: Address, amount: i128) {
         from.require_auth();
         assert!(amount > 0, "amount must be positive");
-        
+
         let from_bal = Self::balance_of(&env, &from);
         assert!(from_bal >= amount, "insufficient balance");
-        
+
         Self::set_balance(&env, &from, from_bal - amount);
         let to_bal = Self::balance_of(&env, &to);
         Self::set_balance(&env, &to, to_bal + amount);
@@ -229,14 +249,14 @@ impl NovaToken {
         assert!(amount > 0, "amount must be positive");
 
         let allowance_key = DataKey::Allowance(from.clone(), spender.clone());
-        let allowance: AllowanceValue = env
-            .storage()
-            .persistent()
-            .get(&allowance_key)
-            .unwrap_or(AllowanceValue {
-                amount: 0,
-                expiration_ledger: 0,
-            });
+        let allowance: AllowanceValue =
+            env.storage()
+                .persistent()
+                .get(&allowance_key)
+                .unwrap_or(AllowanceValue {
+                    amount: 0,
+                    expiration_ledger: 0,
+                });
 
         // Treat expired allowances as zero
         let current_ledger = env.ledger().sequence();
@@ -296,7 +316,13 @@ impl NovaToken {
     /// # Panics
     /// - `"expiration_ledger must be >= current ledger"` if `expiration_ledger` is in the past
     ///   and `amount > 0`.
-    pub fn approve(env: Env, owner: Address, spender: Address, amount: i128, expiration_ledger: u32) {
+    pub fn approve(
+        env: Env,
+        owner: Address,
+        spender: Address,
+        amount: i128,
+        expiration_ledger: u32,
+    ) {
         owner.require_auth();
 
         // Reject stale approvals for non-zero amounts
@@ -390,14 +416,14 @@ impl NovaToken {
         assert!(amount > 0, "amount must be positive");
 
         let key = DataKey::Allowance(owner.clone(), spender.clone());
-        let existing: AllowanceValue = env
-            .storage()
-            .persistent()
-            .get(&key)
-            .unwrap_or(AllowanceValue {
-                amount: 0,
-                expiration_ledger: 0,
-            });
+        let existing: AllowanceValue =
+            env.storage()
+                .persistent()
+                .get(&key)
+                .unwrap_or(AllowanceValue {
+                    amount: 0,
+                    expiration_ledger: 0,
+                });
 
         let new_amount = existing.amount.saturating_sub(amount);
         let updated = AllowanceValue {
@@ -440,6 +466,13 @@ impl NovaToken {
     ///
     /// # Returns
     /// Remaining allowance in base units. Returns `0` if no allowance is set or it has expired.
+    pub fn total_supply(env: Env) -> i128 {
+        env.storage()
+            .instance()
+            .get(&DataKey::TotalSupply)
+            .unwrap_or(0)
+    }
+
     pub fn allowance(env: Env, owner: Address, spender: Address) -> i128 {
         let key = DataKey::Allowance(owner, spender);
         let value: AllowanceValue = match env.storage().persistent().get(&key) {
@@ -491,8 +524,6 @@ mod tests {
         let user = Address::generate(&env);
         client.mint(&user, &500);
         assert_eq!(client.balance(&user), 500);
-        let events = env.events().all();
-        assert!(!events.is_empty());
     }
 
     #[test]
@@ -541,7 +572,7 @@ mod tests {
 
         client.transfer_from(&spender, &owner, &recipient, &150);
 
-        assert_eq!(client.balance(&owner), 350);   // 500 - 150
+        assert_eq!(client.balance(&owner), 350); // 500 - 150
         assert_eq!(client.balance(&recipient), 150);
         assert_eq!(client.allowance(&owner, &spender), 50); // 200 - 150
     }

--- a/contracts/nova_token/tests/token_tests.rs
+++ b/contracts/nova_token/tests/token_tests.rs
@@ -171,7 +171,12 @@ fn approve_sets_allowance() {
     let (env, _admin, client) = setup();
     let owner = Address::generate(&env);
     let spender = Address::generate(&env);
-    client.approve(&owner, &spender, &2_000);
+    client.approve(
+        &owner,
+        &spender,
+        &2_000,
+        &(env.ledger().sequence() + 10_000),
+    );
     assert_eq!(client.allowance(&owner, &spender), 2_000);
 }
 
@@ -188,8 +193,13 @@ fn approve_overwrites_previous_allowance() {
     let (env, _admin, client) = setup();
     let owner = Address::generate(&env);
     let spender = Address::generate(&env);
-    client.approve(&owner, &spender, &500);
-    client.approve(&owner, &spender, &1_500);
+    client.approve(&owner, &spender, &500, &(env.ledger().sequence() + 10_000));
+    client.approve(
+        &owner,
+        &spender,
+        &1_500,
+        &(env.ledger().sequence() + 10_000),
+    );
     assert_eq!(client.allowance(&owner, &spender), 1_500);
 }
 
@@ -198,8 +208,13 @@ fn approve_zero_clears_allowance() {
     let (env, _admin, client) = setup();
     let owner = Address::generate(&env);
     let spender = Address::generate(&env);
-    client.approve(&owner, &spender, &1_000);
-    client.approve(&owner, &spender, &0);
+    client.approve(
+        &owner,
+        &spender,
+        &1_000,
+        &(env.ledger().sequence() + 10_000),
+    );
+    client.approve(&owner, &spender, &0, &0);
     assert_eq!(client.allowance(&owner, &spender), 0);
 }
 
@@ -212,7 +227,7 @@ fn transfer_from_insufficient_allowance_panics() {
     let recipient = Address::generate(&env);
 
     client.mint(&owner, &500);
-    client.approve(&owner, &spender, &100);
+    client.approve(&owner, &spender, &100, &(env.ledger().sequence() + 10_000));
     client.transfer_from(&spender, &owner, &recipient, &150);
 }
 

--- a/docs/abis/governance.json
+++ b/docs/abis/governance.json
@@ -1,108 +1,355 @@
 {
   "contract": "governance",
   "version": "1.0.0",
-  "description": "On-chain governance for Nova Rewards protocol parameter changes. Voting period is ~7 days (120,960 ledgers).",
+  "description": "On-chain token-weighted governance for Nova Rewards protocol parameter changes. Voting period is ~7 days (120,960 ledgers).",
   "functions": [
     {
       "name": "initialize",
-      "description": "Initializes the governance contract.",
-      "params": [{ "name": "admin", "type": "Address" }],
+      "description": "Initializes governance with a token contract, configurable quorum, and upgrade multisig.",
+      "params": [
+        {
+          "name": "admin",
+          "type": "Address"
+        },
+        {
+          "name": "token",
+          "type": "Address"
+        },
+        {
+          "name": "quorum",
+          "type": "Quorum"
+        },
+        {
+          "name": "signers",
+          "type": "Vec<Address>"
+        },
+        {
+          "name": "threshold",
+          "type": "u32"
+        }
+      ],
       "returns": null,
-      "errors": ["already initialized"]
+      "errors": [
+        "already initialized"
+      ]
     },
     {
       "name": "create_proposal",
       "description": "Creates a new governance proposal.",
       "params": [
-        { "name": "proposer", "type": "Address" },
-        { "name": "title", "type": "String", "description": "Short title (max 100 chars)." },
-        { "name": "description", "type": "String", "description": "Full description." }
+        {
+          "name": "proposer",
+          "type": "Address"
+        },
+        {
+          "name": "title",
+          "type": "String",
+          "description": "Short title (max 100 chars)."
+        },
+        {
+          "name": "description",
+          "type": "String",
+          "description": "Full description."
+        }
       ],
-      "returns": { "type": "u32", "description": "Proposal ID." },
+      "returns": {
+        "type": "u32",
+        "description": "Proposal ID."
+      },
       "errors": []
     },
     {
       "name": "vote",
-      "description": "Casts a vote on an active proposal.",
+      "description": "Casts a token-weighted vote on an active proposal.",
       "params": [
-        { "name": "voter", "type": "Address" },
-        { "name": "proposal_id", "type": "u32" },
-        { "name": "support", "type": "bool", "description": "true = yes, false = no." }
+        {
+          "name": "voter",
+          "type": "Address"
+        },
+        {
+          "name": "proposal_id",
+          "type": "u32"
+        },
+        {
+          "name": "support",
+          "type": "bool",
+          "description": "true = yes, false = no."
+        }
       ],
       "returns": null,
-      "errors": ["already voted", "voting closed", "not found"]
+      "errors": [
+        "already voted",
+        "voting closed",
+        "not found"
+      ]
     },
     {
       "name": "finalise",
-      "description": "Tallies votes after the voting period ends.",
-      "params": [{ "name": "proposal_id", "type": "u32" }],
+      "description": "Tallies token-weighted votes after the voting period ends and checks configured quorum.",
+      "params": [
+        {
+          "name": "proposal_id",
+          "type": "u32"
+        }
+      ],
       "returns": null,
-      "errors": ["voting period not ended", "already finalised", "not found"]
+      "errors": [
+        "voting period not ended",
+        "already finalised",
+        "not found"
+      ]
     },
     {
       "name": "execute",
       "description": "Marks a passed proposal as executed. Admin only.",
-      "params": [{ "name": "proposal_id", "type": "u32" }],
+      "params": [
+        {
+          "name": "proposal_id",
+          "type": "u32"
+        }
+      ],
       "returns": null,
-      "errors": ["unauthorized", "not passed", "already executed", "not found"]
+      "errors": [
+        "unauthorized",
+        "not passed",
+        "already executed",
+        "not found"
+      ]
     },
     {
       "name": "get_proposal",
       "description": "Returns a proposal by ID.",
-      "params": [{ "name": "proposal_id", "type": "u32" }],
-      "returns": { "type": "Proposal" },
-      "errors": ["not found"]
+      "params": [
+        {
+          "name": "proposal_id",
+          "type": "u32"
+        }
+      ],
+      "returns": {
+        "type": "Proposal"
+      },
+      "errors": [
+        "not found"
+      ]
     },
     {
       "name": "proposal_count",
       "description": "Returns the total number of proposals.",
       "params": [],
-      "returns": { "type": "u32" },
+      "returns": {
+        "type": "u32"
+      },
       "errors": []
     },
     {
       "name": "has_voted",
       "description": "Returns whether an address has voted on a proposal.",
       "params": [
-        { "name": "voter", "type": "Address" },
-        { "name": "proposal_id", "type": "u32" }
+        {
+          "name": "voter",
+          "type": "Address"
+        },
+        {
+          "name": "proposal_id",
+          "type": "u32"
+        }
       ],
-      "returns": { "type": "bool" },
+      "returns": {
+        "type": "bool"
+      },
+      "errors": []
+    },
+    {
+      "name": "set_quorum",
+      "description": "Admin-only update of the quorum model.",
+      "params": [
+        {
+          "name": "quorum",
+          "type": "Quorum"
+        }
+      ],
+      "returns": null,
+      "errors": [
+        "unauthorized",
+        "invalid quorum"
+      ]
+    },
+    {
+      "name": "get_quorum",
+      "description": "Returns the configured quorum model.",
+      "params": [],
+      "returns": {
+        "type": "Quorum"
+      },
+      "errors": []
+    },
+    {
+      "name": "quorum_votes_required",
+      "description": "Returns the current token units required for quorum.",
+      "params": [],
+      "returns": {
+        "type": "i128"
+      },
       "errors": []
     }
   ],
   "types": {
     "ProposalStatus": {
-      "variants": ["Active", "Passed", "Rejected", "Executed"]
+      "variants": [
+        "Active",
+        "Passed",
+        "Rejected",
+        "Executed"
+      ]
     },
     "Proposal": {
       "fields": [
-        { "name": "id", "type": "u32" },
-        { "name": "proposer", "type": "Address" },
-        { "name": "title", "type": "String" },
-        { "name": "description", "type": "String" },
-        { "name": "yes_votes", "type": "u32" },
-        { "name": "no_votes", "type": "u32" },
-        { "name": "end_ledger", "type": "u32" },
-        { "name": "status", "type": "ProposalStatus" }
+        {
+          "name": "id",
+          "type": "u32"
+        },
+        {
+          "name": "proposer",
+          "type": "Address"
+        },
+        {
+          "name": "title",
+          "type": "String"
+        },
+        {
+          "name": "description",
+          "type": "String"
+        },
+        {
+          "name": "yes_votes",
+          "type": "i128"
+        },
+        {
+          "name": "no_votes",
+          "type": "i128"
+        },
+        {
+          "name": "end_ledger",
+          "type": "u32"
+        },
+        {
+          "name": "status",
+          "type": "ProposalStatus"
+        }
+      ]
+    },
+    "Quorum": {
+      "variants": [
+        {
+          "name": "Absolute",
+          "value": "i128"
+        },
+        {
+          "name": "Percent",
+          "value": "u32 basis points"
+        }
       ]
     }
   },
   "events": [
-    { "name": "proposal_created", "fields": [{ "name": "id", "type": "u32" }, { "name": "proposer", "type": "Address" }] },
-    { "name": "voted",            "fields": [{ "name": "voter", "type": "Address" }, { "name": "proposal_id", "type": "u32" }, { "name": "support", "type": "bool" }] },
-    { "name": "finalised",        "fields": [{ "name": "proposal_id", "type": "u32" }, { "name": "status", "type": "ProposalStatus" }] },
-    { "name": "executed",         "fields": [{ "name": "proposal_id", "type": "u32" }] }
+    {
+      "name": "proposal_created",
+      "fields": [
+        {
+          "name": "id",
+          "type": "u32"
+        },
+        {
+          "name": "proposer",
+          "type": "Address"
+        }
+      ]
+    },
+    {
+      "name": "voted",
+      "fields": [
+        {
+          "name": "voter",
+          "type": "Address"
+        },
+        {
+          "name": "proposal_id",
+          "type": "u32"
+        },
+        {
+          "name": "support",
+          "type": "bool"
+        }
+      ]
+    },
+    {
+      "name": "finalised",
+      "fields": [
+        {
+          "name": "proposal_id",
+          "type": "u32"
+        },
+        {
+          "name": "status",
+          "type": "ProposalStatus"
+        }
+      ]
+    },
+    {
+      "name": "executed",
+      "fields": [
+        {
+          "name": "proposal_id",
+          "type": "u32"
+        }
+      ]
+    }
   ],
   "errors": [
-    { "code": 1, "name": "AlreadyInitialized",    "message": "already initialized" },
-    { "code": 2, "name": "Unauthorized",           "message": "unauthorized" },
-    { "code": 3, "name": "AlreadyVoted",           "message": "already voted" },
-    { "code": 4, "name": "VotingClosed",           "message": "voting period has ended" },
-    { "code": 5, "name": "VotingPeriodNotEnded",   "message": "voting period has not ended" },
-    { "code": 6, "name": "AlreadyFinalised",       "message": "already finalised" },
-    { "code": 7, "name": "NotPassed",              "message": "proposal did not pass" },
-    { "code": 8, "name": "AlreadyExecuted",        "message": "already executed" },
-    { "code": 9, "name": "NotFound",               "message": "proposal not found" }
+    {
+      "code": 1,
+      "name": "AlreadyInitialized",
+      "message": "already initialized"
+    },
+    {
+      "code": 2,
+      "name": "Unauthorized",
+      "message": "unauthorized"
+    },
+    {
+      "code": 3,
+      "name": "AlreadyVoted",
+      "message": "already voted"
+    },
+    {
+      "code": 4,
+      "name": "VotingClosed",
+      "message": "voting period has ended"
+    },
+    {
+      "code": 5,
+      "name": "VotingPeriodNotEnded",
+      "message": "voting period has not ended"
+    },
+    {
+      "code": 6,
+      "name": "AlreadyFinalised",
+      "message": "already finalised"
+    },
+    {
+      "code": 7,
+      "name": "NotPassed",
+      "message": "proposal did not pass"
+    },
+    {
+      "code": 8,
+      "name": "AlreadyExecuted",
+      "message": "already executed"
+    },
+    {
+      "code": 9,
+      "name": "NotFound",
+      "message": "proposal not found"
+    }
   ]
 }

--- a/docs/adr/0015-token-weighted-governance-quorum.md
+++ b/docs/adr/0015-token-weighted-governance-quorum.md
@@ -1,0 +1,33 @@
+# ADR 0015: Token-weighted governance quorum
+
+## Status
+Accepted
+
+## Context
+The governance contract previously used a hard-coded `QUORUM = 1`, so one yes-vote could pass any proposal. Production governance needs quorum to reflect token-holder participation and allow administrators to tune the threshold as the circulating token supply and risk profile change.
+
+## Decision
+Governance now stores an admin-configurable `Quorum` at initialization and exposes an admin-only `set_quorum` call for future updates. The selected model is token-weighted voting using the Nova token contract as the source of voting weight:
+
+- `Quorum::Absolute(amount)` requires at least `amount` yes-vote token units.
+- `Quorum::Percent(bps)` requires at least `bps / 10_000` of the Nova token total supply, rounded up to avoid under-counting fractional thresholds.
+
+A voter's weight is read from the token contract's `balance(voter)` query when the vote is cast. Percentage quorum is evaluated during finalisation against the token contract's current `total_supply()`.
+
+## Consequences
+
+### Benefits
+- Replaces single-voter passage with a participation threshold tied to token weight.
+- Supports both simple absolute thresholds and supply-relative thresholds.
+- Keeps governance self-contained and avoids snapshot oracle dependencies, which are explicitly out of scope.
+- Preserves the existing governance event schema version (`schema_version = 1`) for proposal, vote, finalise, execute, and upgrade events.
+
+### Trade-offs
+- Balances are not snapshotted at proposal creation. Token transfers after proposal creation may affect voting weight if holders vote after moving tokens.
+- The double-vote guard prevents the same address from voting twice, but it does not prevent token movement between addresses during an active proposal. A full snapshot or delegation system would address this more completely but is intentionally out of scope.
+- Percentage quorum is evaluated against current total supply at finalisation, so minting or burning during the voting window can change the required quorum.
+
+## Alternatives considered
+- **Minimum voter count:** Easy to reason about, but it ignores token stake and allows many low-stake addresses to dominate quorum.
+- **Proposal-time supply snapshots:** Stronger security properties, but requires additional snapshot storage and/or oracle mechanics outside the current scope.
+- **Off-chain delegated voting:** Flexible, but explicitly out of scope and more complex to audit.


### PR DESCRIPTION
### Motivation
- Replace the hard-coded `QUORUM = 1` (single yes-vote wins) with a production-ready, admin-configurable quorum model tied to token weight or supply percentage.
- Allow governance to be initialized with the token contract and a quorum that can be updated by the admin to reflect changing risk/profile and supply.

### Description
- Introduce a `Quorum` enum (`Quorum::Absolute(i128)` and `Quorum::Percent(u32)` in basis points), a `TokenClient` contract client, and store `Token` and `Quorum` in governance storage; replace the `QUORUM` constant with basis-point denominator `BPS_DENOMINATOR` and dynamic quorum logic in `contracts/governance/src/lib.rs`.
- Make votes token-weighted by adding a voter's `balance(voter)` to `yes_votes`/`no_votes` when `vote` is cast and compute percentage quorum at finalisation using `total_supply()` from the token contract.
- Add admin APIs `set_quorum`, `get_quorum`, and `quorum_votes_required`, and validation logic for quorum parameters; preserve and continue to emit existing governance events with `schema_version = 1`.
- Update `contracts/nova_token/src/lib.rs` to track `TotalSupply` (mint/burn update supply) and expose `total_supply()` for governance percentage calculations.
- Update tests to cover token-weighted scenarios and edge cases (exact quorum, one-below quorum, percent-of-supply quorum, admin updates), adjust integration upgrade tests to deploy a `NovaToken` instance for governance initialization, update the governance ABI (`docs/abis/governance.json`), and add ADR `docs/adr/0015-token-weighted-governance-quorum.md` documenting the design and trade-offs.

### Testing
- Ran `cargo test -p governance` and all governance unit tests passed (`24 passed` in the run observed). 
- Ran `cargo test -p nova_token` and all token unit tests passed (`15 lib tests` and `22 test binary tests` passed in observed runs).
- Attempted integration tests (`integration_tests` / `upgrade_approval_tests`), but full integration test execution is blocked by the workspace `no_std`/panic-handler build constraints for the `integration_tests` crate; integration test sources were updated to initialize governance with a token, but running those test binaries requires addressing the existing `no_std` panic-handler configuration.

Closes #1127