### PR TITLE
fix: re-fetch sequence before each fee-bump retry, enforce MAX_FEE_BUMP_ATTEMPTS=3

### DIFF
--- a/novaRewards/backend/db/__mocks__/transactionRepository.js
+++ b/novaRewards/backend/db/__mocks__/transactionRepository.js
@@ -1,0 +1,2 @@
+import { vi } from 'vitest';
+export const recordTransaction = vi.fn();

--- a/novaRewards/backend/lib/__mocks__/redis.js
+++ b/novaRewards/backend/lib/__mocks__/redis.js
@@ -1,0 +1,3 @@
+import { vi } from 'vitest';
+export const client = { isOpen: true, get: vi.fn(), set: vi.fn(), del: vi.fn() };
+export const connectRedis = vi.fn();

--- a/novaRewards/backend/middleware/__mocks__/authenticateUser.js
+++ b/novaRewards/backend/middleware/__mocks__/authenticateUser.js
@@ -1,0 +1,5 @@
+export const authenticateUser = (req, _res, next) => {
+  req.user = { id: 1, role: 'user' };
+  next();
+};
+export const requireAdmin = (_req, _res, next) => next();

--- a/novaRewards/backend/middleware/__mocks__/rateLimiter.js
+++ b/novaRewards/backend/middleware/__mocks__/rateLimiter.js
@@ -1,0 +1,2 @@
+export const slidingAuth = (_req, _res, next) => next();
+export const slidingGlobal = (_req, _res, next) => next();

--- a/novaRewards/backend/services/stellarTransactionService.js
+++ b/novaRewards/backend/services/stellarTransactionService.js
@@ -5,10 +5,23 @@ const {
   BASE_FEE,
   Keypair,
 } = require('stellar-sdk');
-const { server } = require('../../blockchain/stellarService');
-const { recordTransaction } = require('../db/transactionRepository');
+const { server: _serverModule } = require('../../blockchain/stellarService');
+const { recordTransaction: _recordTransactionModule } = require('../db/transactionRepository');
 const { getConfig, getRequiredConfig } = require('./configService');
 const logger = require('../lib/logger');
+
+// ---------------------------------------------------------------------------
+// Dependency injection seam — override in tests via stellarTxService._deps
+// ---------------------------------------------------------------------------
+const _deps = {
+  server: _serverModule,
+  recordTransaction: _recordTransactionModule,
+};
+
+// Convenience accessors used throughout the module so that tests that inject
+// via _deps automatically affect all internal calls.
+function getServer() { return _deps.server; }
+function getRecordTransaction() { return _deps.recordTransaction; }
 
 
 // ---------------------------------------------------------------------------
@@ -89,7 +102,7 @@ async function submit({ sourceAddress, operations, signers, options = {} }) {
   const signerList = Array.isArray(signers) ? signers : [signers];
 
   // 1. Fetch fresh sequence number from Horizon
-  const account = await server.loadAccount(sourceAddress);
+  const account = await getServer().loadAccount(sourceAddress);
 
   // 2. Build transaction
   const timeout = options.timeout || DEFAULT_TIMEOUT;
@@ -137,38 +150,101 @@ async function submit({ sourceAddress, operations, signers, options = {} }) {
  * Submits a transaction, and if it's stuck (bad_seq, insufficient_fee, too_late),
  * retries with a fee-bump transaction up to MAX_FEE_BUMP_ATTEMPTS times.
  *
- * @param {import('stellar-sdk').Transaction} transaction
+ * On each fee-bump attempt the sequence number is re-fetched via loadAccount so
+ * that a stale sequence from a prior attempt never causes an infinite retry loop.
+ *
+ * @param {import('stellar-sdk').Transaction} transaction - Initial signed transaction
  * @param {object} options
+ * @param {string}  options.sourceAddress   - Source account public key
+ * @param {import('stellar-sdk').xdr.Operation[]} options.operations
+ * @param {import('stellar-sdk').Keypair[]}        options.signers
+ * @param {string}  [options.feeSourceSecret]
+ * @param {number}  [options.timeout]
+ * @param {string}  [options.memo]
  * @returns {Promise<{ txHash: string, ledger: number, status: string, resultXdr: string }>}
  */
 async function submitWithFeeBumpRetry(transaction, options = {}) {
   let lastError;
 
-  // Acceptance criteria: Horizon tx_bad_seq triggers a sequence refresh and one retry.
-  let didRefreshSequenceRetry = false;
+  // ── First attempt: submit the original transaction ──────────────────────
+  // submitHorizonTransaction handles tx_bad_seq inline by refreshing the
+  // sequence number and re-submitting the inner transaction once.  All other
+  // stuck codes (tx_insufficient_fee, tx_too_late) fall through to the
+  // fee-bump loop below.
+  try {
+    const horizonResult = await submitHorizonTransaction(transaction, {
+      options,
+      refreshSequenceAndRebuildOnce: async () => {
+        return refreshAndRebuildTransaction({
+          sourceAddress: options.sourceAddress,
+          operations: options.operations,
+          signers: options.signers,
+          memo: options.memo,
+          timeout: options.timeout,
+        });
+      },
+    });
 
-  const submitContext = {
-    sourceAddress: options?.sourceAddress,
-    transaction,
-    operations: options?.operations,
-    signers: options?.signers,
-    feeSourceSecret: options?.feeSourceSecret,
-    timeout: options?.timeout,
-    memo: options?.memo,
-    txType: options?.txType,
-  };
+    return {
+      txHash: horizonResult.hash,
+      ledger: horizonResult.ledger,
+      status: 'submitted',
+      resultXdr: horizonResult.result_xdr,
+      _raw: horizonResult,
+    };
+  } catch (err) {
+    lastError = err;
 
-  for (let attempt = 0; attempt <= MAX_FEE_BUMP_ATTEMPTS; attempt++) {
+    const resultCodes = extractResultCodes(err);
+    // Also check err.code — submitHorizonTransaction wraps Horizon errors and
+    // puts the original Horizon code in err.code.
+    const allCodes = resultCodes.length > 0 ? resultCodes : (err.code ? [err.code] : []);
+    const isStuck = STUCK_RESULT_CODES.some((code) => allCodes.includes(code));
+
+    // Non-stuck error — propagate immediately without any fee-bump retry.
+    if (!isStuck) {
+      throw err;
+    }
+  }
+
+  // ── Fee-bump retry loop ──────────────────────────────────────────────────
+  // Each attempt:
+  //   1. Re-fetch the sequence number from Horizon (avoids stale-seq loops).
+  //   2. Rebuild + re-sign the inner transaction with the fresh sequence.
+  //   3. Wrap in a fee-bump with an exponentially increasing fee.
+  //   4. Submit the fee-bump.
+  //
+  // We iterate exactly MAX_FEE_BUMP_ATTEMPTS times (1-indexed for clarity).
+  const feeSourceSecret =
+    options.feeSourceSecret || getRequiredConfig('FEE_SOURCE_SECRET');
+  const feeSourceKeypair = Keypair.fromSecret(feeSourceSecret);
+
+  for (let attempt = 1; attempt <= MAX_FEE_BUMP_ATTEMPTS; attempt++) {
     try {
-      const horizonResult = await submitHorizonTransaction(transaction, {
-        options,
-        didRefreshSequenceRetry,
-        refreshSequenceAndRebuildOnce: async () => {
-          if (didRefreshSequenceRetry) return null;
-          didRefreshSequenceRetry = true;
-          return refreshAndRebuildTransaction(submitContext);
-        },
+      // Step 1 & 2: always re-fetch sequence before each fee-bump attempt.
+      const freshInnerTx = await refreshAndRebuildTransaction({
+        sourceAddress: options.sourceAddress,
+        operations: options.operations,
+        signers: options.signers,
+        memo: options.memo,
+        timeout: options.timeout,
       });
+
+      // Step 3: build fee-bump with doubled fee per attempt.
+      const bumpedFee = String(
+        parseInt(BASE_FEE, 10) * FEE_BUMP_MULTIPLIER * attempt,
+      );
+
+      const feeBumpTx = TransactionBuilder.buildFeeBumpTransaction(
+        feeSourceKeypair,
+        bumpedFee,
+        freshInnerTx,
+        NETWORK_PASSPHRASE,
+      );
+      feeBumpTx.sign(feeSourceKeypair);
+
+      // Step 4: submit.
+      const horizonResult = await getServer().submitTransaction(feeBumpTx);
 
       return {
         txHash: horizonResult.hash,
@@ -181,36 +257,30 @@ async function submitWithFeeBumpRetry(transaction, options = {}) {
       lastError = err;
 
       const resultCodes = extractResultCodes(err);
-      const isStuck = STUCK_RESULT_CODES.some((code) => resultCodes.includes(code));
+      const allCodes = resultCodes.length > 0 ? resultCodes : (err.code ? [err.code] : []);
+      const isStuck = STUCK_RESULT_CODES.some((code) => allCodes.includes(code));
 
-      if (!isStuck || attempt >= MAX_FEE_BUMP_ATTEMPTS) {
+      logger.warn(
+        `[stellarTransactionService] Fee-bump attempt ${attempt}/${MAX_FEE_BUMP_ATTEMPTS} failed`,
+        { codes: allCodes, isStuck },
+      );
+
+      // If this error is not a stuck code, stop retrying immediately.
+      if (!isStuck) {
         break;
       }
 
-      // Keep existing fee-bump retry behavior for stuck tx_insufficient_fee/tx_too_late.
-      const feeSourceSecret =
-        options.feeSourceSecret || getRequiredConfig('FEE_SOURCE_SECRET');
-      const feeSourceKeypair = Keypair.fromSecret(feeSourceSecret);
-      const bumpedFee = String(
-        parseInt(transaction.fee, 10) * FEE_BUMP_MULTIPLIER * (attempt + 1),
-      );
-
-      const feeBumpTx = TransactionBuilder.buildFeeBumpTransaction(
-        feeSourceKeypair,
-        bumpedFee,
-        transaction,
-        NETWORK_PASSPHRASE,
-      );
-      feeBumpTx.sign(feeSourceKeypair);
-
-      const feeBumpResult = await submitFeeBumpTransaction(feeBumpTx);
-      return feeBumpResult;
+      // If we've exhausted all attempts, fall through to the throw below.
     }
   }
 
+  // All attempts exhausted — throw a typed, catchable error.
   const resultCodes = extractResultCodes(lastError);
+  const allLastCodes = resultCodes.length > 0 ? resultCodes : (lastError.code ? [lastError.code] : []);
   throw createError(
-    `Transaction submission failed: ${resultCodes.join(', ') || lastError.message}`,
+    `Transaction submission failed after ${MAX_FEE_BUMP_ATTEMPTS} fee-bump attempts: ${
+      allLastCodes.join(', ') || lastError.message
+    }`,
     400,
     'tx_submission_failed',
   );
@@ -227,7 +297,7 @@ async function submitWithFeeBumpRetry(transaction, options = {}) {
  */
 async function submitFeeBumpTransaction(feeBumpTx) {
   try {
-    const horizonResult = await server.submitTransaction(feeBumpTx);
+    const horizonResult = await getServer().submitTransaction(feeBumpTx);
 
     return {
       txHash: horizonResult.hash,
@@ -349,7 +419,7 @@ function sleep(ms) {
 
 async function refreshAndRebuildTransaction({ sourceAddress, operations, signers, memo, timeout }) {
   if (!sourceAddress || !operations || !signers) return null;
-  const account = await server.loadAccount(sourceAddress);
+  const account = await getServer().loadAccount(sourceAddress);
 
   let builder = new TransactionBuilder(account, {
     fee: BASE_FEE,
@@ -380,12 +450,13 @@ async function refreshAndRebuildTransaction({ sourceAddress, operations, signers
 async function submitHorizonTransaction(transaction, { refreshSequenceAndRebuildOnce }) {
   const maxTimeoutRetries = 3;
   let timeoutAttempt = 0;
+  // Guard: only refresh sequence once per submitHorizonTransaction invocation.
+  let didSequenceRefresh = false;
 
-
-  // Attempt loop only for timeout errors.
+  // Attempt loop only for timeout errors and a single tx_bad_seq refresh.
   while (true) {
     try {
-      return await server.submitTransaction(transaction);
+      return await getServer().submitTransaction(transaction);
     } catch (err) {
       const horizonBody = extractHorizonResponseBody(err);
       logger.error('[stellarTransactionService] Horizon submission error', {
@@ -396,11 +467,15 @@ async function submitHorizonTransaction(transaction, { refreshSequenceAndRebuild
 
       const codes = extractResultCodes(err);
 
-      // Acceptance criteria: tx_bad_seq => refresh sequence and one retry.
-      if (codes.includes('tx_bad_seq') && typeof refreshSequenceAndRebuildOnce === 'function') {
+      // tx_bad_seq => refresh sequence number and retry once.
+      if (
+        codes.includes('tx_bad_seq') &&
+        !didSequenceRefresh &&
+        typeof refreshSequenceAndRebuildOnce === 'function'
+      ) {
         const rebuiltTx = await refreshSequenceAndRebuildOnce();
         if (rebuiltTx) {
-          // After refresh/rebuild, retry the submission once.
+          didSequenceRefresh = true;
           transaction = rebuiltTx;
           continue;
         }
@@ -456,7 +531,7 @@ function parseTransactionResult(horizonResult) {
  */
 async function storeTransactionResult(result, options = {}) {
   try {
-    await recordTransaction({
+    await getRecordTransaction()({
       txHash: result.txHash,
       txType: options.txType || 'transfer',
       amount: options.amount || '0',
@@ -489,7 +564,7 @@ async function storeTransactionResult(result, options = {}) {
  * @returns {Promise<string>} Sequence number as a string
  */
 async function getSequenceNumber(publicKey) {
-  const account = await server.loadAccount(publicKey);
+  const account = await getServer().loadAccount(publicKey);
   return account.sequence;
 }
 
@@ -505,4 +580,5 @@ module.exports = {
   STUCK_RESULT_CODES,
   FEE_BUMP_MULTIPLIER,
   MAX_FEE_BUMP_ATTEMPTS,
+  _deps,
 };

--- a/novaRewards/backend/tests/stellarTransactionService.test.js
+++ b/novaRewards/backend/tests/stellarTransactionService.test.js
@@ -670,3 +670,232 @@ describe('Route: GET /api/transactions/sequence/:publicKey', () => {
     expect(res.body.error).toBe('account_not_found');
   });
 });
+
+// ---------------------------------------------------------------------------
+// Tests: Fee-bump retry logic (acceptance criteria)
+//
+// These tests use the _deps injection seam on stellarTransactionService to
+// mock loadAccount and submitTransaction without relying on vitest module
+// interception of CJS require() calls (which doesn't work reliably).
+// ---------------------------------------------------------------------------
+describe('stellarTransactionService — fee-bump retry logic', () => {
+  const { Keypair, Account, BASE_FEE } = require('stellar-sdk');
+  const stellarTxSvc = require('../services/stellarTransactionService');
+
+  // Generate a valid fee-source keypair for all fee-bump tests
+  const feeSourceKp = Keypair.random();
+  const feeSourceSecret = feeSourceKp.secret();
+
+  // Build a minimal Account mock the TransactionBuilder accepts
+  function makeFakeAccount(publicKey, sequence = '100') {
+    return new Account(publicKey, sequence);
+  }
+
+  let mockLoadAccount;
+  let mockSubmitTransaction;
+  let mockRecordTx;
+  let savedDeps;
+
+  beforeEach(() => {
+    mockLoadAccount = vi.fn();
+    mockSubmitTransaction = vi.fn();
+    mockRecordTx = vi.fn().mockResolvedValue({ id: 1 });
+
+    // Save real deps and inject mocks
+    savedDeps = { server: stellarTxSvc._deps.server, recordTransaction: stellarTxSvc._deps.recordTransaction };
+    stellarTxSvc._deps.server = {
+      loadAccount: mockLoadAccount,
+      submitTransaction: mockSubmitTransaction,
+    };
+    stellarTxSvc._deps.recordTransaction = mockRecordTx;
+  });
+
+  afterEach(() => {
+    // Restore real deps so other test suites are unaffected
+    stellarTxSvc._deps.server = savedDeps.server;
+    stellarTxSvc._deps.recordTransaction = savedDeps.recordTransaction;
+  });
+
+  // ── AC-1: tx_bad_seq → sequence refresh → success on fee-bump ────────────
+  it('AC-1: resolves with correct txHash when tx_bad_seq triggers a fee-bump retry', async () => {
+    const sourceKp = Keypair.random();
+    const destKp  = Keypair.random();
+
+    const badSeqError = Object.assign(new Error('tx_bad_seq'), {
+      response: { data: { extras: { result_codes: { transaction: ['tx_bad_seq'] } } } },
+    });
+
+    // loadAccount calls:
+    //   1 — initial submit (inside submit())
+    //   2 — inline tx_bad_seq refresh (inside submitHorizonTransaction)
+    //   3 — fee-bump attempt 1 (inside submitWithFeeBumpRetry loop)
+    mockLoadAccount
+      .mockResolvedValueOnce(makeFakeAccount(sourceKp.publicKey(), '100'))
+      .mockResolvedValueOnce(makeFakeAccount(sourceKp.publicKey(), '101'))
+      .mockResolvedValueOnce(makeFakeAccount(sourceKp.publicKey(), '102'));
+
+    // submitTransaction calls:
+    //   1 — initial fails with tx_bad_seq
+    //   2 — after inline refresh also fails with tx_bad_seq → fee-bump loop
+    //   3 — fee-bump attempt 1 succeeds
+    mockSubmitTransaction
+      .mockRejectedValueOnce(badSeqError)
+      .mockRejectedValueOnce(badSeqError)
+      .mockResolvedValueOnce({ hash: 'feebump_success_hash', ledger: 55, result_xdr: 'AAAAAA==' });
+
+    const result = await stellarTxSvc.submit({
+      sourceAddress: sourceKp.publicKey(),
+      operations: [Operation.payment({ destination: destKp.publicKey(), asset: Asset.native(), amount: '10' })],
+      signers: [sourceKp],
+      options: { feeSourceSecret },
+    });
+
+    expect(result.txHash).toBe('feebump_success_hash');
+    expect(result.status).toBe('submitted');
+  });
+
+  // ── AC-2: MAX_FEE_BUMP_ATTEMPTS exhausted → typed error ─────────────────
+  it('AC-2: rejects with typed error (code=tx_submission_failed) after MAX_FEE_BUMP_ATTEMPTS consecutive failures', async () => {
+    const sourceKp = Keypair.random();
+    const destKp  = Keypair.random();
+
+    const insufficientFeeErr = Object.assign(new Error('tx_insufficient_fee'), {
+      response: { data: { extras: { result_codes: { transaction: ['tx_insufficient_fee'] } } } },
+    });
+
+    // Every loadAccount and submitTransaction call fails with tx_insufficient_fee
+    mockLoadAccount.mockResolvedValue(makeFakeAccount(sourceKp.publicKey(), '200'));
+    mockSubmitTransaction.mockRejectedValue(insufficientFeeErr);
+
+    const err = await stellarTxSvc.submit({
+      sourceAddress: sourceKp.publicKey(),
+      operations: [Operation.payment({ destination: destKp.publicKey(), asset: Asset.native(), amount: '1' })],
+      signers: [sourceKp],
+      options: { feeSourceSecret },
+    }).catch(e => e);
+
+    expect(err).toBeInstanceOf(Error);
+    expect(err.code).toBe('tx_submission_failed');
+    expect(err.message).toMatch(/tx_insufficient_fee/);
+    expect(err.status).toBe(400);
+  });
+
+  // ── AC-3: No sequence number reuse — loadAccount called per attempt ──────
+  it('AC-3: calls loadAccount before each fee-bump attempt (no stale sequence reuse)', async () => {
+    const sourceKp = Keypair.random();
+    const destKp  = Keypair.random();
+
+    const tooLateErr = Object.assign(new Error('tx_too_late'), {
+      response: { data: { extras: { result_codes: { transaction: ['tx_too_late'] } } } },
+    });
+
+    // 1 initial + 3 fee-bump refreshes = 4 total loadAccount calls
+    mockLoadAccount
+      .mockResolvedValueOnce(makeFakeAccount(sourceKp.publicKey(), '300'))
+      .mockResolvedValueOnce(makeFakeAccount(sourceKp.publicKey(), '301'))
+      .mockResolvedValueOnce(makeFakeAccount(sourceKp.publicKey(), '302'))
+      .mockResolvedValueOnce(makeFakeAccount(sourceKp.publicKey(), '303'));
+
+    mockSubmitTransaction.mockRejectedValue(tooLateErr);
+
+    await stellarTxSvc.submit({
+      sourceAddress: sourceKp.publicKey(),
+      operations: [Operation.payment({ destination: destKp.publicKey(), asset: Asset.native(), amount: '2' })],
+      signers: [sourceKp],
+      options: { feeSourceSecret },
+    }).catch(() => {});
+
+    // 1 initial + 3 fee-bump refreshes = 4 calls total
+    expect(mockLoadAccount).toHaveBeenCalledTimes(1 + stellarTxSvc.MAX_FEE_BUMP_ATTEMPTS);
+
+    // Every call must use the source address (NOT the fee-source address)
+    mockLoadAccount.mock.calls.forEach(call => {
+      expect(call[0]).toBe(sourceKp.publicKey());
+    });
+  });
+
+  // ── AC-4: tx_insufficient_fee — fee doubled per attempt (FEE_BUMP_MULTIPLIER=2) ──
+  it('AC-4: doubles the base fee on each tx_insufficient_fee fee-bump attempt', async () => {
+    const sourceKp = Keypair.random();
+    const destKp  = Keypair.random();
+
+    const insufficientFeeErr = Object.assign(new Error('tx_insufficient_fee'), {
+      response: { data: { extras: { result_codes: { transaction: ['tx_insufficient_fee'] } } } },
+    });
+
+    mockLoadAccount.mockResolvedValue(makeFakeAccount(sourceKp.publicKey(), '400'));
+
+    // initial fails, fee-bump 1 fails, fee-bump 2 fails, fee-bump 3 succeeds
+    mockSubmitTransaction
+      .mockRejectedValueOnce(insufficientFeeErr)
+      .mockRejectedValueOnce(insufficientFeeErr)
+      .mockRejectedValueOnce(insufficientFeeErr)
+      .mockResolvedValueOnce({ hash: 'feebump_fee_hash', ledger: 77, result_xdr: 'BBBBBB==' });
+
+    const result = await stellarTxSvc.submit({
+      sourceAddress: sourceKp.publicKey(),
+      operations: [Operation.payment({ destination: destKp.publicKey(), asset: Asset.native(), amount: '3' })],
+      signers: [sourceKp],
+      options: { feeSourceSecret },
+    });
+
+    expect(result.txHash).toBe('feebump_fee_hash');
+    // 1 initial + 3 fee-bump attempts = 4 total
+    expect(mockSubmitTransaction).toHaveBeenCalledTimes(4);
+
+    // Verify fee increases on each fee-bump attempt.
+    // stellar-sdk computes feeBumpTx.fee = baseFee * (innerTxOps + 1).
+    // With 1 inner operation: fee = baseFee * 2.
+    // attempt 1: bumpedFee = BASE_FEE*FEE_BUMP_MULTIPLIER*1 = 200 → tx.fee = 400
+    // attempt 2: bumpedFee = BASE_FEE*FEE_BUMP_MULTIPLIER*2 = 400 → tx.fee = 800
+    // attempt 3: bumpedFee = BASE_FEE*FEE_BUMP_MULTIPLIER*3 = 600 → tx.fee = 1200
+    const { FEE_BUMP_MULTIPLIER: mult } = stellarTxSvc;
+    const baseFeeNum = parseInt(BASE_FEE, 10);
+
+    const feeBumpCalls = mockSubmitTransaction.mock.calls.slice(1); // skip initial
+    expect(feeBumpCalls.length).toBe(stellarTxSvc.MAX_FEE_BUMP_ATTEMPTS);
+
+    // Each successive fee-bump must have a strictly higher fee than the previous
+    const fees = feeBumpCalls.map(call => parseInt(call[0].fee, 10));
+    for (let i = 1; i < fees.length; i++) {
+      expect(fees[i]).toBeGreaterThan(fees[i - 1]);
+    }
+    // Verify multiplier scaling: fee[i] / fee[0] should equal (i+1)
+    for (let i = 0; i < fees.length; i++) {
+      expect(fees[i]).toBe(fees[0] * (i + 1));
+    }
+    // fee[0] must use FEE_BUMP_MULTIPLIER
+    expect(fees[0]).toBe(baseFeeNum * mult * 2); // *2 because stellar fee-bump fee = baseFee*(innerOps+1)
+  });
+
+  // ── AC-5: tx_too_late → success on first fee-bump ────────────────────────
+  it('AC-5: resolves on first fee-bump attempt when initial tx_too_late fails', async () => {
+    const sourceKp = Keypair.random();
+    const destKp  = Keypair.random();
+
+    const tooLateErr = Object.assign(new Error('tx_too_late'), {
+      response: { data: { extras: { result_codes: { transaction: ['tx_too_late'] } } } },
+    });
+
+    // 1 initial + 1 fee-bump refresh = 2 loadAccount calls
+    mockLoadAccount
+      .mockResolvedValueOnce(makeFakeAccount(sourceKp.publicKey(), '500'))
+      .mockResolvedValueOnce(makeFakeAccount(sourceKp.publicKey(), '501'));
+
+    mockSubmitTransaction
+      .mockRejectedValueOnce(tooLateErr)
+      .mockResolvedValueOnce({ hash: 'too_late_bump_hash', ledger: 88, result_xdr: 'CCCCCC==' });
+
+    const result = await stellarTxSvc.submit({
+      sourceAddress: sourceKp.publicKey(),
+      operations: [Operation.payment({ destination: destKp.publicKey(), asset: Asset.native(), amount: '4' })],
+      signers: [sourceKp],
+      options: { feeSourceSecret },
+    });
+
+    expect(result.txHash).toBe('too_late_bump_hash');
+    expect(mockSubmitTransaction).toHaveBeenCalledTimes(2);
+    expect(mockLoadAccount).toHaveBeenCalledTimes(2);
+  });
+});
+

--- a/novaRewards/backend/vitest.config.js
+++ b/novaRewards/backend/vitest.config.js
@@ -1,7 +1,48 @@
 import { defineConfig } from 'vitest/config';
 import path from 'path';
 
+/**
+ * Vite plugin that transforms `jest.mock(...)` / `jest.fn(...)` calls to
+ * their vitest equivalents (`vi.mock` / `vi.fn`) in test files so that
+ * vitest's AST-level hoisting recognises and hoists them correctly.
+ *
+ * Required for backwards-compatibility with test files originally written for
+ * Jest that use `jest.*` globals.
+ */
+function jestMockCompatPlugin() {
+  return {
+    name: 'jest-mock-compat',
+    transform(code, id) {
+      // Only process test files
+      if (!id.includes('/tests/') && !id.endsWith('.test.js') && !id.endsWith('.spec.js')) {
+        return null;
+      }
+      if (
+        !code.includes('jest.mock') &&
+        !code.includes('jest.fn') &&
+        !code.includes('jest.useFakeTimers') &&
+        !code.includes('jest.spyOn')
+      ) {
+        return null;
+      }
+      const transformed = code
+        .replace(/\bjest\.mock\s*\(/g, 'vi.mock(')
+        .replace(/\bjest\.fn\s*\(/g, 'vi.fn(')
+        .replace(/\bjest\.useFakeTimers\s*\(/g, 'vi.useFakeTimers(')
+        .replace(/\bjest\.useRealTimers\s*\(/g, 'vi.useRealTimers(')
+        .replace(/\bjest\.advanceTimersByTime\s*\(/g, 'vi.advanceTimersByTime(')
+        .replace(/\bjest\.clearAllMocks\s*\(/g, 'vi.clearAllMocks(')
+        .replace(/\bjest\.resetAllMocks\s*\(/g, 'vi.resetAllMocks(')
+        .replace(/\bjest\.restoreAllMocks\s*\(/g, 'vi.restoreAllMocks(')
+        .replace(/\bjest\.spyOn\s*\(/g, 'vi.spyOn(')
+        .replace(/\bjest\.resetModules\s*\(/g, 'vi.resetModules(');
+      return { code: transformed, map: null };
+    },
+  };
+}
+
 export default defineConfig({
+  plugins: [jestMockCompatPlugin()],
   resolve: {
     alias: {
       // Stub out missing optional packages so vi.mock() hoisting works with CJS require chains

--- a/novaRewards/backend/vitest.setup.js
+++ b/novaRewards/backend/vitest.setup.js
@@ -7,18 +7,24 @@ try {
   // Silently skip if test utils cannot be loaded in this environment
 }
 
+// ---------------------------------------------------------------------------
+// Jest compatibility shim
+// ---------------------------------------------------------------------------
 // Expose jest as global for backwards compatibility with existing tests
-// jest.fn() returns a mock function that needs to have all mock methods
+// that were written for Jest but run under Vitest.
 global.jest = {
-  fn: (...args) => {
-    const mock = vi.fn(...args);
-    return mock;
-  },
+  fn: (...args) => vi.fn(...args),
   mock: vi.mock,
+  unmock: vi.unmock,
   clearAllMocks: vi.clearAllMocks,
   resetAllMocks: vi.resetAllMocks,
   restoreAllMocks: vi.restoreAllMocks,
   resetModules: vi.resetModules,
+  useFakeTimers: (...args) => vi.useFakeTimers(...args),
+  useRealTimers: () => vi.useRealTimers(),
+  advanceTimersByTime: (ms) => vi.advanceTimersByTime(ms),
+  runAllTimers: () => vi.runAllTimers(),
+  spyOn: (...args) => vi.spyOn(...args),
 };
 
 // Suppress console.error during tests to reduce noise from expected validation errors

--- a/novaRewards/blockchain/__mocks__/stellarService.js
+++ b/novaRewards/blockchain/__mocks__/stellarService.js
@@ -1,0 +1,33 @@
+/**
+ * Manual vitest mock for novaRewards/blockchain/stellarService.js
+ *
+ * Used when vi.mock('../../blockchain/stellarService') is called without a
+ * factory, providing proper vitest mock functions so that tests can call
+ * .mockResolvedValue() / .mockRejectedValue() etc.
+ */
+import { vi } from 'vitest';
+import { StrKey } from 'stellar-sdk';
+
+export const server = {
+  loadAccount: vi.fn(),
+  submitTransaction: vi.fn(),
+  transactions: vi.fn(() => ({
+    transaction: vi.fn(() => ({
+      call: vi.fn(),
+    })),
+  })),
+};
+
+export const NOVA = {
+  code: 'NOVA',
+  issuer: process.env.ISSUER_PUBLIC || 'GTESTISSUER',
+};
+
+export const isValidStellarAddress = vi.fn((addr) => {
+  if (typeof addr !== 'string') return false;
+  try {
+    return StrKey.isValidEd25519PublicKey(addr);
+  } catch {
+    return false;
+  }
+});


### PR DESCRIPTION
## Summary

Fixes the fee-bump retry logic in `stellarTransactionService.js` where a stale sequence number caused indefinite retry failures under high load.

## Changes

### `novaRewards/backend/services/stellarTransactionService.js`
- **`submitWithFeeBumpRetry`**: rewritten — re-fetches sequence via `loadAccount` before every fee-bump attempt (fixes stale-seq loop), enforces exactly `MAX_FEE_BUMP_ATTEMPTS = 3` retries, then throws typed `tx_submission_failed` error (status 400)
- **`submitHorizonTransaction`**: added `didSequenceRefresh` guard so inline `tx_bad_seq` refresh fires only once
- Stuck-code detection falls back to `err.code` on wrapped Horizon errors so `tx_insufficient_fee`/`tx_too_late` correctly trigger the fee-bump loop
- Exported `_deps` injection seam for test isolation

### `novaRewards/backend/tests/stellarTransactionService.test.js`
5 new passing AC tests added:
- AC-1: `tx_bad_seq` → sequence refresh → fee-bump success with correct hash
- AC-2: all 3 attempts exhausted → typed `tx_submission_failed` error, not unhandled exception
- AC-3: `loadAccount` called `1 + MAX_FEE_BUMP_ATTEMPTS` times, always with source address (no seq reuse)
- AC-4: fee increases proportionally per attempt (`FEE_BUMP_MULTIPLIER = 2`)
- AC-5: `tx_too_late` → success on first fee-bump

### Supporting files
- `vitest.config.js`: added jest-mock-compat transform plugin + `useFakeTimers`/`spyOn` shim
- `vitest.setup.js`: extended jest globals shim
- `__mocks__` files for `stellarService`, `transactionRepository`, `redis`, `authenticateUser`, `rateLimiter`

## Test results
```
Tests: 5 new AC tests passed
Pre-existing: 7 passed (20 failures are pre-existing systemic vitest/CJS mock issue on main)
```